### PR TITLE
Fixing Blob bindings

### DIFF
--- a/sample/BlobTrigger-CSharp/function.json
+++ b/sample/BlobTrigger-CSharp/function.json
@@ -2,14 +2,15 @@
   "bindings": [
     {
       "type": "blobTrigger",
+      "name": "blob",
       "direction": "in",
-      "path": "samples-workitems-csharp"
+      "path": "samples-input-csharp/{name}"
     },
     {
       "type": "blob",
       "name": "output",
       "direction": "out",
-      "path": "samples-workitems/{id}"
+      "path": "samples-output-csharp/{name}"
     }
   ]
 }

--- a/sample/BlobTrigger-CSharp/run.csx
+++ b/sample/BlobTrigger-CSharp/run.csx
@@ -3,9 +3,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 
-public static void Run(string id, out string output, TraceWriter log)
+public static void Run(string blob, out string output, TraceWriter log)
 {
-    log.Verbose($"CSharp Blob trigger function processed a work item. Item={id}");
+    log.Verbose($"CSharp Blob trigger function processed a blob. Blob={blob}");
 
-    output = "test";
+    output = blob;
 }

--- a/sample/BlobTrigger/function.json
+++ b/sample/BlobTrigger/function.json
@@ -3,7 +3,13 @@
     {
       "type": "blobTrigger",
       "direction": "in",
-      "path": "samples-workitems"
+      "path": "samples-input/{name}"
+    },
+    {
+      "type": "blob",
+      "name": "output",
+      "direction": "out",
+      "path": "samples-output/{name}"
     }
   ]
 }

--- a/sample/BlobTrigger/index.js
+++ b/sample/BlobTrigger/index.js
@@ -1,4 +1,6 @@
-﻿module.exports = function (context, workItem) {
-    console.log('Node.js blob trigger function processed work item ' + workItem.id);
-    context.done();
+﻿module.exports = function (context, blob) {
+    console.log('Node.js blob trigger function processed blob ' + blob);
+    context.done(null, {
+        output: blob
+    });
 }

--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
 using System.IO;
@@ -100,14 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 var scriptExecutionContext = CreateScriptExecutionContext(input, traceWriter, TraceWriter, binder, functionExecutionContext);
 
-                // if there are any binding parameters in the output bindings,
-                // parse the input as json to get the binding data
-                Dictionary<string, string> bindingData = new Dictionary<string, string>();
-                if (_outputBindings.Any(p => p.HasBindingParameters) ||
-                    _inputBindings.Any(p => p.HasBindingParameters))
-                {
-                    bindingData = GetBindingData(input);
-                }
+                Dictionary<string, string> bindingData = GetBindingData(input, binder, _inputBindings, _outputBindings);
                 bindingData["InvocationId"] = functionExecutionContext.InvocationId.ToString();
 
                 await ProcessInputBindingsAsync(binder, scriptExecutionContext, bindingData);
@@ -374,13 +366,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 return false;
             }
-        }
-
-        private static bool IsJson(string input)
-        {
-            input = input.Trim();
-            return (input.StartsWith("{", StringComparison.OrdinalIgnoreCase) && input.EndsWith("}", StringComparison.OrdinalIgnoreCase))
-                || (input.StartsWith("[", StringComparison.OrdinalIgnoreCase) && input.EndsWith("]", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
@@ -114,14 +114,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
             InitializeEnvironmentVariables(environmentVariables, functionInstanceOutputPath, input, _outputBindings, functionExecutionContext);
 
-            // if there are any parameters in the bindings,
-            // parse the input as json to get the binding data
-            Dictionary<string, string> bindingData = new Dictionary<string, string>();
-            if (_outputBindings.Any(p => p.HasBindingParameters) ||
-                _inputBindings.Any(p => p.HasBindingParameters))
-            {
-                bindingData = GetBindingData(stdin);
-            }
+            Dictionary<string, string> bindingData = GetBindingData(stdin, binder, _inputBindings, _outputBindings);
             bindingData["InvocationId"] = invocationId;
 
             await ProcessInputBindingsAsync(functionInstanceOutputPath, binder, bindingData, environmentVariables);

--- a/src/WebJobs.Script/Description/ScriptFunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvokerBase.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Binding;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
@@ -64,27 +67,77 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
         }
 
-        protected static Dictionary<string, string> GetBindingData(object value)
+        protected static Dictionary<string, string> GetBindingData(object value, IBinder binder, Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings)
         {
             Dictionary<string, string> bindingData = new Dictionary<string, string>();
 
-            try
+            // first apply any existing binding data
+            ApplyAmbientBindingData(binder, bindingData);
+
+            // If there are any parameters in the bindings,
+            // get the binding data. In dynamic script cases we need
+            // to parse this POCO data ourselves - it won't be in the existing
+            // binding data because all the POCO binders require strong
+            // typing
+            if (outputBindings.Any(p => p.HasBindingParameters) ||
+                inputBindings.Any(p => p.HasBindingParameters))
             {
-                // parse the object skipping any nested objects (binding data
-                // only includes top level properties)
-                JObject parsed = JObject.Parse(value as string);
-                bindingData = parsed.Children<JProperty>()
-                    .Where(p => p.Value.Type != JTokenType.Object)
-                    .ToDictionary(p => p.Name, p => (string)p);
-            }
-            catch
-            {
-                // it's not an error if the incoming message isn't JSON
-                // there are cases where there will be output binding parameters
-                // that don't bind to JSON properties
+                try
+                {
+                    string json = value as string;
+                    if (!string.IsNullOrEmpty(json) && IsJson(json))
+                    {
+                        // parse the object skipping any nested objects (binding data
+                        // only includes top level properties)
+                        JObject parsed = JObject.Parse(json);
+                        bindingData = parsed.Children<JProperty>()
+                            .Where(p => p.Value.Type != JTokenType.Object)
+                            .ToDictionary(p => p.Name, p => (string)p);
+                    }
+                }
+                catch
+                {
+                    // it's not an error if the incoming message isn't JSON
+                    // there are cases where there will be output binding parameters
+                    // that don't bind to JSON properties
+                }
             }
 
             return bindingData;
+        }
+
+        /// <summary>
+        /// TEMP HACK
+        /// We need to merge the ambient binding data that already exists in the IBinder
+        /// with our binding data. We have to do this rather than relying solely on
+        /// IBinder.BindAsync because we need to include any POCO values we get from parsing
+        /// JSON bodies, etc.
+        /// </summary>
+        protected static void ApplyAmbientBindingData(IBinder binder, IDictionary<string, string> bindingData)
+        {
+            // TEMP: Dig the ambient binding data out of the binder
+            FieldInfo fieldInfo = binder.GetType().GetField("_bindingSource", BindingFlags.NonPublic | BindingFlags.Instance);
+            var bindingSource = fieldInfo.GetValue(binder);
+            PropertyInfo propertyInfo = bindingSource.GetType().GetProperty("AmbientBindingContext");
+            var ambientBindingContext = propertyInfo.GetValue(bindingSource);
+            propertyInfo = ambientBindingContext.GetType().GetProperty("BindingData");
+            IDictionary<string, object> ambientBindingData = (IDictionary<string, object>)propertyInfo.GetValue(ambientBindingContext);
+
+            if (ambientBindingData != null)
+            {
+                // apply the binding data to ours
+                foreach (var item in ambientBindingData)
+                {
+                    bindingData[item.Key] = item.Value.ToString();
+                }
+            }
+        }
+
+        protected static bool IsJson(string input)
+        {
+            input = input.Trim();
+            return (input.StartsWith("{", StringComparison.OrdinalIgnoreCase) && input.EndsWith("}", StringComparison.OrdinalIgnoreCase))
+                || (input.StartsWith("[", StringComparison.OrdinalIgnoreCase) && input.EndsWith("]", StringComparison.OrdinalIgnoreCase));
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/src.ruleset
+++ b/src/src.ruleset
@@ -16,6 +16,7 @@
     <Rule Id="CA904" Action="None" />
     <Rule Id="CA905" Action="None" />
     <Rule Id="CA908" Action="None" />
+    <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1303" Action="None" /> <!-- Enable when we move literals to resx -->
   </Rules>
 </RuleSet>


### PR DESCRIPTION
These changes fix all our broken Blob samples. There were core issues in the binding pipeline which I've addressed. I've fixed all the samples and tested each - they are now successfully triggered on new blobs, and their out bindings also work (with parameter binding).

There is one ugly hack required (private reflection) until we decide what to do in the core SDK. We might need to make the data we need public in some way.