### PR TITLE
Fixing Blob trigger input conversion

### DIFF
--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -280,13 +280,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 { "bind", bind }
             };
 
-            Type triggerParameterType = input.GetType();
-            if (triggerParameterType == typeof(string))
-            {
-                // if the input is json, convert to an object
-                input = TryConvertJsonToObject((string)input);
-            }
-            else if (triggerParameterType == typeof(HttpRequestMessage))
+            if (input is HttpRequestMessage)
             {
                 // convert the request to a json object
                 HttpRequestMessage request = (HttpRequestMessage)input;
@@ -306,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     context["req"] = requestObject;
                 }
             }
-            else if (triggerParameterType == typeof(TimerInfo))
+            else if (input is TimerInfo)
             {
                 TimerInfo timerInfo = (TimerInfo)input;
                 var inputValues = new Dictionary<string, object>()
@@ -320,13 +314,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 }
                 input = inputValues;
             }
-            else if (typeof(Stream).IsAssignableFrom(triggerParameterType))
+            else if (input is Stream)
             {
                 Stream inputStream = (Stream)input;
                 using (StreamReader sr = new StreamReader(inputStream))
                 {
                     input = sr.ReadToEnd();
                 }
+            }
+
+            if (input is string)
+            {
+                // if the input is json, convert to an object
+                input = TryConvertJsonToObject((string)input);
             }
 
             bindings.Add(_trigger.Name, input);

--- a/src/src.ruleset
+++ b/src/src.ruleset
@@ -18,5 +18,6 @@
     <Rule Id="CA908" Action="None" />
     <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1303" Action="None" /> <!-- Enable when we move literals to resx -->
+    <Rule Id="CA1800" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Our Node BlobTrigger templates are currently broken since they expect the input to be an object (if the blob content is JSON). E.g. https://github.com/Azure/azure-webjobs-sdk-templates/blob/master/Templates/BlobTrigger-NodeJS/index.js.

The issue is that we're doing the string JSON -> object conversion too early. The blob triggering works just fine, but if the script is expecting an object (like the template) it won't be.