### PR TITLE
Log Node.js global unhandled exceptions properly (#209)

### DIFF
--- a/src/WebJobs.Script/Description/ScriptFunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvokerBase.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             string error = Utility.FlattenException(ex);
             TraceWriter.Error(error);
+
+            // when any errors occur, we want to flush immediately
+            TraceWriter.Flush();
         }
 
         protected void InitializeFileWatcherIfEnabled()

--- a/src/WebJobs.Script/FileTraceWriter.cs
+++ b/src/WebJobs.Script/FileTraceWriter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _flushTimer.Start();
         }
 
-        public void FlushToFile()
+        public override void Flush()
         {
             if (_logBuffer.Count == 0)
             {
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     }
 
                     // ensure any remaining logs are flushed
-                    FlushToFile();
+                    Flush();
                 }
 
                 _disposed = true;
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void OnFlushLogs(object sender, ElapsedEventArgs e)
         {
-            FlushToFile();
+            Flush();
         }
 
         internal void SetNewLogFile()

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -203,6 +203,8 @@ namespace Microsoft.Azure.WebJobs.Script
                 new CSharpFunctionDescriptionProvider(this, ScriptConfig)
             };
 
+            NodeFunctionInvoker.UnhandledException += OnUnhandledException;
+
             // read all script functions and apply to JobHostConfiguration
             Collection<FunctionDescriptor> functions = ReadFunctions(ScriptConfig, descriptionProviders);
             string defaultNamespace = "Host";
@@ -217,6 +219,11 @@ namespace Microsoft.Azure.WebJobs.Script
             ApplyBindingConfiguration(functions, ScriptConfig.HostConfig);
 
             Functions = functions;
+        }
+
+        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            HandleHostError((Exception)e.ExceptionObject);
         }
 
         // Bindings may require us to update JobHostConfiguration. 
@@ -656,28 +663,75 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             foreach (TraceEvent traceEvent in traceFilter.Events)
             {
-                if (traceEvent.Exception is FunctionInvocationException)
-                {
-                    // For all function invocation events, we notify the invoker so it can
-                    // log the error as needed to its function specific logs.
-                    FunctionInvocationException invocationException = traceEvent.Exception as FunctionInvocationException;
-                    NotifyInvoker(invocationException.MethodName, invocationException);
-                }
-                else if (traceEvent.Exception is FunctionIndexingException)
-                {
-                    // For all startup time indexing errors, we accumulate them per function
-                    FunctionIndexingException indexingException = traceEvent.Exception as FunctionIndexingException;
-                    string formattedError = Utility.FlattenException(indexingException);
-                    AddFunctionError(indexingException.MethodName, formattedError);
+                HandleHostError(traceEvent.Exception);
+            }
+        }
 
-                    // Also notify the invoker so the error can also be written to the function
-                    // log file
-                    NotifyInvoker(indexingException.MethodName, indexingException);
+        private void HandleHostError(Exception exception)
+        {
+            // First, ensure that we've logged to the host log
+            // Also ensure we flush immediately to ensure any buffered logs
+            // are written
+            TraceWriter.Error("An ScriptHost error has occurred", exception);
+            TraceWriter.Flush();
 
-                    // Mark the error as handled so indexing will continue
-                    indexingException.Handled = true;
+            if (exception is FunctionInvocationException)
+            {
+                // For all function invocation errors, we notify the invoker so it can
+                // log the error as needed to its function specific logs.
+                FunctionInvocationException invocationException = exception as FunctionInvocationException;
+                NotifyInvoker(invocationException.MethodName, invocationException);
+            }
+            else if (exception is FunctionIndexingException)
+            {
+                // For all startup time indexing errors, we accumulate them per function
+                FunctionIndexingException indexingException = exception as FunctionIndexingException;
+                string formattedError = Utility.FlattenException(indexingException);
+                AddFunctionError(indexingException.MethodName, formattedError);
+
+                // Also notify the invoker so the error can also be written to the function
+                // log file
+                NotifyInvoker(indexingException.MethodName, indexingException);
+
+                // Mark the error as handled so indexing will continue
+                indexingException.Handled = true;
+            }
+            else
+            {
+                // See if we can identify which function caused the error, and if we can
+                // log the error as needed to its function specific logs.
+                FunctionDescriptor function = null;
+                if (TryGetFunctionFromException(Functions, exception, out function))
+                {
+                    NotifyInvoker(function.Name, exception);
                 }
             }
+        }
+
+        internal static bool TryGetFunctionFromException(Collection<FunctionDescriptor> functions, Exception exception, out FunctionDescriptor function)
+        {
+            function = null;
+
+            string errorStack = exception.ToString().ToLowerInvariant();
+            foreach (var currFunction in functions)
+            {
+                // For each function, we search the entire error stack trace to see if it contains
+                // the function entry/primary script path. If it does, we're virtually certain that
+                // that function caused the error (e.g. as in the case of global unhandled exceptions
+                // coming from Node.js scripts).
+                // We use the directory name for the script rather than the full script path itself to ensure
+                // that we handle cases where the error might be coming from some other script (e.g. an NPM
+                // module) that is part of the function.
+                string absoluteScriptPath = Path.GetFullPath(currFunction.Metadata.Source).ToLowerInvariant();
+                string functionDirectory = Path.GetDirectoryName(absoluteScriptPath);
+                if (errorStack.Contains(functionDirectory))
+                {
+                    function = currFunction;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void NotifyInvoker(string functionName, Exception ex)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -353,6 +353,7 @@
       <Link>edge\edge.js</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="globalInitialization.js" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/WebJobs.Script/globalInitialization.js
+++ b/src/WebJobs.Script/globalInitialization.js
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+var process = require('process');
+
+return function (context, callback) {{
+    process.on('uncaughtException', function (err) {{
+        context.handleUncaughtException(err.stack);
+    }});
+
+    callback();
+}};
+

--- a/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
@@ -103,7 +103,7 @@ namespace WebJobs.Script.Tests
             Assert.Equal(0, files.Length);
 
             traceWriter.Verbose("Test log");
-            traceWriter.FlushToFile();
+            traceWriter.Flush();
 
             files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
             Assert.Equal(1, files.Length);
@@ -118,7 +118,7 @@ namespace WebJobs.Script.Tests
                 traceWriter.Verbose(string.Format("Test message {0} {1}", Thread.CurrentThread.ManagedThreadId, i));
             }
 
-            traceWriter.FlushToFile();
+            traceWriter.Flush();
         }
     }
 }


### PR DESCRIPTION
Preview of proposed changes to address https://github.com/Azure/azure-webjobs-sdk-script/issues/209. Initially I considered using Node.js Domains and that would work (allowing us to get scoped errors for a particular function invocation including any async calls), but Domains are deprecated ([see here](https://nodejs.org/api/domain.html)).

So I'm registering a standard Node uncaught exception handler allowing us to intercept and log the error before the process goes down. This allows me to write the error to the function error stream.

@paulbatum @danderson00 Any other mechanisms I might use that I'm not aware of? I called this preview above because I haven't written tests yet, but I've tested it locally e2e and verified that it addresses Brett's scenario.

I've verified the repro scenario via private site extension in prod - these errors are now logged, e.g:

2016-04-08T21:27:31  Welcome, you are now connected to log-streaming service.
2016-04-08T21:27:45.226 Function started (Id=d46ffb76-263a-405d-b278-4bbeed1ee474)
2016-04-08T21:27:45.226 Node.js HTTP trigger function processed a request. RequestUri=https://functions-test.azurewebsites.net/api/httptriggernode
2016-04-08T21:27:45.273 TypeError: Cannot read property 'is' of undefined
    at Timeout._onTimeout (D:\home\site\wwwroot\HttpTriggerNode\index.js:7:35)
    at tryOnTimeout (timers.js:224:11)
    at Timer.listOnTimeout (timers.js:198:5).

2016-04-08T21:27:47  The application was terminated.