### PR TITLE
Host level error handling improvements

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/AdminController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/AdminController.cs
@@ -90,7 +90,7 @@ namespace WebJobs.Script.WebHost.Controllers
             if (lastError != null)
             {
                 status.Errors = new Collection<string>();
-                status.Errors.Add(lastError.Message);
+                status.Errors.Add(Utility.FlattenException(lastError));
             }
 
             return status;

--- a/src/src.ruleset
+++ b/src/src.ruleset
@@ -19,5 +19,6 @@
     <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1303" Action="None" /> <!-- Enable when we move literals to resx -->
     <Rule Id="CA1800" Action="None" />
+    <Rule Id="CA1307" Action="None" />
   </Rules>
 </RuleSet>

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script;
+using Xunit;
+
+namespace WebJobs.Script.Tests
+{
+    public class UtilityTests
+    {
+        [Fact]
+        public void FlattenException_AggregateException_ReturnsExpectedResult()
+        {
+            ApplicationException ex1 = new ApplicationException("Incorrectly configured setting 'Foo'");
+            ex1.Source = "Acme.CloudSystem";
+
+            // a dupe of the first
+            ApplicationException ex2 = new ApplicationException("Incorrectly configured setting 'Foo'");
+            ex1.Source = "Acme.CloudSystem";
+
+            AggregateException aex = new AggregateException("One or more errors occurred.", ex1, ex2);
+
+            string formattedResult = Utility.FlattenException(aex);
+            Assert.Equal("Acme.CloudSystem: Incorrectly configured setting 'Foo'.", formattedResult);
+        }
+
+        [Fact]
+        public void FlattenException_SingleException_ReturnsExpectedResult()
+        {
+            ApplicationException ex = new ApplicationException("Incorrectly configured setting 'Foo'");
+            ex.Source = "Acme.CloudSystem";
+
+            string formattedResult = Utility.FlattenException(ex);
+            Assert.Equal("Acme.CloudSystem: Incorrectly configured setting 'Foo'.", formattedResult);
+        }
+
+        [Fact]
+        public void FlattenException_MultipleInnerExceptions_ReturnsExpectedResult()
+        {
+            ApplicationException ex1 = new ApplicationException("Exception message 1");
+            ex1.Source = "Source1";
+
+            ApplicationException ex2 = new ApplicationException("Exception message 2.", ex1);
+            ex2.Source = "Source2";
+
+            ApplicationException ex3 = new ApplicationException("Exception message 3", ex2);
+
+            string formattedResult = Utility.FlattenException(ex3);
+            Assert.Equal("Exception message 3. Source2: Exception message 2. Source1: Exception message 1.", formattedResult);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>WebJobs.Script.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
@@ -232,6 +233,7 @@
     <Compile Include="TestHelpers.cs" />
     <Compile Include="TestInvoker.cs" />
     <Compile Include="TestTraceWriter.cs" />
+    <Compile Include="UtilityTests.cs" />
     <Compile Include="WindowsBatchEndToEndTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The Portal hits the admin/host/status endpoint to get host level errors. This API is working in production, but the error messages it returns aren't detailed enough. For example, in a recent issue (https://github.com/Azure/azure-webjobs-sdk-script/issues/151) involving a bad EventHubs connection string, the error message returned is the very frustrating:

     "One or more errors occurred"

That's because we were just returning the top level ex message. With my changes we now return:

     "Microsoft.ServiceBus: No such host is known."
