### PR TITLE
Honor "connection" in Queue output binding

### DIFF
--- a/src/WebJobs.Script/Binding/QueueBinding.cs
+++ b/src/WebJobs.Script/Binding/QueueBinding.cs
@@ -70,7 +70,15 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             Stream valueStream = context.Value as Stream;
 
             var attribute = new QueueAttribute(boundQueueName);
-            RuntimeBindingContext runtimeContext = new RuntimeBindingContext(attribute);
+            Attribute[] additionalAttributes = null;
+            if (!string.IsNullOrEmpty(Metadata.Connection))
+            {
+                additionalAttributes = new Attribute[]
+                {
+                    new StorageAccountAttribute(Metadata.Connection)
+                };
+            }
+            RuntimeBindingContext runtimeContext = new RuntimeBindingContext(attribute, additionalAttributes);
 
             // only an output binding is supported
             IAsyncCollector<byte[]> collector = await context.Binder.BindAsync<IAsyncCollector<byte[]>>(runtimeContext);


### PR DESCRIPTION
When I did multi-connection support (PR https://github.com/Azure/azure-webjobs-sdk-script/commit/07f8f1c3551d53e7651c97f071cc82bc3dcd960b), I missed it for the Queue output binding (I already did it for the queue trigger).