### PR TITLE
Moving binding temp file storage out of logs directory and into temp dir

### DIFF
--- a/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
@@ -129,8 +129,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             string invocationId = functionExecutionContext.InvocationId.ToString();
             string workingDirectory = Path.GetDirectoryName(_scriptFilePath);
-            string rootOutputPath = Path.Combine(_config.RootLogPath, "Binding");
-            string functionInstanceOutputPath = Path.Combine(rootOutputPath, invocationId);
+            string functionInstanceOutputPath = Path.Combine(Path.GetTempPath(), "Functions", "Binding", invocationId);
 
             Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
             InitializeEnvironmentVariables(environmentVariables, functionInstanceOutputPath, input, _outputBindings, functionExecutionContext);


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk-script/issues/14. I was writing the intermediate binding files to the LogFiles dir - they don't belong there.