### PR TITLE
Fixing IL generation on out/ref parameter result assignment

### DIFF
--- a/src/WebJobs.Script/Description/FunctionGenerator.cs
+++ b/src/WebJobs.Script/Description/FunctionGenerator.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     il.Emit(OpCodes.Ldelem_Ref);
                     il.Emit(OpCodes.Castclass, param.Type.GetElementType());
 
-                    il.Emit(OpCodes.Stind_Ref, i);
+                    il.Emit(OpCodes.Stind_Ref);
                 }
 
                 il.Emit(OpCodes.Ret);


### PR DESCRIPTION
Fixing an issue with IL generation when storing the out/ref parameters result. This would cause functions where the out parameter was in a position other then 2 (index 1).

Validated that this fixes issues uncovered by EasyTable bindings tests.