### PR TITLE
Adding multi-storage account support

### DIFF
--- a/function.json
+++ b/function.json
@@ -3,14 +3,14 @@
     {
       "type": "eventHubTrigger",
       "direction": "in",
-      "connectionString": "%AzureWebJobsEventHubReceiver%",
-      "path": "%AzureWebJobsEventHubPath%"
+      "connection": "AzureWebJobsEventHubReceiver",
+      "path": "AzureWebJobsEventHubPath"
     },
     {
       "type": "eventHub",
       "name": "output",
       "direction": "out",
-      "connectionString": "%AzureWebJobsEventHubSender%",
+      "connection": "AzureWebJobsEventHubSender",
       "path": "%AzureWebJobsEventHubPath%"
     }
   ]

--- a/src/WebJobs.Script/Config/NameResolver.cs
+++ b/src/WebJobs.Script/Config/NameResolver.cs
@@ -24,21 +24,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 }
             }
 
-            string value = ConfigurationManager.AppSettings[name];
-            if (!string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
-            // Check env var
-            value = Environment.GetEnvironmentVariable(name);
-            if (value != null)
-            {
-                return value;
-            }
-
             // contract is to return null if not found. 
-            return null;
+            return Utility.GetAppSettingOrEnvironmentValue(name);
         }
     }
 }

--- a/src/WebJobs.Script/Description/DocumentDBBindingMetadata.cs
+++ b/src/WebJobs.Script/Description/DocumentDBBindingMetadata.cs
@@ -14,9 +14,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public bool CreateIfNotExists { get; set; }
 
-        [AllowNameResolution]
-        public string ConnectionString { get; set; }
-
         public override void ApplyToConfig(JobHostConfigurationBuilder configBuilder)
         {
             if (configBuilder == null)
@@ -25,9 +22,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             DocumentDBConfiguration config = new DocumentDBConfiguration();
-            if (!string.IsNullOrEmpty(ConnectionString))
+            if (!string.IsNullOrEmpty(Connection))
             {
-                config.ConnectionString = ConnectionString;
+                config.ConnectionString = Utility.GetAppSettingOrEnvironmentValue(Connection);
             }
 
             configBuilder.Config.UseDocumentDB(config);

--- a/src/WebJobs.Script/Description/EventHubBindingMetadata.cs
+++ b/src/WebJobs.Script/Description/EventHubBindingMetadata.cs
@@ -9,9 +9,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     public class EventHubBindingMetadata : BindingMetadata
     {
         [AllowNameResolution]
-        public string ConnectionString { get; set; }
-
-        [AllowNameResolution]
         public string Path { get; set; }
 
         public override void ApplyToConfig(JobHostConfigurationBuilder configBuilder)
@@ -21,6 +18,12 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 throw new ArgumentNullException("configBuilder");
             }
             EventHubConfiguration eventHubConfig = configBuilder.EventHubConfiguration;
+
+            string connectionString = null;
+            if (!string.IsNullOrEmpty(Connection))
+            {
+                connectionString = Utility.GetAppSettingOrEnvironmentValue(Connection);
+            }
 
             if (this.IsTrigger)
             {
@@ -32,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                      eventProcessorHostName,
                      this.Path,
                      Microsoft.ServiceBus.Messaging.EventHubConsumerGroup.DefaultGroupName,
-                     this.ConnectionString,
+                     connectionString,
                      storageConnectionString);
 
                 eventHubConfig.AddEventProcessorHost(this.Path, eventProcessorHost);
@@ -40,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             else
             {                
                 var client = Microsoft.ServiceBus.Messaging.EventHubClient.CreateFromConnectionString(
-                    this.ConnectionString, this.Path);
+                    connectionString, this.Path);
 
                 eventHubConfig.AddEventHubClient(this.Path, client);
             }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -28,6 +29,25 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             return formattedError;
+        }
+
+        public static string GetAppSettingOrEnvironmentValue(string name)
+        {
+            // first check app settings
+            string value = ConfigurationManager.AppSettings[name];
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            // Check environment variables
+            value = Environment.GetEnvironmentVariable(name);
+            if (value != null)
+            {
+                return value;
+            }
+
+            return null;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/TestScripts/Node/EventHubSender/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/EventHubSender/function.json
@@ -8,7 +8,7 @@
       "type": "eventHub",
       "name": "output",
       "direction": "out",
-      "connectionString": "%AzureWebJobsEventHubSender%",
+      "connection": "AzureWebJobsEventHubSender",
       "path": "%AzureWebJobsEventHubPath%"
     }
   ]

--- a/test/WebJobs.Script.Tests/TestScripts/Node/EventHubTrigger/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/EventHubTrigger/function.json
@@ -3,7 +3,7 @@
     {
       "type": "eventHubTrigger",
       "direction": "in",
-      "connectionString": "%AzureWebJobsEventHubReceiver%",
+      "connection": "AzureWebJobsEventHubReceiver",
       "path": "%AzureWebJobsEventHubPath%"
     },
     {


### PR DESCRIPTION
With these changes all the bindings that target Azure Storage (Queues/Blobs/Tables) can now specify the storage account to use for the binding. This allows mix-n-match - you can trigger on a queue in one storage account, and write blobs to another storage account, in the same function.

This PR addressess issues https://github.com/Azure/azure-webjobs-sdk-script/issues/76 and https://github.com/Azure/azure-webjobs-sdk-script/issues/55

The connection to use is specified in metadata via a new `connection` property. The value when set should be the name of an app setting whose value contains the Azure Storage connection string. The value can also contain %% name resolver markers, in which case the value itself can come from another app setting.

This feature leverages the core SDK **StorageAccountAttribute** which takes an app setting name, so our job in script is to just ensure that the parameter we generate/bind to has the right StorageAccountAttribute.

The core SDK IBinder interface that we're using had an unfortunate limitation that prevented us from specifying these additional attributes. I've addressed that in core and I'm leveraging those changes here. See companion PR: https://github.com/Azure/azure-webjobs-sdk/pull/666. Pay no attention to the fact that that PR bears the mark of the beast.

Still thinking about the right way to test. I've done my own testing, however baking in some e2e tests would require people to have 2 storage accounts.