### PR TITLE
Allow context.log to log objects (via util.inspect)

### DIFF
--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -248,9 +248,13 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // create a TraceWriter wrapper that can be exposed to Node.js
             var log = (Func<object, Task<object>>)(p =>
             {
-                string text = (string)p;
-                traceWriter.Verbose(text);
-                fileTraceWriter.Verbose(text);
+                string text = p as string;
+                if (text != null)
+                {
+                    traceWriter.Verbose(text);
+                    fileTraceWriter.Verbose(text);
+                } 
+
                 return Task.FromResult<object>(null);
             });
 

--- a/src/WebJobs.Script/functionTemplate.js
+++ b/src/WebJobs.Script/functionTemplate.js
@@ -1,9 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-var f = require('{0}');
+var f = require('{0}'),
+    util = require('util');
 
 return function (context, callback) {{
+    var origLog = context.log;
+    context.log = function(value) {{
+        origLog(util.inspect(value));
+    }};
+
     context.done = function(err, result) {{
         if (err) {{
             callback(err);

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -92,6 +94,12 @@ namespace WebJobs.Script.Tests
                 { "input", testData }
             };
             await Fixture.Host.CallAsync("ManualTrigger", arguments);
+
+            TraceEvent scriptTrace = Fixture.TraceWriter.Traces.Single(p => p.Message.Contains(testData));
+            Assert.Equal(TraceLevel.Verbose, scriptTrace.Level);
+            JObject logEntry = JObject.Parse(scriptTrace.Message);
+            Assert.Equal("Node.js manually triggered function called!", logEntry["message"]);
+            Assert.Equal(testData, logEntry["input"]);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/TestScripts/Node/ManualTrigger/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/ManualTrigger/index.js
@@ -1,4 +1,12 @@
 ﻿module.exports = function (context, input) {
-    context.log('Node.js manually triggered function called with input ' + input);
+    var logEntry = {
+        message: 'Node.js manually triggered function called!',
+        input: input
+    };
+    context.log(logEntry);
+    context.log(null);
+    context.log(1234);
+    context.log(true);
+
     context.done();
 }


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk-script/issues/118

Fixing `context.log` so it handles more than just strings. I've chosen to use `util.inspect` in the node wrapper, to avoid implementing all the conversions in .NET from ExpandoObjects, etc.