### PR TITLE
Handling ReadWrite bindings in BlobBinding

### DIFF
--- a/src/WebJobs.Script/Binding/ApiHubBinding.cs
+++ b/src/WebJobs.Script/Binding/ApiHubBinding.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public string Path { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             Collection<CustomAttributeBuilder> attributes = new Collection<CustomAttributeBuilder>();
 

--- a/src/WebJobs.Script/Binding/DocumentDBBinding.cs
+++ b/src/WebJobs.Script/Binding/DocumentDBBinding.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public int CollectionThroughput { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             Type attributeType = typeof(DocumentDBAttribute);
 

--- a/src/WebJobs.Script/Binding/EventHubBinding.cs
+++ b/src/WebJobs.Script/Binding/EventHubBinding.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public string EventHubName { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             var constructorTypes = new Type[] { typeof(string) };
             var constructorArguments = new object[] { EventHubName };

--- a/src/WebJobs.Script/Binding/FunctionBinding.cs
+++ b/src/WebJobs.Script/Binding/FunctionBinding.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public abstract Task BindAsync(BindingContext context);
 
-        public abstract Collection<CustomAttributeBuilder> GetCustomAttributes();
+        public abstract Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType);
 
         internal static Collection<FunctionBinding> GetBindings(ScriptHostConfiguration config, IEnumerable<BindingMetadata> bindingMetadatas, FileAccess fileAccess)
         {

--- a/src/WebJobs.Script/Binding/HttpBinding.cs
+++ b/src/WebJobs.Script/Binding/HttpBinding.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         {
         }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             return null;
         }

--- a/src/WebJobs.Script/Binding/MobileTableBinding.cs
+++ b/src/WebJobs.Script/Binding/MobileTableBinding.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Reflection;
@@ -36,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public string ApiKey { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             PropertyInfo[] props = new[]
             {

--- a/src/WebJobs.Script/Binding/NotificationHubBinding.cs
+++ b/src/WebJobs.Script/Binding/NotificationHubBinding.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public string HubName { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             Type attributeType = typeof(NotificationHubAttribute);
             PropertyInfo[] props = new[]

--- a/src/WebJobs.Script/Binding/QueueBinding.cs
+++ b/src/WebJobs.Script/Binding/QueueBinding.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public string QueueName { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             Collection<CustomAttributeBuilder> attributes = new Collection<CustomAttributeBuilder>();
 

--- a/src/WebJobs.Script/Binding/ServiceBusBinding.cs
+++ b/src/WebJobs.Script/Binding/ServiceBusBinding.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public string QueueOrTopicName { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             var constructorTypes = new Type[] { typeof(string) };
             var constructorArguments = new object[] { QueueOrTopicName };

--- a/src/WebJobs.Script/Binding/TableBinding.cs
+++ b/src/WebJobs.Script/Binding/TableBinding.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         public int Take { get; private set; }
         public string Filter { get; private set; }
 
-        public override Collection<CustomAttributeBuilder> GetCustomAttributes()
+        public override Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType)
         {
             Collection<CustomAttributeBuilder> attributes = new Collection<CustomAttributeBuilder>();
 

--- a/src/WebJobs.Script/Description/CSharp/CSharpFunctionDescriptionProvider.cs
+++ b/src/WebJobs.Script/Description/CSharp/CSharpFunctionDescriptionProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                         var binding = bindings.FirstOrDefault(b => string.Compare(b.Metadata.Name, parameter.Name, StringComparison.Ordinal) == 0);
                         if (binding != null)
                         {
-                            Collection<CustomAttributeBuilder> customAttributes = binding.GetCustomAttributes();
+                            Collection<CustomAttributeBuilder> customAttributes = binding.GetCustomAttributes(parameter.ParameterType);
                             if (customAttributes != null)
                             {
                                 foreach (var customAttribute in customAttributes)

--- a/test/WebJobs.Script.Tests/Binding/BlobBindingTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/BlobBindingTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Binding
+{
+    public class BlobBindingTests
+    {
+        [Theory]
+        [InlineData(typeof(ICloudBlob), FileAccess.Read, FileAccess.ReadWrite)]
+        [InlineData(typeof(CloudBlockBlob), FileAccess.Read, FileAccess.ReadWrite)]
+        [InlineData(typeof(CloudPageBlob), FileAccess.Read, FileAccess.ReadWrite)]
+        [InlineData(typeof(CloudBlobDirectory), FileAccess.Read, FileAccess.ReadWrite)]
+        [InlineData(typeof(ICloudBlob), FileAccess.Write, FileAccess.ReadWrite)]
+        [InlineData(typeof(CloudBlockBlob), FileAccess.Write, FileAccess.ReadWrite)]
+        [InlineData(typeof(CloudPageBlob), FileAccess.Write, FileAccess.ReadWrite)]
+        [InlineData(typeof(CloudBlobDirectory), FileAccess.Write, FileAccess.ReadWrite)]
+        [InlineData(typeof(Stream), FileAccess.Write, FileAccess.Write)]
+        [InlineData(typeof(Stream), FileAccess.Read, FileAccess.Read)]
+        [InlineData(typeof(Stream), FileAccess.Write, FileAccess.Write)]
+        [InlineData(typeof(TextReader), FileAccess.Read, FileAccess.Read)]
+        [InlineData(typeof(TextWriter), FileAccess.Write, FileAccess.Write)]
+        [InlineData(typeof(string), FileAccess.Read, FileAccess.Read)]
+        public void GetCustomAttributes_WithReadWriteTypes_AppliesReadWriteAccess(Type parameterType, FileAccess metadataAccess, FileAccess expectedAccess)
+        {
+            var metadata = new BlobBindingMetadata()
+            {
+                Path = "my/blob"
+            };
+            var binding = new BlobBinding(new ScriptHostConfiguration(), metadata, metadataAccess);
+
+            Collection<CustomAttributeBuilder> attributeBuilders = binding.GetCustomAttributes(parameterType);
+
+            // Get blob attribute
+            var builder = attributeBuilders.FirstOrDefault(b =>
+            string.CompareOrdinal(GetCustomAttributeBuilderFieldValue<ConstructorInfo>("m_con", b).DeclaringType.FullName,
+            "Microsoft.Azure.WebJobs.BlobAttribute") == 0);
+
+            Assert.NotNull(builder);
+
+            var attributeParameters = GetCustomAttributeBuilderFieldValue<object[]>("m_constructorArgs", builder);
+
+            Assert.Equal(2, attributeParameters.Length);
+            Assert.IsType(typeof(FileAccess), attributeParameters[1]);
+
+            FileAccess access = (FileAccess)attributeParameters[1];
+
+            Assert.Equal(expectedAccess, access);
+        }
+
+        private T GetCustomAttributeBuilderFieldValue<T>(string fieldName, object instance)
+        {
+            object result = typeof(CustomAttributeBuilder)
+                .GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .GetValue(instance);
+
+            return result != null ? (T)result : default(T);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -249,6 +249,7 @@
     <Compile Include="AdminControllerTests.cs" />
     <Compile Include="AuthorizationLevelAttributeTests.cs" />
     <Compile Include="BashEndToEndTests.cs" />
+    <Compile Include="Binding\BlobBindingTests.cs" />
     <Compile Include="CompositeTraceWriterTests.cs" />
     <Compile Include="CSharpEndToEndTests.cs" />
     <Compile Include="CSharpFunctionSignatureTests.cs" />


### PR DESCRIPTION
This is a simple fix that will allow us to support ReadWrite binding/types for Blobs. An enhancement may be introduced at a later time if needed, using InOut direction.

Resolves #89 