### PR TITLE
Apply configured TraceLevel to file loggers (#201)

### DIFF
--- a/sample/ApiHubFileTrigger-CSharp/run.csx
+++ b/sample/ApiHubFileTrigger-CSharp/run.csx
@@ -8,7 +8,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(string input, out string output, TraceWriter log)
 {
-    log.Verbose($"C# ApiHub trigger function processed a file...");
+    log.Info($"C# ApiHub trigger function processed a file...");
 
     output = input;
 }

--- a/sample/BlobTrigger-CSharp/run.csx
+++ b/sample/BlobTrigger-CSharp/run.csx
@@ -5,7 +5,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(string blob, out string output, TraceWriter log)
 {
-    log.Verbose($"C# Blob trigger function processed a blob. Blob={blob}");
+    log.Info($"C# Blob trigger function processed a blob. Blob={blob}");
 
     output = blob;
 }

--- a/sample/HttpTrigger-CSharp/run.csx
+++ b/sample/HttpTrigger-CSharp/run.csx
@@ -11,7 +11,7 @@ public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter 
     var queryParamms = req.GetQueryNameValuePairs()
         .ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
 
-    log.Verbose(string.Format("C# HTTP trigger function processed a request. Name={0}", req.RequestUri));
+    log.Info(string.Format("C# HTTP trigger function processed a request. Name={0}", req.RequestUri));
 
     HttpResponseMessage res = null;
     string name;

--- a/sample/QueueTrigger-CSharp/run.csx
+++ b/sample/QueueTrigger-CSharp/run.csx
@@ -5,7 +5,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(Message message, out string result, TraceWriter log)
 {
-    log.Verbose($"C# Queue trigger function processed message: {message.Id}");
+    log.Info($"C# Queue trigger function processed message: {message.Id}");
 
     result = message.Value;
 }

--- a/sample/TimerTrigger-CSharp/run.csx
+++ b/sample/TimerTrigger-CSharp/run.csx
@@ -5,5 +5,5 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(TimerInfo input, TraceWriter log)
 {
-    log.Verbose("C# Timer trigger function executed.");
+    log.Info("C# Timer trigger function executed.");
 }

--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -81,7 +81,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -109,11 +109,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -11,15 +11,15 @@
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="1.4.0" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10291" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10305" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="1.1.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10279" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -134,7 +134,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -162,11 +162,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -26,15 +26,15 @@
   <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net46" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10291" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10305" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="1.1.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10279" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net452" />

--- a/src/WebJobs.Script/Description/CSharp/CSharpFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/CSharp/CSharpFunctionInvoker.cs
@@ -110,9 +110,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             // Reset cached function
             ResetFunctionValue();
-            TraceWriter.Verbose(string.Format(CultureInfo.InvariantCulture, "Script for function '{0}' changed. Reloading.", Metadata.Name));
+            TraceWriter.Info(string.Format(CultureInfo.InvariantCulture, "Script for function '{0}' changed. Reloading.", Metadata.Name));
 
-            TraceWriter.Verbose("Compiling function script.");
+            TraceWriter.Info("Compiling function script.");
 
             Script<object> script = CreateScript();
             Compilation compilation = GetScriptCompilation(script, _compileWithDebugOptmization);
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             bool compilationSucceeded = !compilationResult.Any(d => d.Severity == DiagnosticSeverity.Error);
 
-            TraceWriter.Verbose(string.Format(CultureInfo.InvariantCulture, "Compilation {0}.",
+            TraceWriter.Info(string.Format(CultureInfo.InvariantCulture, "Compilation {0}.",
                 compilationSucceeded ? "succeeded" : "failed"));
 
             // If the compilation succeeded, AND:
@@ -160,19 +160,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private void RestorePackages()
         {
-            TraceWriter.Verbose("Restoring packages.");
+            TraceWriter.Info("Restoring packages.");
 
             _metadataResolver.RestorePackagesAsync()
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted)
                     {
-                        TraceWriter.Verbose("Package restore failed:");
-                        TraceWriter.Verbose(t.Exception.ToString());
+                        TraceWriter.Info("Package restore failed:");
+                        TraceWriter.Info(t.Exception.ToString());
                         return;
                     }
 
-                    TraceWriter.Verbose("Packages restored.");
+                    TraceWriter.Info("Packages restored.");
                     _reloadScript();
                 });
         }
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 startedEvent = new FunctionStartedEvent(functionExecutionContext.InvocationId, Metadata);
                 _metrics.BeginEvent(startedEvent);
 
-                TraceWriter.Verbose(string.Format("Function started (Id={0})", invocationId));
+                TraceWriter.Info(string.Format("Function started (Id={0})", invocationId));
 
                 parameters = ProcessInputParameters(parameters);
 
@@ -220,18 +220,18 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     _resultProcessor(function, parameters, systemParameters, functionResult);
                 }
 
-                TraceWriter.Verbose(string.Format("Function completed (Success, Id={0})", invocationId));
+                TraceWriter.Info(string.Format("Function completed (Success, Id={0})", invocationId));
             }
             catch
             {
                 if (startedEvent != null)
                 {
                     startedEvent.Success = false;
-                    TraceWriter.Verbose(string.Format("Function completed (Failure, Id={0})", invocationId));
+                    TraceWriter.Error(string.Format("Function completed (Failure, Id={0})", invocationId));
                 }
                 else
                 {
-                    TraceWriter.Verbose("Function completed (Failure)");
+                    TraceWriter.Error("Function completed (Failure)");
                 }
                 throw;
             }

--- a/src/WebJobs.Script/Description/CSharp/PackageManager.cs
+++ b/src/WebJobs.Script/Description/CSharp/PackageManager.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     process.Close();
                 };
 
-                _traceWriter.Verbose("Starting NuGet restore");
+                _traceWriter.Info("Starting NuGet restore");
 
                 process.Start();
                 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private void ProcessDataReceived(object sender, DataReceivedEventArgs e)
         {
-            _traceWriter.Verbose(e.Data ?? string.Empty);
+            _traceWriter.Info(e.Data ?? string.Empty);
         }
     }
 }

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (scriptConfig.FileLoggingEnabled)
             {
+                TraceLevel functionTraceLevel = scriptConfig.HostConfig.Tracing.ConsoleLevel;
                 string logFilePath = Path.Combine(scriptConfig.RootLogPath, "Function", functionName);
-                return new FileTraceWriter(logFilePath, TraceLevel.Verbose);
+                return new FileTraceWriter(logFilePath, functionTraceLevel);
             }
 
             return NullTraceWriter.Instance;

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             try
             {
-                TraceWriter.Verbose(string.Format("Function started (Id={0})", invocationId));
+                TraceWriter.Info(string.Format("Function started (Id={0})", invocationId));
 
                 var scriptExecutionContext = CreateScriptExecutionContext(input, binder, traceWriter, TraceWriter, functionExecutionContext);
                 var bindingData = (Dictionary<string, string>)scriptExecutionContext["bindingData"];
@@ -131,12 +131,12 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 await ProcessOutputBindingsAsync(_outputBindings, input, binder, bindingData, scriptExecutionContext, functionResult);
 
-                TraceWriter.Verbose(string.Format("Function completed (Success, Id={0})", invocationId));
+                TraceWriter.Info(string.Format("Function completed (Success, Id={0})", invocationId));
             }
             catch
             {
                 startedEvent.Success = false;
-                TraceWriter.Verbose(string.Format("Function completed (Failure, Id={0})", invocationId));
+                TraceWriter.Error(string.Format("Function completed (Failure, Id={0})", invocationId));
                 throw;
             }
             finally
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 // clear the node module cache
                 ClearRequireCacheFunc(null).Wait();
 
-                TraceWriter.Verbose(string.Format(CultureInfo.InvariantCulture, "Script for function '{0}' changed. Reloading.", Metadata.Name));
+                TraceWriter.Info(string.Format(CultureInfo.InvariantCulture, "Script for function '{0}' changed. Reloading.", Metadata.Name));
             }
         }
 
@@ -270,8 +270,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 string text = p as string;
                 if (text != null)
                 {
-                    traceWriter.Verbose(text);
-                    fileTraceWriter.Verbose(text);
+                    traceWriter.Info(text);
+                    fileTraceWriter.Info(text);
                 } 
 
                 return Task.FromResult<object>(null);

--- a/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 }
             }
 
-            TraceWriter.Verbose(string.Format("Function started (Id={0})", invocationId));
+            TraceWriter.Info(string.Format("Function started (Id={0})", invocationId));
 
             string workingDirectory = Path.GetDirectoryName(_scriptFilePath);
             string functionInstanceOutputPath = Path.Combine(Path.GetTempPath(), "Functions", "Binding", invocationId);
@@ -132,19 +132,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 startedEvent.Success = false;
 
-                TraceWriter.Verbose(string.Format("Function completed (Failure, Id={0})", invocationId));
+                TraceWriter.Error(string.Format("Function completed (Failure, Id={0})", invocationId));
 
                 string error = process.StandardError.ReadToEnd();
                 throw new ApplicationException(error);
             }
 
             string output = process.StandardOutput.ReadToEnd();
-            TraceWriter.Verbose(output);
-            traceWriter.Verbose(output);
+            TraceWriter.Info(output);
+            traceWriter.Info(output);
 
             await ProcessOutputBindingsAsync(functionInstanceOutputPath, _outputBindings, input, binder, bindingData);
 
-            TraceWriter.Verbose(string.Format("Function completed (Success, Id={0})", invocationId));
+            TraceWriter.Info(string.Format("Function completed (Success, Id={0})", invocationId));
         }
 
         private void InitializeEnvironmentVariables(Dictionary<string, string> environmentVariables, string functionInstanceOutputPath, object input, Collection<FunctionBinding> outputBindings, ExecutionContext context)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -75,7 +75,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -103,15 +103,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus.Messaging.EventProcessorHost, Version=0.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -12,16 +12,16 @@
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="1.4.0" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10291" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10305" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="1.1.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10279" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="1.2.0-alpha-10291" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="1.2.0-alpha-10305" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests/EndToEndTestsBase.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(TestHelpers.RemoveByteOrderMarkAndWhitespace(messageContent), TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
 
             TraceEvent traceEvent = await WaitForTraceAsync(p => p.Message.Contains(id));
-            Assert.Equal(TraceLevel.Verbose, traceEvent.Level);
+            Assert.Equal(TraceLevel.Info, traceEvent.Level);
 
             string trace = traceEvent.Message;
             Assert.True(trace.Contains("script processed queue message"));

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // verify use of context.log to log complex objects
             TraceEvent scriptTrace = Fixture.TraceWriter.Traces.Single(p => p.Message.Contains(testData));
-            Assert.Equal(TraceLevel.Verbose, scriptTrace.Level);
+            Assert.Equal(TraceLevel.Info, scriptTrace.Level);
             JObject logEntry = JObject.Parse(scriptTrace.Message);
             Assert.Equal("Node.js manually triggered function called!", logEntry["message"]);
             Assert.Equal(testData, logEntry["input"]);

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileSender/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileSender/run.csx
@@ -3,7 +3,7 @@ using System;
 
 public static void Run(string input, out string item, TraceWriter log)
 {
-    log.Verbose($"C# ApiHub trigger function processed a file...");
+    log.Info($"C# ApiHub trigger function processed a file...");
 
     item = input;
 }

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileTrigger/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/ApiHubFileTrigger/run.csx
@@ -8,7 +8,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(string input, out string output, TraceWriter log)
 {
-    log.Verbose($"C# ApiHub trigger function processed a file...");
+    log.Info($"C# ApiHub trigger function processed a file...");
 
     output = input;
 }

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/BlobTrigger/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/BlobTrigger/run.csx
@@ -6,5 +6,5 @@ using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(Stream input, TraceWriter log)
 {
-    log.Verbose($"CSharp Blob trigger function processed a work item. Item={input}");
+    log.Info($"CSharp Blob trigger function processed a work item. Item={input}");
 }

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/DocumentDBIn/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/DocumentDBIn/run.csx
@@ -4,7 +4,7 @@ using System;
 using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json.Linq;
 
-public static void Run(string input, JObject item, TraceWriter log)
+public static void Run(string input, JObject item)
 {
     item["text"] = "This was updated!";
 }

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/LoadScriptReference/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/LoadScriptReference/run.csx
@@ -3,7 +3,7 @@
 using System.Net;
 using System.Diagnostics;
 
-public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
+public static Task<HttpResponseMessage> Run(HttpRequestMessage req)
 {
     string response = new Test().Response;
     req.Properties["LoadedScriptResponse"] = response;

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/MobileTableIn/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/MobileTableIn/run.csx
@@ -8,5 +8,5 @@ public static void Run(string input, JObject item, TraceWriter log)
 {
     item["Text"] = "This was updated!";
 
-    log.Verbose($"Updating item {item["Id"]}");
+    log.Info($"Updating item {item["Id"]}");
 }

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/MobileTableOut/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/MobileTableOut/run.csx
@@ -9,7 +9,7 @@ public static void Run(string input, out Item item, TraceWriter log)
         Text = "Hello from C#!"
     };
 
-    log.Verbose($"Inserting item {item.Id}");
+    log.Info($"Inserting item {item.Id}");
 }
 
 public class Item

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/QueueTriggerToBlob/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/QueueTriggerToBlob/run.csx
@@ -8,7 +8,7 @@ public static void Run(WorkItem input, out string output, TraceWriter log)
 {
     string json = string.Format("{{ \"id\": \"{0}\" }}", input.Id);
 
-    log.Verbose($"C# script processed queue message. Item={json}");
+    log.Info($"C# script processed queue message. Item={json}");
 
     output = json;
 }

--- a/test/WebJobs.Script.Tests/TestScripts/FunctionGeneration/HttpTrigger-CSharp/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/FunctionGeneration/HttpTrigger-CSharp/run.csx
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Host;
 
-public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
+public static Task<HttpResponseMessage> Run(HttpRequestMessage req)
 {
     // DO NOT modify this pattern as we want the test to run with it in place
     // to ensure it won't cause a deadlock.

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -65,7 +65,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -93,11 +93,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10305\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -10,15 +10,15 @@
   <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net46" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10291" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10305" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="1.1.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10279" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10279" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10291" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10305" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />


### PR DESCRIPTION
Currently we're doing Verbose logging always, and that isn't configurable via host.json. That means there is a bunch of noise in your host log files (take a look - you'll see all kind of Singleton lock traces, etc.).

Now, you can set the log level in host.json. The default is Info (which is why as part of this PR I adjusted all the logs we were doing to Info level). This will mean that any Verbose logs that C# functions might be writing won't show up unless they fix up their code to do Info instead (or set the log level to Verbose in host.json). I believe this is the right thing to do though - it gives users more logging flexibility.

As part of this I also made a PR against the SDK repo: https://github.com/Azure/azure-webjobs-sdk/pull/701. In doing this work I noticed that we were no longer doing function instance logging to the host log (we used to).