### PR TITLE
Mathewc dev

### DIFF
--- a/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/NodeFunctionInvoker.cs
@@ -34,20 +34,18 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private Func<object, Task<object>> _scriptFunc;
         private Func<object, Task<object>> _clearRequireCache;
+        private static Func<object, Task<object>> _globalInitializationFunc;
         private static string _functionTemplate;
         private static string _clearRequireCacheScript;
+        private static string _globalInitializationScript;
 
         static NodeFunctionInvoker()
         {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("Microsoft.Azure.WebJobs.Script.functionTemplate.js")))
-            {
-                _functionTemplate = reader.ReadToEnd();
-            }
-            using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("Microsoft.Azure.WebJobs.Script.clearRequireCache.js")))
-            {
-                _clearRequireCacheScript = reader.ReadToEnd();
-            }
+            _functionTemplate = ReadResourceString("functionTemplate.js");
+            _clearRequireCacheScript = ReadResourceString("clearRequireCache.js");
+            _globalInitializationScript = ReadResourceString("globalInitialization.js");
+
+            Initialize();
         }
 
         internal NodeFunctionInvoker(ScriptHost host, BindingMetadata trigger, FunctionMetadata functionMetadata, Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings)
@@ -61,6 +59,24 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _metrics = host.ScriptConfig.HostConfig.GetService<IMetricsLogger>();
 
             InitializeFileWatcherIfEnabled();
+        }
+
+        /// <summary>
+        /// Event raised whenever an unhandled Node exception occurs at the
+        /// global level (e.g. an unhandled async exception).
+        /// </summary>
+        public static event UnhandledExceptionEventHandler UnhandledException;
+
+        private static Func<object, Task<object>> GlobalInitializationFunc
+        {
+            get
+            {
+                if (_globalInitializationFunc == null)
+                {
+                    _globalInitializationFunc = Edge.Func(_globalInitializationScript);
+                }
+                return _globalInitializationFunc;
+            }
         }
 
         private Func<object, Task<object>> ScriptFunc
@@ -411,6 +427,43 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             catch
             {
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Performs required static initialization in the Edge context.
+        /// </summary>
+        private static void Initialize()
+        {
+            var handle = (Func<object, Task<object>>)(err =>
+            {
+                if (UnhandledException != null)
+                {
+                    // raise the event to allow subscribers to handle
+                    var ex = new InvalidOperationException((string)err);
+                    UnhandledException(null, new UnhandledExceptionEventArgs(ex, true));
+
+                    // ensure that we kill the process - unhandled Node global
+                    // exceptions should never be swallowed
+                    throw ex;
+                }
+                return Task.FromResult<object>(null);
+            });
+            var context = new Dictionary<string, object>()
+            {
+                { "handleUncaughtException", handle }
+            };
+
+            GlobalInitializationFunc(context).Wait();
+        }
+
+        private static string ReadResourceString(string fileName)
+        {
+            string resourcePath = string.Format("Microsoft.Azure.WebJobs.Script.{0}", fileName);
+            Assembly assembly = Assembly.GetExecutingAssembly();
+            using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourcePath)))
+            {
+                return reader.ReadToEnd();
             }
         }
     }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -344,6 +344,7 @@
       <Link>edge\edge.js</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="globalInitialization.js" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/WebJobs.Script/globalInitialization.js
+++ b/src/WebJobs.Script/globalInitialization.js
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+var process = require('process');
+
+return function (context, callback) {{
+    process.on('uncaughtException', function (err) {{
+        context.handleUncaughtException(err.stack);
+    }});
+
+    callback();
+}};
+


### PR DESCRIPTION
Preview of proposed changes to address https://github.com/Azure/azure-webjobs-sdk-script/issues/209. Initially I considered using Node.js Domains and that would work (allowing us to get scoped errors for a particular function invocation including any async calls), but Domains are deprecated ([see here](https://nodejs.org/api/domain.html)).

So I'm registering a standard Node uncaught exception handler allowing us to intercept and log the error before the process goes down. This allows me to write the error to the function error stream.

@paulbatum @danderson00 Any other mechanisms I might use that I'm not aware of? I called this preview above because I haven't written tests yet, but I've tested it locally e2e and verified that it addresses Brett's scenario.