### PR TITLE
Improvements to core error handling/reporting

### DIFF
--- a/sample/QueueTrigger/function.json
+++ b/sample/QueueTrigger/function.json
@@ -7,6 +7,7 @@
     },
     {
       "type": "blob",
+      "storageAccount": "AzureWebJobsSecondaryStorage",
       "name": "receipt",
       "direction": "out",
       "path": "samples-workitems/{id}"

--- a/sample/host.json
+++ b/sample/host.json
@@ -1,3 +1,4 @@
 {
-  "id": "5a709861cab44e68bfed5d2c2fe7fc0c"
+  "id": "5a709861cab44e68bfed5d2c2fe7fc0c",
+  "functions": [ "QueueTrigger" ]
 }

--- a/src/WebJobs.Script/Description/BindingMetadata.cs
+++ b/src/WebJobs.Script/Description/BindingMetadata.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         public string Name { get; set; }
 
+        public string StorageAccount { get; set; }
+
         public BindingType Type { get; set; }
 
         public BindingDirection Direction { get; set; }

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -204,6 +204,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 attributeBuilder
             };
+
+            if (!string.IsNullOrEmpty(trigger.StorageAccount))
+            {
+                ctorInfo = typeof(StorageAccountAttribute).GetConstructor(new Type[] { typeof(string) });
+                attributeBuilder = new CustomAttributeBuilder(ctorInfo, new object[] { trigger.StorageAccount });
+                attributes.Add(attributeBuilder);
+            }
+
             return new ParameterDescriptor(parameterName, triggerParameterType, attributes);
         }
 

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -291,6 +291,7 @@ namespace Microsoft.Azure.WebJobs.Script
             BindingMetadata bindingMetadata = null;
             string bindingTypeValue = (string)binding["type"];
             string bindingDirectionValue = (string)binding["direction"];
+            string storageAccount = (string)binding["storageAccount"];
             BindingType bindingType = default(BindingType);
             BindingDirection bindingDirection = default(BindingDirection);
 
@@ -349,6 +350,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             bindingMetadata.Type = bindingType;
             bindingMetadata.Direction = bindingDirection;
+            bindingMetadata.StorageAccount = storageAccount;
 
             nameResolver.ResolveAllProperties(bindingMetadata);
 


### PR DESCRIPTION
These changes to error handling/reporting address the following issues (and probably more):

https://github.com/Azure/azure-webjobs-sdk-script/issues/109
https://github.com/Azure/azure-webjobs-sdk-script/issues/71

The main change is to make use of the TraceMonitor Extension (part of the extensions repo) to hook into all host level errors. We're then able to inspect/handle them as needed. There are 2 classes of errors that are now handled properly:

1) In the case of startup time function initialization issues, we capture the error and add to the function errors collection (which is shown in the portal). Importantly, we don't let the error bring down the host - we continue to index the rest of the functions. Previously many binding config errors would bring down the host.

2) In the case of runtime invoke errors, we route them through a new IFunctionInvoker.OnError interface which allows the invoker for that function to handle the error as needed. The base invoker writes all such errors to the function log file, so it will show up in the log stream. I've removed the invoker specific logic for this that existed previously - it's now the same centralized logic across invokers. Previously many errors happened outside of our invoker pipeline (e.g. in the core SDK), so we were unable to log the errors to the function log file.

Changes in the core SDK were required. See: https://github.com/Azure/azure-webjobs-sdk/pull/661