### PR TITLE
Adding assemblies to shared assemblies list

### DIFF
--- a/src/WebJobs.Script/Description/CSharp/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/CSharp/FunctionMetadataResolver.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private static readonly Assembly[] SharedAssemblies =
             {
-                typeof(Newtonsoft.Json.JsonConvert).Assembly /*Newtonsoft.Json*/
+                typeof(Newtonsoft.Json.JsonConvert).Assembly, /*Newtonsoft.Json*/
+                typeof(AspNet.WebHooks.IWebHookReceiver).Assembly, /*Microsoft.AspNet.WebHooks.Receivers*/
+                typeof(AspNet.WebHooks.Config.WebHooksConfig).Assembly /*Microsoft.AspNet.WebHooks.Common*/
             };
 
         private static readonly string[] DefaultNamespaceImports =


### PR DESCRIPTION
Adding Microsoft.AspNet.WebHooks.Receivers and Microsoft.AspNet.WebHooks.Common to shared assemblies.

Resolves #129 