### PR TITLE
adding DocDB and EasyTables input bindings

### DIFF
--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -80,23 +80,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EasyTables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -12,11 +12,11 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="1.4.0" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10286" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10260" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10266" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -133,23 +133,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EasyTables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -27,11 +27,11 @@
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10286" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10260" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10266" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/src/WebJobs.Script/Description/DocumentDBBindingMetadata.cs
+++ b/src/WebJobs.Script/Description/DocumentDBBindingMetadata.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public string CollectionName { get; set; }
 
         public bool CreateIfNotExists { get; set; }
+
+        public string Id { get; set; }
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -74,23 +74,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EasyTables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -13,11 +13,11 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="1.4.0" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10286" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10260" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10266" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
@@ -22,7 +22,7 @@ namespace WebJobs.Script.Tests
         [Fact]
         public async Task EasyTables()
         {
-            await EasyTablesTest();
+            await EasyTablesTest(isCSharp: true);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -54,8 +54,7 @@ namespace WebJobs.Script.Tests
         [Fact]
         public async Task EasyTables()
         {
-            // Only out bindings are supported in node right now: https://github.com/Azure/azure-webjobs-sdk-script/issues/107
-            await EasyTablesTest(writeToQueue: false);
+            await EasyTablesTest();
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/DocumentDBIn/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/DocumentDBIn/function.json
@@ -1,0 +1,17 @@
+﻿{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "queueName": "documentdb-input",
+      "direction": "in"
+    },
+    {
+      "type": "documentdb",
+      "name": "item",
+      "direction": "in",
+      "databaseName": "ItemDb",
+      "collectionName": "ItemCollection",
+      "id": "{QueueTrigger}"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/DocumentDBIn/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/DocumentDBIn/run.csx
@@ -1,0 +1,10 @@
+﻿#r "Newtonsoft.Json"
+
+using System;
+using Microsoft.Azure.WebJobs.Host;
+using Newtonsoft.Json.Linq;
+
+public static void Run(string input, JObject item, TraceWriter log)
+{
+    item["text"] = "This was updated!";
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/DocumentDBIn/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/DocumentDBIn/function.json
@@ -1,0 +1,25 @@
+﻿{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "queueName": "documentdb-input",
+      "direction": "in"
+    },
+    {
+      "type": "documentdb",
+      "name": "itemIn",
+      "direction": "in",
+      "databaseName": "ItemDb",
+      "collectionName": "ItemCollection",
+      "id": "{QueueTrigger}"
+    },
+    {
+      "type": "documentdb",
+      "name": "itemOut",
+      "direction": "out",
+      "databaseName": "ItemDb",
+      "collectionName": "ItemCollection",
+      "createIfNotExists": true
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/DocumentDBIn/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/DocumentDBIn/index.js
@@ -1,0 +1,7 @@
+﻿module.exports = function (context, input) {    
+
+    context.bindings.itemOut = context.bindings.itemIn;
+    context.bindings.itemOut.text = "This was updated!";
+
+    context.done();
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/EasyTableIn/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/EasyTableIn/function.json
@@ -1,0 +1,22 @@
+﻿{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "queueName": "easytables-input",
+      "direction": "in"
+    },
+    {
+      "type": "easyTable",
+      "name": "itemIn",
+      "direction": "in",
+      "tableName": "Item",
+      "id": "{QueueTrigger}"
+    },
+    {
+      "type": "easyTable",
+      "direction": "out",
+      "name": "itemOut",
+      "tableName": "Item"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/EasyTableIn/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/EasyTableIn/index.js
@@ -1,0 +1,15 @@
+﻿// EasyTable node scripts cannot Update values 
+// because output bindings perform an insert rather
+// than an upsert.
+// So we'll insert with a known id that we can query
+// from the test. That'll confirm this was called as
+// expected.
+
+module.exports = function (context, input) {    
+
+    context.bindings.itemOut = {
+        id: context.bindings.itemIn.id + "-success"
+    };
+
+    context.done();
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -64,23 +64,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EasyTables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EasyTables.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.EasyTables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10260\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.1.0.2-alpha-10266\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -254,6 +254,12 @@
     <None Include="TestScripts\CSharp\BlobTrigger\run.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\CSharp\DocumentDBIn\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\CSharp\DocumentDBIn\run.csx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\CSharp\NotificationHubOutNotification\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -318,6 +324,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestScripts\host.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\Node\DocumentDBIn\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\Node\EasyTableIn\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestScripts\Node\NotificationHubOut\function.json">
@@ -407,6 +419,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\Common\test.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestScripts\Node\DocumentDBIn\index.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestScripts\Node\EasyTableIn\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\NotificationHubOut\index.js">

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -11,11 +11,11 @@
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10286" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10260" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10260" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="1.0.2-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.EasyTables" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10266" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.0.2-alpha-10266" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.1.2-alpha-10286" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />


### PR DESCRIPTION
Adds:

- Input bindings for DocumentDB. Non-C# bindings do not automatically update the document when the function exits but you can chain them with another DocumentDB ouput binding to do this. There is an E2E test that does this.

- Non-C# input bindings for EasyTables. The binding will read the item but it is not automatically updated and you cannot chain them with an EasyTable output binding b/c EasyTables performs an insert rather than an upsert. C# is the better language to use if you want to update records.

When issue #49 is resolved, these input bindings will become more useful.