### PR TITLE
Fixing issue with compilation diagnostics

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public ImmutableArray<Diagnostic> GetDiagnostics()
         {
-            return _compilation.WithAnalyzers(GetAnalyzers()).GetAllDiagnosticsAsync().Result;
+            var diagnostics = _compilation.WithAnalyzers(GetAnalyzers()).GetAllDiagnosticsAsync().Result;
+            return diagnostics.AddRange(_compilation.GetDiagnostics());
         }
 
         public FunctionSignature GetEntryPointSignature(IFunctionEntryPointResolver entryPointResolver)


### PR DESCRIPTION
Fixing issue when getting compilation and analyzer diagnostics. 
The previous version was not correctly getting compilation diagnostics in the script diagnostics check pass.