### PR TITLE
Incorporating code comments Mathew provided in the last PR

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/IMetricsEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/IMetricsEventGenerator.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace WebJobs.Script.WebHost.Diagnostics
 {
     public interface IMetricsEventGenerator

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventGenerator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Diagnostics.Tracing;
 
 namespace WebJobs.Script.WebHost.Diagnostics

--- a/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
@@ -8,16 +8,16 @@ namespace WebJobs.Script.WebHost.Diagnostics
 {
     public class WebHostMetricsLogger : IMetricsLogger
     {
-        private MetricsEventManager metricsEventManager;
+        private MetricsEventManager _metricsEventManager;
 
         public WebHostMetricsLogger()
-            : this(new MetricsEventGenerator())
+            : this(new MetricsEventGenerator(), 5)
         {
         }
 
-        public WebHostMetricsLogger(IMetricsEventGenerator metricsEventGenerator)
+        public WebHostMetricsLogger(IMetricsEventGenerator metricsEventGenerator, int metricEventIntervalInSeconds)
         {
-            metricsEventManager = new MetricsEventManager(metricsEventGenerator);
+            _metricsEventManager = new MetricsEventManager(metricsEventGenerator, metricEventIntervalInSeconds);
         }
 
         public void BeginEvent(MetricEvent metricEvent)
@@ -26,7 +26,7 @@ namespace WebJobs.Script.WebHost.Diagnostics
             if (startedEvent != null)
             {
                 startedEvent.StartTime = DateTime.Now;
-                metricsEventManager.FunctionStarted(startedEvent);
+                _metricsEventManager.FunctionStarted(startedEvent);
             }
         }
 
@@ -36,7 +36,7 @@ namespace WebJobs.Script.WebHost.Diagnostics
             if (completedEvent != null)
             {
                 completedEvent.EndTime = DateTime.Now;
-                metricsEventManager.FunctionCompleted(completedEvent);
+                _metricsEventManager.FunctionCompleted(completedEvent);
             }
         }
 
@@ -45,7 +45,7 @@ namespace WebJobs.Script.WebHost.Diagnostics
             HostStarted hostStartedEvent = metricEvent as HostStarted;
             if (hostStartedEvent != null)
             {
-                metricsEventManager.HostStarted(hostStartedEvent.Host);
+                _metricsEventManager.HostStarted(hostStartedEvent.Host);
             }
         }
     }


### PR DESCRIPTION
2. Prefixing all private data members with '_'
3. Instead of waiting 5 second interval to generate 'InProgress' events, using a data member to provide a custom wait time to make tests run faster
4. Renaming 'ShortDummyFunction' and 'LongDummyFunction' to 'ShortTestFunction' and 'LongTestFunction' respectively