### PR TITLE
[Tests] Add a cleanup hook before the ScriptHostManager is started.

### DIFF
--- a/CustomDictionary.xml
+++ b/CustomDictionary.xml
@@ -75,6 +75,9 @@
       <Word>Debounce</Word>
       <Word>ScriptHost</Word>
       <Word>EventHub</Word>
+      <Word>DropBox</Word>
+      <Word>ApiHub</Word>
+      <Word>Api</Word>
 	</Recognized>
     <Deprecated/>
     <Compound>

--- a/test/WebJobs.Script.Tests/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests/TestHelpers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 if ((DateTime.Now - start).TotalMilliseconds > timeout)
                 {
-                    throw new ApplicationException("Condition not reached within timeout.");
+                    throw new ApplicationException(string.Format("Condition not reached within timeout:{0}.", timeout));
                 }
             }
         }
@@ -30,12 +30,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return s.Trim().Replace(" ", string.Empty).Replace(byteOrderMark, string.Empty);
         }
 
-        public static async Task<string> WaitForBlobAsync(CloudBlockBlob blob)
+        public static async Task<string> WaitForBlobAsync(CloudBlockBlob blob, int timeout = 60 * 1000)
         {
             await TestHelpers.Await(() =>
             {
                 return blob.Exists();
-            });
+            }, timeout);
 
             string result = await blob.DownloadTextAsync(Encoding.UTF8,
                 null, new BlobRequestOptions(), new Microsoft.WindowsAzure.Storage.OperationContext());

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileSender/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileSender/function.json
@@ -7,7 +7,7 @@
     {
       "type": "apiHubFile",
       "name" : "item",
-      "connection": "AzureWebJobsDropBox",
+      "connection": "AzureWebJobsBox",
       "direction": "out",
       "path": "teste2e/test.txt"
     }

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileTrigger/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileTrigger/function.json
@@ -2,7 +2,7 @@
   "bindings": [
     {
       "type": "apiHubFileTrigger",
-      "connection": "AzureWebJobsDropBox",
+      "connection": "AzureWebJobsBox",
       "direction": "in",
       "path": "teste2e/test.txt"
     },


### PR DESCRIPTION
Once ScriptHostManager the SAAS triggers start listening and will not trigger if file is deleted/readded

There is a bug in DropBox connector which doesn't delete the file. Switching to Box provider for now