### PR TITLE
Moving FastLogger registration to WebHost

### DIFF
--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -16,7 +16,6 @@
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10306" />
       <dependency id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10306" />
-      <dependency id="Microsoft.Azure.WebJobs.Logging" version="1.2.0-alpha-10306" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="1.1.0-alpha-10287" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10287" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10287" />

--- a/src/WebJobs.Script.WebHost/Diagnostics/FastLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FastLogger.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script;
 using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+namespace WebJobs.Script.WebHost.Diagnostics
 {
     // Adapter for capturing SDK events and logging them to tables.
     internal class FastLogger : IAsyncCollector<FunctionInstanceLogEntry>

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -165,6 +165,10 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10306\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.1.2.0-alpha-10306\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10306\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
       <Private>True</Private>
@@ -296,6 +300,7 @@
     <Compile Include="Controllers\AdminController.cs" />
     <Compile Include="Controllers\FunctionsController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Diagnostics\FastLogger.cs" />
     <Compile Include="Diagnostics\IMetricsEventGenerator.cs" />
     <Compile Include="Diagnostics\MetricsEventGenerator.cs" />
     <Compile Include="Diagnostics\MetricsEventManager.cs" />

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -11,6 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.WebHooks;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -137,6 +139,14 @@ namespace WebJobs.Script.WebHost
             
             // Add our WebHost specific services
             config.AddService<IMetricsLogger>(_metricsLogger);
+
+            var dashboardString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Dashboard);
+            if (dashboardString != null)
+            {
+                var fastLogger = new FastLogger(dashboardString);
+                config.AddService<IAsyncCollector<FunctionInstanceLogEntry>>(fastLogger);
+            }
+            config.DashboardConnectionString = null; // disable slow logging 
         }
 
         protected override void OnHostStarted()

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -35,6 +35,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10287" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10287" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10287" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="1.2.0-alpha-10306" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10306" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Indexers;
-using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -173,16 +172,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // take a snapshot so we can detect function additions/removals
             _directoryCountSnapshot = Directory.EnumerateDirectories(ScriptConfig.RootScriptPath).Count();
-
-            var dashboardString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Dashboard);
-
-            var config = ScriptConfig.HostConfig;
-            if (dashboardString != null)
-            {
-                var fastLogger = new FastLogger(dashboardString);
-                config.AddService<IAsyncCollector<FunctionInstanceLogEntry>>(fastLogger);
-            }
-            config.DashboardConnectionString = null; // disable slow logging 
 
             IMetricsLogger metricsLogger = ScriptConfig.HostConfig.GetService<IMetricsLogger>();
             if (metricsLogger == null)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -90,10 +90,6 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.2.0-alpha-10306\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.1.2.0-alpha-10306\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.1.2.0-alpha-10306\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
       <Private>True</Private>
@@ -286,7 +282,6 @@
     <Compile Include="Description\Binding\ServiceBusBindingMetadata.cs" />
     <Compile Include="Description\Binding\TableBindingMetadata.cs" />
     <Compile Include="Description\Binding\TimerBindingMetadata.cs" />
-    <Compile Include="Diagnostics\FastLogger.cs" />
     <Compile Include="Diagnostics\FunctionStartedEvent.cs" />
     <Compile Include="Diagnostics\IMetricsLogger.cs" />
     <Compile Include="Diagnostics\MetricEvent.cs" />

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -16,7 +16,6 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10287" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10287" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="1.1.0-alpha-10287" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="1.2.0-alpha-10306" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="1.2.0-alpha-10306" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />


### PR DESCRIPTION
We only want to do the new prototype FastLogger stuff in AzureFunctions, not when running in a traditional WebJob. So I'm moving the registration of the FastLogger into the WebHost. This allows the ScriptHost running in a traditional WebJob to use the existing Dashboard users expect. I've tested this end to end in a deployed WebJob.