### PR TITLE
Adding InvocationId to FunctionStartedEvent 

### DIFF
--- a/src/WebJobs.Script/Description/CSharp/CSharpFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/CSharp/CSharpFunctionInvoker.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 ExecutionContext functionExecutionContext = (ExecutionContext)systemParameters[0];
                 invocationId = functionExecutionContext.InvocationId.ToString();
 
-                startedEvent = new FunctionStartedEvent(Metadata);
+                startedEvent = new FunctionStartedEvent(functionExecutionContext.InvocationId, Metadata);
                 _metrics.BeginEvent(startedEvent);
 
                 TraceWriter.Verbose(string.Format("Function started (Id={0})", invocationId));

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             ExecutionContext functionExecutionContext = (ExecutionContext)parameters[3];
             string invocationId = functionExecutionContext.InvocationId.ToString();
 
-            FunctionStartedEvent startedEvent = new FunctionStartedEvent(Metadata);
+            FunctionStartedEvent startedEvent = new FunctionStartedEvent(functionExecutionContext.InvocationId, Metadata);
             _metrics.BeginEvent(startedEvent);
 
             try

--- a/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             ExecutionContext functionExecutionContext = (ExecutionContext)invocationParameters[3];
             string invocationId = functionExecutionContext.InvocationId.ToString();
 
-            FunctionStartedEvent startedEvent = new FunctionStartedEvent(Metadata);
+            FunctionStartedEvent startedEvent = new FunctionStartedEvent(functionExecutionContext.InvocationId, Metadata);
             _metrics.BeginEvent(startedEvent);
 
             // perform any required input conversions

--- a/src/WebJobs.Script/Diagnostics/FunctionStartedEvent.cs
+++ b/src/WebJobs.Script/Diagnostics/FunctionStartedEvent.cs
@@ -1,19 +1,23 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script.Diagnostics
 {
     public class FunctionStartedEvent : MetricEvent
     {
-        public FunctionStartedEvent(FunctionMetadata functionMetadata)
+        public FunctionStartedEvent(Guid invocationId, FunctionMetadata functionMetadata)
         {
+            InvocationId = invocationId;
             FunctionMetadata = functionMetadata;
             Success = true;
         }
 
         public FunctionMetadata FunctionMetadata { get; private set; }
+
+        public Guid InvocationId { get; private set; }
 
         public bool Success { get; set; }
     }


### PR DESCRIPTION
To allow for start/end correlation in ETW events. @akurmi needs this.