### PR TITLE
Correct casing of file names

### DIFF
--- a/src/WebJobs.Script/Description/CSharp/CSharpConstants.cs
+++ b/src/WebJobs.Script/Description/CSharp/CSharpConstants.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         public const string PrivateAssembliesFolderName = "bin";
 
-        public const string ProjectFileName = "Project.json";
+        public const string ProjectFileName = "project.json";
 
-        public const string ProjectLockFileName = "Project.lock.json";
+        public const string ProjectLockFileName = "project.lock.json";
 
         public const string MissingFunctionEntryPointCompilationCode = "AF001";
 


### PR DESCRIPTION
Since we are referring to filenames we should care about the casing (it's important on some operating systems)