### PR TITLE
Fixing issues with NuGet restore

### DIFF
--- a/src/WebJobs.Script/Description/CSharp/PackageManager.cs
+++ b/src/WebJobs.Script/Description/CSharp/PackageManager.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 if (!string.IsNullOrEmpty(kuduPath))
                 {
-                    path = Path.Combine(kuduPath, "\\bin\\scripts", NuGetFileName);
+                    path = Path.Combine(kuduPath, "bin\\scripts", NuGetFileName);
                 }                
             }
 


### PR DESCRIPTION
Fixing a couple of small issues Matthew ran into with NuGet package dependencies.

- Using the assembly name as the key/lookup when matching NuGet assemblies
- Fixing path fragment causing issues with Path.Combine used to locate Nuget.exe