### PR TITLE
Handle duplicate context.done calls gracefully (#207)

### DIFF
--- a/src/WebJobs.Script/Binding/ApiHubBinding.cs
+++ b/src/WebJobs.Script/Binding/ApiHubBinding.cs
@@ -73,16 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             var attribute = new ApiHubFileAttribute(Key, boundBlobPath, Access);
 
             RuntimeBindingContext runtimeContext = new RuntimeBindingContext(attribute);
-            Stream blobStream = await context.Binder.BindAsync<Stream>(runtimeContext);
-
-            if (Access == FileAccess.Write)
-            {
-                await context.Value.CopyToAsync(blobStream);
-            }
-            else
-            {
-                await blobStream.CopyToAsync(context.Value);
-            }
+            await BindStreamAsync(context.Value, Access, context.Binder, runtimeContext);
         }
     }
 }

--- a/src/WebJobs.Script/Binding/BlobBinding.cs
+++ b/src/WebJobs.Script/Binding/BlobBinding.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;
@@ -60,15 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             }
 
             RuntimeBindingContext runtimeContext = new RuntimeBindingContext(attribute, additionalAttributes);
-            Stream blobStream = await context.Binder.BindAsync<Stream>(runtimeContext);
-            if (Access == FileAccess.Write)
-            {
-                await context.Value.CopyToAsync(blobStream);
-            }
-            else
-            {
-                await blobStream.CopyToAsync(context.Value);
-            }
+            await BindStreamAsync(context.Value, Access, context.Binder, runtimeContext);
         }
 
         public override Collection<CustomAttributeBuilder> GetCustomAttributes()

--- a/src/WebJobs.Script/Binding/FunctionBinding.cs
+++ b/src/WebJobs.Script/Binding/FunctionBinding.cs
@@ -206,5 +206,18 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                 await collector.AddAsync((T)converted);
             }
         }
+
+        internal static async Task BindStreamAsync(Stream stream, FileAccess access, IBinderEx binder, RuntimeBindingContext runtimeContext)
+        {
+            Stream boundStream = await binder.BindAsync<Stream>(runtimeContext);
+            if (access == FileAccess.Write)
+            {
+                await stream.CopyToAsync(boundStream);
+            }
+            else
+            {
+                await boundStream.CopyToAsync(stream);
+            }
+        }
     }
 }

--- a/src/WebJobs.Script/FileTraceWriter.cs
+++ b/src/WebJobs.Script/FileTraceWriter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script
     {
         internal const int LastModifiedCutoffDays = 1;
         private const long MaxLogFileSizeBytes = 5 * 1024 * 1024;
-        private const int LogFlushIntervalMs = 1000;
+        internal const int LogFlushIntervalMs = 1000;
         private readonly string _logFilePath;
         private readonly string _instanceId;
         private readonly DirectoryInfo _logDirectory;

--- a/src/WebJobs.Script/functionTemplate.js
+++ b/src/WebJobs.Script/functionTemplate.js
@@ -12,6 +12,12 @@ return function (context, callback) {{
     }};
 
     context.done = function(err, result) {{
+        if (context._done) {{
+            context.log("Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.");
+            return;
+        }}
+        context._done = true;
+
         if (err) {{
             callback(err);
         }}

--- a/test/WebJobs.Script.Tests/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests/EndToEndTestFixture.cs
@@ -33,7 +33,8 @@ namespace WebJobs.Script.Tests
             ScriptHostConfiguration config = new ScriptHostConfiguration()
             {
                 RootScriptPath = rootPath,
-                TraceWriter = TraceWriter
+                TraceWriter = TraceWriter,
+                FileLoggingEnabled = true
             };
 
             HostManager = new ScriptHostManager(config);

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -109,6 +109,30 @@ namespace WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task Scenario_DoneCalledMultipleTimes_ErrorIsLogged()
+        {
+            ClearFunctionLogs("Scenarios");
+
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "input", "doubleDone" }
+            };
+            await Fixture.Host.CallAsync("Scenarios", arguments);
+
+            var logs = await GetFunctionLogsAsync("Scenarios");
+
+            Assert.Equal(4, logs.Count);
+            Assert.True(logs.Any(p => p.Contains("Function started")));
+            Assert.True(logs.Any(p => p.Contains("Running scenario 'doubleDone'")));
+
+            // verify an error was written
+            Assert.True(logs.Any(p => p.Contains("Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.")));
+
+            // verify the function completed successfully
+            Assert.True(logs.Any(p => p.Contains("Function completed (Success")));
+        }
+
+        [Fact]
         public async Task HttpTrigger_Get()
         {
             HttpRequestMessage request = new HttpRequestMessage

--- a/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
@@ -170,10 +170,10 @@ namespace WebJobs.Script.Tests
 
         private static MethodInfo GenerateMethod(BindingMetadata trigger)
         {
-            string rootPath = Path.Combine(Environment.CurrentDirectory, @"TestScripts");
+            string rootPath = Path.Combine(Environment.CurrentDirectory, @"TestScripts\Node");
             FunctionMetadata metadata = new FunctionMetadata();
             metadata.Name = "Test";
-            metadata.Source = Path.Combine(rootPath, @"Node\Common\test.js");
+            metadata.Source = Path.Combine(rootPath, @"Common\test.js");
             metadata.Bindings.Add(trigger);
 
             List<FunctionMetadata> metadatas = new List<FunctionMetadata>();

--- a/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/function.json
@@ -1,0 +1,8 @@
+﻿{
+  "bindings": [
+    {
+      "type": "manualTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
@@ -1,0 +1,11 @@
+﻿module.exports = function (context, scenario) {
+    context.log("Running scenario '%s'", scenario);
+
+    if (scenario == 'doubleDone') {
+        context.done();
+        context.done();
+    }
+    else {
+        context.done();
+    }
+}

--- a/test/WebJobs.Script.Tests/TestScripts/host.json
+++ b/test/WebJobs.Script.Tests/TestScripts/host.json
@@ -1,3 +1,0 @@
-{
-  "id": "5a709861cab44e68bfed5d2c2fe7fc0c"
-}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -367,9 +367,6 @@
     <None Include="TestScripts\FunctionGeneration\HttpTrigger-CSharp\run.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="TestScripts\host.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="TestScripts\Node\DocumentDBIn\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -403,9 +400,15 @@
     <None Include="TestScripts\Node\QueueTriggerToBlob\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="TestScripts\Node\Scenarios\index.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestScripts\Node\ServiceBusQueueTriggerToBlob\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="TestScripts\Node\Scenarios\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Node\WebHookTrigger\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -540,6 +543,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/207. I verified the behavior Brett initially reported - before this fix, calling context.done twice resulted in a very low level V8 exception in Edge that we can't catch/log - it brings down the process.

With these changes, we log any extraneous calls to done and ignore them - only the first call to done is processed.