### PR TITLE
Setting PartitionKey and RowKey arguments to null if not set when creating TableAttribute

### DIFF
--- a/src/WebJobs.Script/Binding/TableBinding.cs
+++ b/src/WebJobs.Script/Binding/TableBinding.cs
@@ -80,8 +80,11 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             }
             else
             {
+                string partitionKey = string.IsNullOrEmpty(PartitionKey) ? null : PartitionKey;
+                string rowKey = string.IsNullOrEmpty(RowKey) ? null : RowKey;
+
                 constructorTypes = new Type[] { typeof(string), typeof(string), typeof(string) };
-                constructorArguments = new object[] { TableName, PartitionKey, RowKey };
+                constructorArguments = new object[] { TableName, partitionKey, rowKey };
             }
 
             attributes.Add(new CustomAttributeBuilder(typeof(TableAttribute).GetConstructor(constructorTypes), constructorArguments));


### PR DESCRIPTION
This addresses issue #261 for C#.

The WebJobs SDK expects the partition key and row key arguments to be null if not set/used. Passing an empty string (which is what the current portal logic does when the metadata property is present) causes the binding failure that leads to this issue.