### PR TITLE
Purge log files

### DIFF
--- a/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
@@ -46,6 +46,57 @@ namespace WebJobs.Script.Tests
             Assert.Equal((3 * numLines) + 1, fileLines.Length);
         }
 
+        [Fact]
+        public void SetNewLogFile_PurgesOldLogFiles()
+        {
+            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
+            directory.Create();
+
+            int initialCount = FileTraceWriter.MaxLogFileCount + 5;
+            for (int i = 0; i < initialCount; i++)
+            {
+                string fileName = string.Format("{0}-{1}.log", i, FileTraceWriter.GetInstanceId());
+                string path = Path.Combine(_logFilePath, fileName);
+                Thread.Sleep(50);
+                File.WriteAllText(path, "Test Logs");
+            }
+
+            var files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
+            Assert.Equal(initialCount, files.Length);
+
+            FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose);
+            traceWriter.SetNewLogFile();
+
+            files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
+
+            // verify log files are purged
+            Assert.Equal(FileTraceWriter.MaxLogFileCount - 1, files.Length);
+            for (int i = 0; i < FileTraceWriter.MaxLogFileCount - 1; i++)
+            {
+                string expectedFilePrefix = (initialCount - 1 - i).ToString();
+                Assert.True(files[i].Name.StartsWith(expectedFilePrefix));
+            }
+        }
+
+        [Fact]
+        public void SetNewLogFile_EmptyDirectory_Succeeds()
+        {
+            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
+            directory.Create();
+
+            FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose);
+            traceWriter.SetNewLogFile();
+
+            var files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
+            Assert.Equal(0, files.Length);
+
+            traceWriter.Verbose("Test log");
+            traceWriter.FlushToFile();
+
+            files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
+            Assert.Equal(1, files.Length);
+        }
+
         private void WriteLogs(string logFilePath, int numLogs)
         {
             FileTraceWriter traceWriter = new FileTraceWriter(logFilePath, TraceLevel.Verbose);


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/153. Just putting a simple retention count in place for each log directory (host/function logs). We'll retain the last 3 most recent files.