### PR TITLE
Allow running fsx scripts when there are spaces in the path to run.fsx.

### DIFF
--- a/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     await ExecuteScriptAsync(bashPath, scriptHostArguments, parameters);
                     break;
                 case "fsx":
-                    scriptHostArguments = string.Format("/c fsi.exe {0}", _scriptFilePath);
+                    scriptHostArguments = string.Format("/c fsi.exe \"{0}\"", _scriptFilePath);
                     await ExecuteScriptAsync("cmd", scriptHostArguments, parameters);
                     break;
             }


### PR DESCRIPTION
Tested out a sample "hello world" .fsx script - fails because the path has spaces in it (unless I'm doing something really wrong) - this fixed it.