### PR TITLE
Making all binding data available on context 

### DIFF
--- a/sample/QueueTrigger/index.js
+++ b/sample/QueueTrigger/index.js
@@ -1,5 +1,9 @@
 ﻿module.exports = function (context, workItem) {
     context.log('Node.js queue trigger function processed work item ' + workItem.id);
+
+    context.log('DequeueCount=' + context.bindingData.DequeueCount);
+    context.log('InsertionTime=' + context.bindingData.InsertionTime);
+
     context.done(null, {
         receipt: workItem
     });

--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 Dictionary<string, string> bindingData = GetBindingData(input, binder, _inputBindings, _outputBindings);
                 bindingData["InvocationId"] = functionExecutionContext.InvocationId.ToString();
+                scriptExecutionContext["bindingData"] = bindingData;
 
                 await ProcessInputBindingsAsync(binder, scriptExecutionContext, bindingData);
 


### PR DESCRIPTION
E.g. DequeueCount, InsertionTime, etc. Basically all the useful standard binding data that people have access to in the WebJobs SDK. (http://go.microsoft.com/fwlink/?LinkID=524028&clcid=0x409). See the updated Node queue sample which accesses this info.