### PR TITLE
Setting temporary host defaults

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -92,6 +92,18 @@ namespace Microsoft.Azure.WebJobs.Script
                 File.WriteAllText(hostConfigFilePath, "{}");
             }
 
+            if (ScriptConfig.HostConfig.IsDevelopment)
+            {
+                ScriptConfig.HostConfig.UseDevelopmentSettings();
+            }
+            else
+            {
+                // TEMP: Until https://github.com/Azure/azure-webjobs-sdk-script/issues/100 is addressed
+                // we're using some presets that are a good middle ground
+                ScriptConfig.HostConfig.Queues.MaxPollingInterval = TimeSpan.FromSeconds(10);
+                ScriptConfig.HostConfig.Singleton.ListenerLockPeriod = TimeSpan.FromSeconds(15);
+            }
+
             string json = File.ReadAllText(hostConfigFilePath);
             JObject hostConfig = JObject.Parse(json);
             ApplyConfiguration(hostConfig, ScriptConfig);
@@ -170,11 +182,6 @@ namespace Microsoft.Azure.WebJobs.Script
             if (metricsLogger == null)
             {
                 ScriptConfig.HostConfig.AddService<IMetricsLogger>(new MetricsLogger());
-            }
-
-            if (ScriptConfig.HostConfig.IsDevelopment)
-            {
-                ScriptConfig.HostConfig.UseDevelopmentSettings();
             }
 
             // Bindings may use name resolution, so provide this before reading the bindings. 


### PR DESCRIPTION
Capping some of the default limits to improve debug portal experience.

E.g. for queues by default, the exponential backoff algorithm will eventually only poll every minute for messages. Here we cap that so it will never take longer than 10 seconds to trigger on a new message. Currently with the defaults, it can take up to a minute if there hasn't been any recent activity on the queue.