### PR TITLE
Assembly Name + Namespace updates

### DIFF
--- a/src/WebJobs.Script.Host/GlobalSuppressions.cs
+++ b/src/WebJobs.Script.Host/GlobalSuppressions.cs
@@ -9,3 +9,4 @@
 // You do not need to add suppressions to this file manually.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "WebJobs.Script.Host.Program.#Main(System.String[])")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.Host.Program.#Main(System.String[])")]

--- a/src/WebJobs.Script.Host/Program.cs
+++ b/src/WebJobs.Script.Host/Program.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Azure.WebJobs.Script;
 
-namespace WebJobs.Script.Host
+namespace Microsoft.Azure.WebJobs.Script.Host
 {
     public static class Program
     {

--- a/src/WebJobs.Script.Host/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script.Host/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("WebJobs.Script.Host")]
+[assembly: AssemblyTitle("Microsoft.Azure.WebJobs.Script.Host")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyTrademark("")]

--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{F5FAB5A1-A816-441B-86BF-CA3CAE2F7588}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>WebJobs.Script.Host</RootNamespace>
-    <AssemblyName>WebJobs.Script.Host</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Script.Host</RootNamespace>
+    <AssemblyName>Microsoft.Azure.WebJobs.Script.Host</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/WebJobs.Script.WebHost/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script.WebHost/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("WebJobs.Script.WebHost")]
+[assembly: AssemblyTitle("Microsoft.Azure.WebJobs.Script.WebHost")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyTrademark("")]
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
-[assembly: InternalsVisibleTo("WebJobs.Script.Tests")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests")]

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>WebJobs.Script.WebHost</RootNamespace>
-    <AssemblyName>WebJobs.Script.WebHost</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Script.WebHost</RootNamespace>
+    <AssemblyName>Microsoft.Azure.WebJobs.Script.WebHost</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />

--- a/src/WebJobs.Script/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
-[assembly: InternalsVisibleTo("WebJobs.Script.Tests")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests")]

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -234,6 +234,7 @@
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>

--- a/src/WebJobs.Script/app.config
+++ b/src/WebJobs.Script/app.config
@@ -1,46 +1,61 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
-  	<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-  			<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-4.0.20511.1437" newVersion="4.0.20511.1437" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
-  		</dependentAssembly>
-  		<dependentAssembly>
-  			<assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-  			<bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
-  		</dependentAssembly>
-  	</assemblyBinding>
-	</runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup>
-<appSettings>
-</appSettings>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20511.1437" newVersion="4.0.20511.1437" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+  <appSettings>
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/test/WebJobs.Script.Tests/AdminControllerTests.cs
+++ b/test/WebJobs.Script.Tests/AdminControllerTests.cs
@@ -8,7 +8,7 @@ using WebJobs.Script.WebHost.Controllers;
 using WebJobs.Script.WebHost.Filters;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class AdminControllerTests
     {

--- a/test/WebJobs.Script.Tests/AuthorizationLevelAttributeTests.cs
+++ b/test/WebJobs.Script.Tests/AuthorizationLevelAttributeTests.cs
@@ -13,7 +13,7 @@ using WebJobs.Script.WebHost;
 using WebJobs.Script.WebHost.Filters;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class AuthorizationLevelAttributeTests
     {

--- a/test/WebJobs.Script.Tests/BashEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/BashEndToEndTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class BashEndToEndTests : EndToEndTestsBase<BashEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class CSharpEndToEndTests : EndToEndTestsBase<CSharpEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/CSharpFunctionSignatureTests.cs
+++ b/test/WebJobs.Script.Tests/CSharpFunctionSignatureTests.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class CSharpFunctionSignatureTests
     {

--- a/test/WebJobs.Script.Tests/CompositeTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/CompositeTraceWriterTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class CompositeTraceWriterTests
     {

--- a/test/WebJobs.Script.Tests/Description/CSharp/PackageAssemblyResolverTests.cs
+++ b/test/WebJobs.Script.Tests/Description/CSharp/PackageAssemblyResolverTests.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
-using WebJobs.Script.Tests.Properties;
+using Microsoft.Azure.WebJobs.Script.Tests.Properties;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class PackageAssemblyResolverTests : IDisposable
     {

--- a/test/WebJobs.Script.Tests/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests/EndToEndTestFixture.cs
@@ -13,7 +13,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.Queue;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public abstract class EndToEndTestFixture : IDisposable
     {

--- a/test/WebJobs.Script.Tests/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests/EndToEndTestsBase.cs
@@ -26,7 +26,7 @@ using Microsoft.WindowsAzure.Storage.Queue;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     [Trait("Category", "E2E")]
     public abstract class EndToEndTestsBase<TTestFixture> :

--- a/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class FSharpEndToEndTests : EndToEndTestsBase<FSharpEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class FileTraceWriterTests
     {

--- a/test/WebJobs.Script.Tests/FunctionBindingTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionBindingTests.cs
@@ -13,7 +13,7 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class FunctionBindingTests
     {

--- a/test/WebJobs.Script.Tests/FunctionGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionGeneratorTests.cs
@@ -20,7 +20,7 @@ using Microsoft.WindowsAzure.Storage;
 using WebJobs.Script.WebHost;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     [Trait("Category", "E2E")]
     public class FunctionGeneratorTests

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class NodeEndToEndTests : EndToEndTestsBase<NodeEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
@@ -16,7 +16,7 @@ using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class NodeFunctionGenerationTests
     {

--- a/test/WebJobs.Script.Tests/PhpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/PhpEndToEndTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class PhpEndToEndTests : EndToEndTestsBase<PhpEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/PowershellEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/PowershellEndToEndTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class PowershellEndToEndTests : EndToEndTestsBase<PowershellEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/Properties/Resources.Designer.cs
+++ b/test/WebJobs.Script.Tests/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WebJobs.Script.Tests.Properties {
+namespace Microsoft.Azure.WebJobs.Script.Tests.Properties {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace WebJobs.Script.Tests.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("WebJobs.Script.Tests.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Azure.WebJobs.Script.Tests.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/test/WebJobs.Script.Tests/PythonEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/PythonEndToEndTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class PythonEndToEndTests : EndToEndTestsBase<PythonEndToEndTests.TestFixture>
     {

--- a/test/WebJobs.Script.Tests/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/SamplesEndToEndTests.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json.Linq;
 using WebJobs.Script.WebHost;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     [Trait("Category", "E2E")]
     public class SamplesEndToEndTests : IClassFixture<SamplesEndToEndTests.TestFixture>

--- a/test/WebJobs.Script.Tests/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostManagerTests.cs
@@ -11,7 +11,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     [Trait("Category", "E2E")]
     public class ScriptHostManagerTests 

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Azure.WebJobs.Script.Description;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class ScriptHostTests
     {

--- a/test/WebJobs.Script.Tests/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests/TestHelpers.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage.Blob;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public static class TestHelpers
     {

--- a/test/WebJobs.Script.Tests/TestInvoker.cs
+++ b/test/WebJobs.Script.Tests/TestInvoker.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class TestInvoker : IFunctionInvoker
     {

--- a/test/WebJobs.Script.Tests/TestTraceWriter.cs
+++ b/test/WebJobs.Script.Tests/TestTraceWriter.cs
@@ -5,7 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Host;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class TestTraceWriter : TraceWriter
     {

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -5,7 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Script;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class UtilityTests
     {

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -9,8 +9,8 @@
     <ProjectGuid>{38C609D3-B126-43B0-B9D8-6D62FAEE2ABC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>WebJobs.Script.Tests</RootNamespace>
-    <AssemblyName>WebJobs.Script.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests</RootNamespace>
+    <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/test/WebJobs.Script.Tests/WindowsBatchEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/WindowsBatchEndToEndTests.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace WebJobs.Script.Tests
+namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class WindowsBatchEndToEndTests : EndToEndTestsBase<WindowsBatchEndToEndTests.TestFixture>
     {


### PR DESCRIPTION
Primary change here is to add the Microsoft.Azure.WebJobs prefix to the WebHost assembly name as well to make it consistent with Microsoft.Azure.WebJobs.Script.

Also going through and making namespaces consistent.