### PR TITLE
Fixing Table input binding issue

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
@@ -117,7 +117,7 @@ namespace WebJobs.Script.WebHost
             bool isLocal = string.IsNullOrEmpty(home);
             if (isLocal)
             {
-                settings.ScriptPath = Path.Combine(HostingEnvironment.ApplicationPhysicalPath, @"..\..\sample");
+                settings.ScriptPath = Environment.GetEnvironmentVariable("AzureWebJobsScriptRoot");
                 settings.LogPath = Path.Combine(Path.GetTempPath(), @"Functions");
                 settings.SecretsPath = HttpContext.Current.Server.MapPath("~/App_Data/Secrets");
             }
@@ -127,6 +127,11 @@ namespace WebJobs.Script.WebHost
                 settings.ScriptPath = Path.Combine(home, @"site\wwwroot");
                 settings.LogPath = Path.Combine(home, @"LogFiles\Application\Functions");
                 settings.SecretsPath = Path.Combine(home, @"data\Functions\secrets");
+            }
+
+            if (string.IsNullOrEmpty(settings.ScriptPath))
+            {
+                throw new InvalidOperationException("Unable to determine function script root directory.");
             }
 
             return settings;


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/181. Issue was the Table bindings were causing the underlying Stream to be closed.

I've tested this locally and this fixes the issue. I'll also try to add a regression test for this.