### PR TITLE
Fixing HTTP Trigger sample argument name

### DIFF
--- a/sample/BlobTrigger-CSharp/run.csx
+++ b/sample/BlobTrigger-CSharp/run.csx
@@ -5,7 +5,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(string blob, out string output, TraceWriter log)
 {
-    log.Verbose($"CSharp Blob trigger function processed a blob. Blob={blob}");
+    log.Verbose($"C# Blob trigger function processed a blob. Blob={blob}");
 
     output = blob;
 }

--- a/sample/HttpTrigger-CSharp/run.csx
+++ b/sample/HttpTrigger-CSharp/run.csx
@@ -6,12 +6,12 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Host;
 
-public static Task<HttpResponseMessage> Run(HttpRequestMessage input, TraceWriter log)
+public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
 {
-    var queryParamms = input.GetQueryNameValuePairs()
+    var queryParamms = req.GetQueryNameValuePairs()
         .ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
 
-    log.Verbose(string.Format("CSharp HTTP trigger function processed a request. Name={0}", input.RequestUri));
+    log.Verbose(string.Format("C# HTTP trigger function processed a request. Name={0}", req.RequestUri));
 
     HttpResponseMessage res = null;
     string name;

--- a/sample/TimerTrigger-CSharp/run.csx
+++ b/sample/TimerTrigger-CSharp/run.csx
@@ -5,7 +5,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(TimerInfo input, out string message, TraceWriter log)
 {
-    log.Verbose("CSharp Timer trigger function executed.");
+    log.Verbose("C# Timer trigger function executed.");
 
     message = $"Trigger function executed at {DateTime.Now}";
 }


### PR DESCRIPTION
Fixing HTTP Trigger sample argument name and updating C# samples to match templates and use "C#" instead of "CSharp"