### PR TITLE
Making FileTraceWriter lock static to fix concurrency issues

### DIFF
--- a/src/WebJobs.Script/FileTraceWriter.cs
+++ b/src/WebJobs.Script/FileTraceWriter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class FileTraceWriter : TraceWriter
     {
-        private object _syncLock = new object();
+        private static object _syncLock = new object();
         private readonly string _logFilePath;
         private readonly string _instanceId;
         private const long _maxLogFileSizeBytes = 5 * 1024 * 1024;

--- a/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Xunit;
+
+namespace WebJobs.Script.Tests
+{
+    public class FileTraceWriterTests
+    {
+        private string _logFilePath;
+
+        public FileTraceWriterTests()
+        {
+            _logFilePath = Path.Combine(Path.GetTempPath(), "WebJobs.Script.Tests", "FileTraceWriterTests");
+
+            if (Directory.Exists(_logFilePath))
+            {
+                Directory.Delete(_logFilePath, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task MultipleConcurrentInstances_WritesAreSerialized()
+        {
+            int numLines = 100;
+
+            // first ensure the file exists by writing a single entry
+            // this ensures all the instances below will be operating on
+            // the same file
+            WriteLogs(_logFilePath, 1);
+
+            // start 3 concurrent instances
+            await Task.WhenAll(
+                Task.Run(() => WriteLogs(_logFilePath, numLines)),
+                Task.Run(() => WriteLogs(_logFilePath, numLines)),
+                Task.Run(() => WriteLogs(_logFilePath, numLines))
+            );
+
+            string logFile = Directory.EnumerateFiles(_logFilePath).Single();
+            string[] fileLines = File.ReadAllLines(logFile);
+            Assert.Equal(3 * numLines + 1, fileLines.Length);
+        }
+
+        private void WriteLogs(string logFilePath, int numLogs)
+        {
+            FileTraceWriter traceWriter = new FileTraceWriter(logFilePath, TraceLevel.Verbose);
+
+            for (int i = 0; i < numLogs; i++)
+            {
+                traceWriter.Verbose(string.Format("Test message {0} {1}", Thread.CurrentThread.ManagedThreadId, i));
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="BashEndToEndTests.cs" />
     <Compile Include="EndToEndTestFixture.cs" />
     <Compile Include="EndToEndTestsBase.cs" />
+    <Compile Include="FileTraceWriterTests.cs" />
     <Compile Include="FSharpEndToEndTests.cs" />
     <Compile Include="FunctionGeneratorTests.cs" />
     <Compile Include="PhpEndToEndTests.cs" />


### PR DESCRIPTION
Since the ScriptHostManager can have multiple host instances running (as it spins instances up/down) within the process, there was still a concurrency issue on the log files because I was doing instance level locking.