### PR TITLE
Fixing issue with indirect private assembly resolution

### DIFF
--- a/src/WebJobs.Script/Description/CSharp/CSharpFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/CSharp/CSharpFunctionInvoker.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly ReaderWriterLockSlim _functionValueLoaderLock = new ReaderWriterLockSlim();
 
         private CSharpFunctionSignature _functionSignature;
-        private FunctionMetadataResolver _metadataResolver;
+        private IFunctionMetadataResolver _metadataResolver;
         private Action _reloadScript;
         private Action _restorePackages;
         private Action<MethodInfo, object[], object[], object> _resultProcessor;
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                         }
 
                         Assembly assembly = Assembly.Load(assemblyStream.GetBuffer(), pdbStream.GetBuffer());
-                        _assemblyLoader.CreateOrUpdateContext(Metadata, assembly, _metadataResolver);
+                        _assemblyLoader.CreateOrUpdateContext(Metadata, assembly, _metadataResolver, TraceWriter);
 
                         // Get our function entry point
                         System.Reflection.TypeInfo scriptType = assembly.DefinedTypes.FirstOrDefault(t => string.Compare(t.Name, ScriptClassName, StringComparison.Ordinal) == 0);

--- a/src/WebJobs.Script/Description/CSharp/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/CSharp/FunctionAssemblyLoadContext.cs
@@ -5,25 +5,28 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
     /// <summary>
     /// Establishes an assembly load context for a given function.
-    /// Assemblies loaded from this context are loaded using the <see cref="FunctionMetadataResolver"/> associated
+    /// Assemblies loaded from this context are loaded using the <see cref="IFunctionMetadataResolver"/> associated
     /// with a given function.
     /// </summary>
     [CLSCompliant(false)]
     public sealed class FunctionAssemblyLoadContext
     {
-        private readonly FunctionMetadataResolver _metadataResolver;
+        private readonly IFunctionMetadataResolver _metadataResolver;
+        private readonly TraceWriter _traceWriter;
         private ImmutableArray<Assembly> _loadedAssemblies;
         private Uri _functionBaseUri;
 
-        public FunctionAssemblyLoadContext(FunctionMetadata functionMetadata, Assembly functionAssembly, FunctionMetadataResolver resolver)
+        public FunctionAssemblyLoadContext(FunctionMetadata functionMetadata, Assembly functionAssembly, IFunctionMetadataResolver resolver, TraceWriter traceWriter)
         {
             _metadataResolver = resolver;
             _loadedAssemblies = ImmutableArray<Assembly>.Empty;
+            _traceWriter = traceWriter;
             FunctionAssembly = functionAssembly;
             Metadata = functionMetadata;
         }
@@ -36,13 +39,21 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
+        public TraceWriter TraceWriter
+        {
+            get
+            {
+                return _traceWriter;
+            }
+        }
+
         public Uri FunctionBaseUri
         {
             get
             {
                 if (_functionBaseUri == null)
                 {
-                    _functionBaseUri = new Uri(Path.GetDirectoryName(Metadata.Source), UriKind.RelativeOrAbsolute);
+                    _functionBaseUri = new Uri(Path.GetDirectoryName(Metadata.Source) + "\\", UriKind.RelativeOrAbsolute);
                 }
 
                 return _functionBaseUri;

--- a/src/WebJobs.Script/Description/CSharp/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/CSharp/FunctionMetadataResolver.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     /// or package assemblies.
     /// </summary>
     [CLSCompliant(false)]
-    public sealed class FunctionMetadataResolver : MetadataReferenceResolver
+    public sealed class FunctionMetadataResolver : MetadataReferenceResolver, IFunctionMetadataResolver
     {
         private readonly string _privateAssembliesPath;
         private readonly string[] _assemblyExtensions = new[] { ".exe", ".dll" };

--- a/src/WebJobs.Script/Description/CSharp/IFunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/CSharp/IFunctionMetadataResolver.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace Microsoft.Azure.WebJobs.Script.Description
+{
+    [CLSCompliant(false)]
+    public interface IFunctionMetadataResolver
+    {
+        ScriptOptions FunctionScriptOptions { get; }
+
+        IReadOnlyCollection<string> GetCompilationReferences();
+
+        Assembly ResolveAssembly(string assemblyName);
+
+        ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties);
+
+        Task RestorePackagesAsync();
+
+        bool TryGetPackageReference(string referenceName, out PackageReference package);
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Binding\QueueBinding.cs" />
     <Compile Include="Binding\ServiceBusBinding.cs" />
     <Compile Include="Binding\TableBinding.cs" />
+    <Compile Include="Description\CSharp\IFunctionMetadataResolver.cs" />
     <Compile Include="Diagnostics\CompositeTraceWriter.cs" />
     <Compile Include="Config\JobHostConfigurationBuilder.cs" />
     <Compile Include="Config\AllowNameResolutionAttribute.cs" />

--- a/test/WebJobs.Script.Tests/Description/CSharp/FunctionAssemblyLoaderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/CSharp/FunctionAssemblyLoaderTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.CodeAnalysis;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Description.CSharp
+{
+    public class FunctionAssemblyLoaderTests
+    {
+        [Fact]
+        public void ResolveAssembly_WithIndirectPrivateDependency_IsResolved()
+        {
+            var resolver = new FunctionAssemblyLoader("c:\\");
+
+            var metadata1 = new FunctionMetadata { Name = "Test1", Source = @"c:\testroot\test1\test.tst" };
+            var metadata2 = new FunctionMetadata { Name = "Test2", Source = @"c:\testroot\test2\test.tst" };
+            var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+
+            var mockResolver = new Mock<IFunctionMetadataResolver>();
+            mockResolver.Setup(m => m.ResolveAssembly("MyTestAssembly.dll"))
+              .Returns(new TestAssembly(new AssemblyName("MyTestAssembly")));
+                
+            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, new FunctionMetadataResolver(metadata1, traceWriter), traceWriter);
+            resolver.CreateOrUpdateContext(metadata2, this.GetType().Assembly, mockResolver.Object, traceWriter);
+
+            Assembly result = resolver.ResolveAssembly(null, new System.ResolveEventArgs("MyTestAssembly.dll",
+                new TestAssembly(new AssemblyName("MyDirectReference"), @"file:///c:/testroot/test2/bin/MyDirectReference.dll")));
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void ResolveAssembly_WithIndirectPrivateDependency_LogsIfResolutionFails()
+        {
+            var resolver = new FunctionAssemblyLoader("c:\\");
+
+            var metadata1 = new FunctionMetadata { Name = "Test1", Source = @"c:\testroot\test1\test.tst" };
+            var metadata2 = new FunctionMetadata { Name = "Test2", Source = @"c:\testroot\test2\test.tst" };
+            var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+
+            var mockResolver = new Mock<IFunctionMetadataResolver>();
+            mockResolver.Setup(m => m.ResolveAssembly("MyTestAssembly.dll"))
+              .Returns<Assembly>(null);
+
+            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, new FunctionMetadataResolver(metadata1, traceWriter), traceWriter);
+            resolver.CreateOrUpdateContext(metadata2, this.GetType().Assembly, mockResolver.Object, traceWriter);
+
+            Assembly result = resolver.ResolveAssembly(null, new System.ResolveEventArgs("MyTestAssembly.dll",
+                new TestAssembly(new AssemblyName("MyDirectReference"), @"file:///c:/testroot/test2/bin/MyDirectReference.dll")));
+
+            Assert.Null(result);
+            Assert.Equal(1, traceWriter.Traces.Count);
+            Assert.Contains("MyTestAssembly.dll", traceWriter.Traces[0].Message);
+        }
+
+        private class TestAssembly : Assembly
+        {
+            private readonly AssemblyName _name;
+            private readonly string _codebase;
+
+            public TestAssembly(AssemblyName name, string codebase = null)
+            {
+                _name = name;
+                _codebase = codebase;
+            }
+
+            public override string CodeBase
+            {
+                get
+                {
+                    return _codebase;
+                }
+            }
+
+            public override string FullName
+            {
+                get
+                {
+                    return _name.FullName;
+                }
+            }
+
+            public override AssemblyName GetName()
+            {
+                return _name;
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -108,6 +108,14 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.1.1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.1.1\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.1.1\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
@@ -165,12 +173,28 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.AppContext.4.0.0\lib\net46\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.StackTrace.4.0.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.4.0.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -224,6 +248,7 @@
     <Compile Include="CompositeTraceWriterTests.cs" />
     <Compile Include="CSharpEndToEndTests.cs" />
     <Compile Include="CSharpFunctionSignatureTests.cs" />
+    <Compile Include="Description\CSharp\FunctionAssemblyLoaderTests.cs" />
     <Compile Include="EndToEndTestFixture.cs" />
     <Compile Include="EndToEndTestsBase.cs" />
     <Compile Include="FileTraceWriterTests.cs" />
@@ -253,7 +278,9 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="TestScripts\Bash\host.json">

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -24,6 +24,8 @@
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.1.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.1.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
@@ -36,24 +38,32 @@
   <package id="Sendgrid" version="6.3.4" targetFramework="net46" />
   <package id="SendGrid.SmtpApi" version="1.3.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net46" developmentDependency="true" />
-  <package id="System.Collections" version="4.0.0" targetFramework="net46" />
+  <package id="System.AppContext" version="4.0.0" targetFramework="net46" />
+  <package id="System.Collections" version="4.0.10" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
-  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.0" targetFramework="net46" />
-  <package id="System.IO" version="4.0.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.0.10" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.0.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.0.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.0.10" targetFramework="net46" />
+  <package id="System.IO" version="4.0.10" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.0.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection" version="4.0.0" targetFramework="net46" />
+  <package id="System.Linq.Expressions" version="4.0.10" targetFramework="net46" />
+  <package id="System.Reflection" version="4.0.10" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net46" />
   <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net46" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net46" />
-  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.0.20" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.0.10" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.0.20" targetFramework="net46" />
   <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
   <package id="System.Text.Encoding" version="4.0.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.0.0" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.0.10" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.0.10" targetFramework="net46" />
   <package id="WindowsAzure.ServiceBus" version="2.7.6" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
This fixes a small, but impactful issue with indirect private dependencies, where the incorrect context was being resolved because of an issue with the function URI format.
This is the bug causing the issue reported on SO here: http://stackoverflow.com/questions/36504717/why-cant-my-azure-function-find-microsoft-xrm-sdk-assembly-dependencies