### PR TITLE
Moving to Edge.js version 5.9.1

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -50,7 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="EdgeJs, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Edge.js.4.0.0\lib\EdgeJs.dll</HintPath>
+      <HintPath>..\..\packages\Edge.js.5.9.1\lib\EdgeJs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.WebHooks.Common, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -319,6 +319,14 @@
     <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\packages\Edge.js.5.9.1\content\edge\x64\edge_nativeclr.node">
+      <Link>edge\x64\edge_nativeclr.node</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\packages\Edge.js.5.9.1\content\edge\x86\edge_nativeclr.node">
+      <Link>edge\x86\edge_nativeclr.node</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
@@ -328,30 +336,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="clearRequireCache.js" />
-    <Content Include="..\..\packages\Edge.js.4.0.0\content\edge\double_edge.js">
-      <Link>edge\double_edge.js</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\packages\Edge.js.4.0.0\content\edge\edge.js">
-      <Link>edge\edge.js</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\packages\Edge.js.4.0.0\content\edge\x64\node.dll">
-      <Link>edge\x64\node.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\packages\Edge.js.4.0.0\content\edge\x64\edge.node">
-      <Link>edge\x64\edge.node</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\packages\Edge.js.4.0.0\content\edge\x86\node.dll">
-      <Link>edge\x86\node.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\packages\Edge.js.4.0.0\content\edge\x86\edge.node">
-      <Link>edge\x86\edge.node</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <EmbeddedResource Include="functionTemplate.js" />
   </ItemGroup>
   <ItemGroup>
@@ -362,6 +346,24 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\packages\Edge.js.5.9.1\content\edge\double_edge.js">
+      <Link>edge\double_edge.js</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\packages\Edge.js.5.9.1\content\edge\edge.js">
+      <Link>edge\edge.js</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\packages\Edge.js.5.9.1\content\edge\x64\node.dll">
+      <Link>edge\x64\node.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\packages\Edge.js.5.9.1\content\edge\x86\node.dll">
+      <Link>edge\x86\node.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets')" />

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net46" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
-  <package id="Edge.js" version="4.0.0" targetFramework="net45" />
+  <package id="Edge.js" version="5.9.1" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Common" version="1.2.0-rc1" targetFramework="net46" />


### PR DESCRIPTION
We're currently using version 4.0.0 of the Edge.js package (which means we're running Node version 4.1.1). Moving to package version 5.9.1 (which will give us Node version 5.9.1).