### PR TITLE
Adding metrics logging

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+
+namespace WebJobs.Script.WebHost.Diagnostics
+{
+    public class WebHostMetricsLogger : IMetricsLogger
+    {
+        public void BeginEvent(MetricEvent metricEvent)
+        {
+            // TODO
+            FunctionStartedEvent startedEvent = metricEvent as FunctionStartedEvent;
+            if (startedEvent != null)
+            {
+                startedEvent.StartTime = DateTime.Now;
+            }
+        }
+
+        public void EndEvent(MetricEvent metricEvent)
+        {
+            // TODO
+            FunctionStartedEvent startedEvent = metricEvent as FunctionStartedEvent;
+            if (startedEvent != null)
+            {
+                startedEvent.EndTime = DateTime.Now;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Controllers\AdminController.cs" />
     <Compile Include="Controllers\FunctionsController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Diagnostics\WebHostMetricsLogger.cs" />
     <Compile Include="Filters\AuthorizationLevelAttribute.cs" />
     <Compile Include="FunctionSecrets.cs" />
     <Compile Include="Global.asax.cs">

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -8,8 +8,11 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using WebJobs.Script.WebHost.Diagnostics;
 
 namespace WebJobs.Script.WebHost
 {
@@ -72,6 +75,14 @@ namespace WebJobs.Script.WebHost
             }
 
             return function;
+        }
+
+        protected override void OnInitializeConfig(JobHostConfiguration config)
+        {
+            base.OnInitializeConfig(config);
+
+            // Add our WebHost specific services
+            config.AddService<IMetricsLogger>(new WebHostMetricsLogger());
         }
 
         protected override void OnHostStarted()

--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using EdgeJs;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
@@ -28,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly string _script;
         private readonly DictionaryJsonConverter _dictionaryJsonConverter = new DictionaryJsonConverter();
         private readonly BindingMetadata _trigger;
+        private readonly FunctionMetadata _functionMetadata;
+        private readonly IMetricsLogger _metrics;
 
         private Func<object, Task<object>> _scriptFunc;
         private Func<object, Task<object>> _clearRequireCache;
@@ -55,6 +58,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _script = string.Format(CultureInfo.InvariantCulture, _functionTemplate, scriptFilePath);
             _inputBindings = inputBindings;
             _outputBindings = outputBindings;
+            _functionMetadata = functionMetadata;
+            _metrics = host.ScriptConfig.HostConfig.GetService<IMetricsLogger>();
 
             InitializeFileWatcherIfEnabled();
         }
@@ -93,6 +98,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             IBinder binder = (IBinder)parameters[2];
             ExecutionContext functionExecutionContext = (ExecutionContext)parameters[3];
 
+            FunctionStartedEvent startedEvent = new FunctionStartedEvent(_functionMetadata);
+            _metrics.BeginEvent(startedEvent);
+
             try
             {
                 TraceWriter.Verbose(string.Format("Function started"));
@@ -113,9 +121,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
             catch (Exception ex)
             {
+                startedEvent.Success = false;
                 TraceWriter.Error(ex.Message, ex);
                 TraceWriter.Verbose(string.Format("Function completed (Failure)"));
                 throw;
+            }
+            finally
+            {
+                _metrics.EndEvent(startedEvent);
             }
         }
 

--- a/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvoker.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
@@ -23,6 +24,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private static string[] _supportedScriptTypes = new string[] { "ps1", "cmd", "bat", "py", "php", "sh", "fsx" };
         private readonly string _scriptFilePath;
         private readonly string _scriptType;
+        private readonly FunctionMetadata _functionMetadata;
+        private readonly IMetricsLogger _metrics;
+
         private readonly Collection<FunctionBinding> _inputBindings;
         private readonly Collection<FunctionBinding> _outputBindings;
 
@@ -33,6 +37,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _scriptType = Path.GetExtension(_scriptFilePath).ToLower(CultureInfo.InvariantCulture).TrimStart('.');
             _inputBindings = inputBindings;
             _outputBindings = outputBindings;
+            _functionMetadata = functionMetadata;
+            _metrics = host.ScriptConfig.HostConfig.GetService<IMetricsLogger>();
         }
 
         public static bool IsSupportedScriptType(string extension)
@@ -87,6 +93,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             IBinder binder = (IBinder)invocationParameters[2];
             ExecutionContext functionExecutionContext = (ExecutionContext)invocationParameters[3];
 
+            FunctionStartedEvent startedEvent = new FunctionStartedEvent(_functionMetadata);
+            _metrics.BeginEvent(startedEvent);
+
             // perform any required input conversions
             string stdin = null;
             if (input != null)
@@ -131,8 +140,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
             process.WaitForExit();
 
-            if (process.ExitCode != 0)
+            bool failed = process.ExitCode != 0;
+            startedEvent.Success = !failed;
+            _metrics.EndEvent(startedEvent);
+
+            if (failed)
             {
+                startedEvent.Success = false;
+
                 string error = process.StandardError.ReadToEnd();
                 TraceWriter.Error(error);
                 TraceWriter.Verbose(string.Format("Function completed (Failure)"));

--- a/src/WebJobs.Script/Diagnostics/FunctionStartedEvent.cs
+++ b/src/WebJobs.Script/Diagnostics/FunctionStartedEvent.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.Description;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    public class FunctionStartedEvent : MetricEvent
+    {
+        public FunctionStartedEvent(FunctionMetadata functionMetadata)
+        {
+            FunctionMetadata = functionMetadata;
+            Success = true;
+        }
+
+        public FunctionMetadata FunctionMetadata { get; private set; }
+
+        public bool Success { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/IMetricsLogger.cs
+++ b/src/WebJobs.Script/Diagnostics/IMetricsLogger.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    /// <summary>
+    /// Defines an interface for emitting metric events from the 
+    /// script runtime for later aggregation and reporting.
+    /// </summary>
+    public interface IMetricsLogger
+    {
+        /// <summary>
+        /// Begins an event.
+        /// </summary>
+        /// <param name="metricEvent">The event.</param>
+        void BeginEvent(MetricEvent metricEvent);
+
+        /// <summary>
+        /// Completes a previously started event.
+        /// </summary>
+        /// <param name="eventHandle">A previously started event.</param>
+        void EndEvent(MetricEvent metricEvent);
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/MetricEvent.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEvent.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    public abstract class MetricEvent
+    {
+        public DateTime StartTime { get; set; }
+
+        public DateTime EndTime { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/MetricsLogger.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricsLogger.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    /// <summary>
+    /// Default implementation of <see cref="IMetricsLogger"/> that doesn't do any logging.
+    /// </summary>
+    public class MetricsLogger : IMetricsLogger
+    {
+        public void BeginEvent(MetricEvent metricEvent)
+        {
+        }
+
+        public void EndEvent(MetricEvent metricEvent)
+        {
+        }
+    }
+}

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.ServiceBus;
 using Newtonsoft.Json.Linq;
 
@@ -119,6 +120,12 @@ namespace Microsoft.Azure.WebJobs.Script
 
         protected virtual void Initialize()
         {
+            IMetricsLogger metricsLogger = ScriptConfig.HostConfig.GetService<IMetricsLogger>();
+            if (metricsLogger == null)
+            {
+                ScriptConfig.HostConfig.AddService<IMetricsLogger>(new MetricsLogger());
+            }
+
             List<FunctionDescriptorProvider> descriptionProviders = new List<FunctionDescriptorProvider>()
             {
                 new ScriptFunctionDescriptorProvider(this, ScriptConfig),

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     {
                         HostId = _config.HostConfig.HostId
                     };
+                    OnInitializeConfig(_config.HostConfig);
                     newInstance = _scriptHostFactory.Create(_config);
                     _traceWriter = newInstance.TraceWriter;
 
@@ -216,6 +217,10 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             return instances;
+        }
+
+        protected virtual void OnInitializeConfig(JobHostConfiguration config)
+        {
         }
 
         protected virtual void OnHostStarted()

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -235,6 +235,10 @@
     <Compile Include="Description\ServiceBusBindingMetadata.cs" />
     <Compile Include="Description\TableBindingMetadata.cs" />
     <Compile Include="Description\TimerBindingMetadata.cs" />
+    <Compile Include="Diagnostics\FunctionStartedEvent.cs" />
+    <Compile Include="Diagnostics\IMetricsLogger.cs" />
+    <Compile Include="Diagnostics\MetricEvent.cs" />
+    <Compile Include="Diagnostics\MetricsLogger.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Extensions\INameResolverExtensions.cs" />
     <Compile Include="Host\ScriptHost.cs" />


### PR DESCRIPTION
Adding an IMetricsLogger component for pipeline instrumentation + events for monitoring. This is just the infrastructure. ScriptHost uses a default/null logger, and WebHost registers it's own implementation since our immediate goal is to only emit events when running as a site extension.