### PR TITLE
Adding Microsoft.CSharp default reference

### DIFF
--- a/src/WebJobs.Script/Description/CSharp/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/CSharp/FunctionMetadataResolver.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 "System.Core",
                 "System.Xml",
                 "System.Net.Http",
+                "Microsoft.CSharp",
                 typeof(object).Assembly.Location,
                 typeof(IAsyncCollector<>).Assembly.Location, /*Microsoft.Azure.WebJobs*/
                 typeof(JobHost).Assembly.Location, /*Microsoft.Azure.WebJobs.Host*/


### PR DESCRIPTION
This enables use of "dynamic" without having to add an explicit reference to the Microsoft.CSharp assembly.

Resolves #87 