### PR TITLE
Fixing BlobTrigger bug

### DIFF
--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -321,6 +321,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 }
                 input = inputValues;
             }
+            else if (typeof(Stream).IsAssignableFrom(triggerParameterType))
+            {
+                Stream inputStream = (Stream)input;
+                using (StreamReader sr = new StreamReader(inputStream))
+                {
+                    input = sr.ReadToEnd();
+                }
+            }
 
             bindings.Add(_trigger.Name, input);
 

--- a/src/WebJobs.Script/Diagnostics/FastLogger.cs
+++ b/src/WebJobs.Script/Diagnostics/FastLogger.cs
@@ -27,25 +27,13 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
             this._writer = LogFactory.NewWriter(containerName, table);
         }
 
-        // SDK notification gives us the full name, which came from Ref.Emit.
-        // It's 'Type.Method'.  We just want 'Method'
-        private static string GetShortName(string fullname)
-        {
-            int i = fullname.LastIndexOf('.');
-            if (i != -1)
-            {
-                return fullname.Substring(i + 1);
-            }
-            return fullname;
-        }
-
         public async Task AddAsync(FunctionInstanceLogEntry item, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Convert Host to Protocol so we can log it 
             var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
             var jsonClone = JsonConvert.SerializeObject(item, settings);
             var item2 = JsonConvert.DeserializeObject<FunctionInstanceLogItem>(jsonClone);
-            item2.FunctionName = GetShortName(item2.FunctionName);
+            item2.FunctionName = Utility.GetFunctionShortName(item2.FunctionName);
             await _writer.AddAsync(item2);
         }
 


### PR DESCRIPTION
BlobTrigger bindings for Node.js are currently broken This is due to some changes that were made almost 2 weeks ago - apparently nobody has been trying this scenario. The issue is that previously we always bound BlobTrigger as a string, but in https://github.com/Azure/azure-webjobs-sdk-script/commit/81ee8b71b4f6c807ee2cbb0661685114fcd81a70 this was changed to be a Stream.

We need to a conversion to string before invoking Node - currently we're passing in the stream causing it to blow up.

I want to add a test as well, but that might have to wait. We can't have tests that wait 10 seconds for a blob to trigger. We'll need to do some infra work to make this better testable.

Exception while executing function: Functions.BlobTrigger
Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Functions.BlobTrigger ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: Timeouts are not supported on this stream.
   at System.IO.Stream.get_ReadTimeout()
   at Microsoft.Azure.WebJobs.Host.Blobs.DelegatingStream.get_ReadTimeout()
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at ClrFunc.MarshalCLRObjectToV8(Local<v8::Object>* , Object netdata)
   at ClrFunc.MarshalCLRToV8(Local<v8::Value>* , Object netdata)
   at ClrFunc.MarshalCLRToV8(Local<v8::Value>* , Object netdata)
   at ClrFunc.MarshalCLRToV8(Local<v8::Value>* , Object netdata)
   at NodejsFuncInvokeContext.CallFuncOnV8Thread()