### PR TITLE
Fixing bug in log file purge logic (#393)

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
 
             // Purge any old Function secrets
-            _secretManager.PurgeOldFiles(Instance.ScriptConfig.RootScriptPath);
+            _secretManager.PurgeOldFiles(Instance.ScriptConfig.RootScriptPath, Instance.TraceWriter);
         }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -212,6 +212,8 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     instance.Dispose();
                 }
+
+                IsRunning = false;
             }
             catch
             {

--- a/test/WebJobs.Script.Tests/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostManagerTests.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -127,6 +128,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
 
             Assert.Null(target.Object.LastError);
+        }
+
+        [Fact]
+        public async Task EmptyHost_StartsSuccessfully()
+        {
+            string functionDir = Path.Combine(TestHelpers.FunctionsTestDirectory, "Functions", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(functionDir);
+
+            // important for the repro that this directory does not exist
+            string logDir = Path.Combine(TestHelpers.FunctionsTestDirectory, "Logs", Guid.NewGuid().ToString());
+
+            JObject hostConfig = new JObject
+            {
+                { "id", "123456" }
+            };
+            File.WriteAllText(Path.Combine(functionDir, ScriptConstants.HostMetadataFileName), hostConfig.ToString());
+
+            ScriptHostConfiguration config = new ScriptHostConfiguration
+            {
+                RootScriptPath = functionDir,
+                RootLogPath = logDir,
+                FileLoggingEnabled = true
+            };
+            ScriptHostManager hostManager = new ScriptHostManager(config);
+
+            Task runTask = Task.Run(() => hostManager.RunAndBlock());
+
+            await TestHelpers.Await(() => hostManager.IsRunning, timeout: 10000);
+
+            hostManager.Stop();
+            Assert.False(hostManager.IsRunning);
+
+            string hostLogFilePath = Directory.EnumerateFiles(Path.Combine(logDir, "Host")).Single();
+            string hostLogs = File.ReadAllText(hostLogFilePath);
+
+            Assert.True(hostLogs.Contains("Generating 0 job function(s)"));
+            Assert.True(hostLogs.Contains("No job functions found."));
+            Assert.True(hostLogs.Contains("Job host started"));
+            Assert.True(hostLogs.Contains("Job host stopped"));
         }
 
         // Update the manifest for the timer function

--- a/test/WebJobs.Script.Tests/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests/TestHelpers.cs
@@ -13,6 +13,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public static class TestHelpers
     {
+        /// <summary>
+        /// Common root directory that functions tests create temporary directories under.
+        /// This enables us to clean up test files by deleting this single directory.
+        /// </summary>
+        public static string FunctionsTestDirectory
+        {
+            get
+            {
+                return Path.Combine(Path.GetTempPath(), "FunctionsTest");
+            }
+        }
+
         public static async Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000)
         {
             DateTime start = DateTime.Now;


### PR DESCRIPTION
In the new purge logic we added, we discovered a bug where if the function log directory does not exist (e.g if no functions have ever been added or ran) the purge logic fails on startup.