### PR TITLE
Rename Source metadata property, clean up resolution logic (#351)

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilationService.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilationService.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             string code = null;
 
-            if (File.Exists(functionMetadata.Source))
+            if (File.Exists(functionMetadata.ScriptFile))
             {
-                code = File.ReadAllText(functionMetadata.Source);
+                code = File.ReadAllText(functionMetadata.ScriptFile);
             }
 
             return code ?? string.Empty;
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 SyntaxTree scriptTree = compilation.SyntaxTrees.FirstOrDefault(t => string.IsNullOrEmpty(t.FilePath));
                 var debugTree = SyntaxFactory.SyntaxTree(scriptTree.GetRoot(),
                   encoding: Encoding.UTF8,
-                  path: Path.GetFileName(functionMetadata.Source),
+                  path: Path.GetFileName(functionMetadata.ScriptFile),
                   options: new CSharpParseOptions(kind: SourceCodeKind.Script));
 
                 compilationOptimizationLevel = OptimizationLevel.Debug;

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 if (_functionBaseUri == null)
                 {
-                    _functionBaseUri = new Uri(Path.GetDirectoryName(Metadata.Source) + "\\", UriKind.RelativeOrAbsolute);
+                    _functionBaseUri = new Uri(Path.GetDirectoryName(Metadata.ScriptFile) + "\\", UriKind.RelativeOrAbsolute);
                 }
 
                 return _functionBaseUri;

--- a/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                         .WithMetadataResolver(this)
                         .WithReferences(GetCompilationReferences())
                         .WithImports(DefaultNamespaceImports)
-                        .WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, Path.GetDirectoryName(_functionMetadata.Source)));
+                        .WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, Path.GetDirectoryName(_functionMetadata.ScriptFile)));
             }
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         /// <returns>The path to the function's private assembly folder</returns>
         private static string GetBinDirectory(FunctionMetadata metadata)
         {
-            string functionDirectory = Path.GetDirectoryName(metadata.Source);
+            string functionDirectory = Path.GetDirectoryName(metadata.ScriptFile);
             return Path.Combine(Path.GetFullPath(functionDirectory), DotNetConstants.PrivateAssembliesFolderName);
         }
 

--- a/src/WebJobs.Script/Description/DotNet/PackageAssemblyResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/PackageAssemblyResolver.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private static ImmutableArray<PackageReference> InitializeAssemblyRegistry(FunctionMetadata metadata)
         {
             var builder = ImmutableArray<PackageReference>.Empty.ToBuilder();
-            string fileName = Path.Combine(Path.GetDirectoryName(metadata.Source), DotNetConstants.ProjectLockFileName);
+            string fileName = Path.Combine(Path.GetDirectoryName(metadata.ScriptFile), DotNetConstants.ProjectLockFileName);
 
             if (File.Exists(fileName))
             {

--- a/src/WebJobs.Script/Description/DotNet/PackageManager.cs
+++ b/src/WebJobs.Script/Description/DotNet/PackageManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             try
             {
-                string functionDirectory = Path.GetDirectoryName(_functionMetadata.Source);
+                string functionDirectory = Path.GetDirectoryName(_functionMetadata.ScriptFile);
                 string projectPath = Path.Combine(functionDirectory, DotNetConstants.ProjectFileName);
                 string nugetHome = GetNugetPackagesPath();
 

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             BindingMetadata triggerMetadata = functionMetadata.InputBindings.FirstOrDefault(p => p.IsTrigger);
           
-            string scriptFilePath = Path.Combine(Config.RootScriptPath, functionMetadata.Source);
+            string scriptFilePath = Path.Combine(Config.RootScriptPath, functionMetadata.ScriptFile);
 
             IFunctionInvoker invoker = null;
 

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (Host.ScriptConfig.FileWatchingEnabled)
             {
-                string functionDirectory = Path.GetDirectoryName(Metadata.Source);
+                string functionDirectory = Path.GetDirectoryName(Metadata.ScriptFile);
                 _fileWatcher = new FileSystemWatcher(functionDirectory, "*.*")
                 {
                     IncludeSubdirectories = true,

--- a/src/WebJobs.Script/Description/FunctionMetadata.cs
+++ b/src/WebJobs.Script/Description/FunctionMetadata.cs
@@ -16,7 +16,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public string Name { get; set; }
 
-        public string Source { get; set; }
+        /// <summary>
+        /// The primary entry point for the function (to disambiguate if there are multiple
+        /// scripts in the function directory).
+        /// </summary>
+        public string ScriptFile { get; set; }
 
         public ScriptType ScriptType { get; set; }
 

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             : base(host, functionMetadata)
         {
             _trigger = trigger;
-            string scriptFilePath = functionMetadata.Source.Replace('\\', '/');
+            string scriptFilePath = functionMetadata.ScriptFile.Replace('\\', '/');
             _script = string.Format(CultureInfo.InvariantCulture, _functionTemplate, scriptFilePath);
             _inputBindings = inputBindings;
             _outputBindings = outputBindings;

--- a/test/WebJobs.Script.Tests/Description/CSharp/FunctionAssemblyLoaderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/CSharp/FunctionAssemblyLoaderTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Description.CSharp
         {
             var resolver = new FunctionAssemblyLoader("c:\\");
 
-            var metadata1 = new FunctionMetadata { Name = "Test1", Source = @"c:\testroot\test1\test.tst" };
-            var metadata2 = new FunctionMetadata { Name = "Test2", Source = @"c:\testroot\test2\test.tst" };
+            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = @"c:\testroot\test1\test.tst" };
+            var metadata2 = new FunctionMetadata { Name = "Test2", ScriptFile = @"c:\testroot\test2\test.tst" };
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
 
             var mockResolver = new Mock<IFunctionMetadataResolver>();
@@ -43,8 +43,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Description.CSharp
         {
             var resolver = new FunctionAssemblyLoader("c:\\");
 
-            var metadata1 = new FunctionMetadata { Name = "Test1", Source = @"c:\testroot\test1\test.tst" };
-            var metadata2 = new FunctionMetadata { Name = "Test2", Source = @"c:\testroot\test2\test.tst" };
+            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = @"c:\testroot\test1\test.tst" };
+            var metadata2 = new FunctionMetadata { Name = "Test2", ScriptFile = @"c:\testroot\test2\test.tst" };
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
 
             var mockResolver = new Mock<IFunctionMetadataResolver>();

--- a/test/WebJobs.Script.Tests/Description/CSharp/PackageAssemblyResolverTests.cs
+++ b/test/WebJobs.Script.Tests/Description/CSharp/PackageAssemblyResolverTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var functionMetadata = new FunctionMetadata()
             {
                 Name = "TestFunction",
-                Source = _lockFilePath, /*We just need the path from this*/
+                ScriptFile = _lockFilePath, /*We just need the path from this*/
                 ScriptType = ScriptType.CSharp
             };
 
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var functionMetadata = new FunctionMetadata()
             {
                 Name = "TestFunction",
-                Source = _lockFilePath, /*We just need the path from this*/
+                ScriptFile = _lockFilePath, /*We just need the path from this*/
                 ScriptType = ScriptType.CSharp
             };
 
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var functionMetadata = new FunctionMetadata()
             {
                 Name = "TestFunction",
-                Source = _lockFilePath, /*We just need the path from this*/
+                ScriptFile = _lockFilePath, /*We just need the path from this*/
                 ScriptType = ScriptType.CSharp
             };
 
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var functionMetadata = new FunctionMetadata()
             {
                 Name = "TestFunction",
-                Source = _lockFilePath, /*We just need the path from this*/
+                ScriptFile = _lockFilePath, /*We just need the path from this*/
                 ScriptType = ScriptType.CSharp
             };
 
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var functionMetadata = new FunctionMetadata()
             {
                 Name = "TestFunction",
-                Source = _lockFilePath, /*We just need the path from this*/
+                ScriptFile = _lockFilePath, /*We just need the path from this*/
                 ScriptType = ScriptType.CSharp
             };
 

--- a/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string rootPath = Path.Combine(Environment.CurrentDirectory, @"TestScripts\Node");
             FunctionMetadata metadata = new FunctionMetadata();
             metadata.Name = "Test";
-            metadata.Source = Path.Combine(rootPath, @"Common\test.js");
+            metadata.ScriptFile = Path.Combine(rootPath, @"Common\test.js");
             metadata.Bindings.Add(trigger);
 
             List<FunctionMetadata> metadatas = new List<FunctionMetadata>();


### PR DESCRIPTION
Addresses bug# https://github.com/Azure/azure-webjobs-sdk-script/issues/351

Also improving the error message we give when we can't determine the primary script file. As David indicated in the bug, Kudu is using this exact same logic. The plan is to copy this updated function to Kudu as well, and release these updates together.

@davidebbo @ahmelsayed