### PR TITLE
Enforce CRON format for TimerTrigger (#400)

### DIFF
--- a/sample/TimerTrigger-CSharp/function.json
+++ b/sample/TimerTrigger-CSharp/function.json
@@ -3,7 +3,6 @@
         {
             "type": "timerTrigger",
             "schedule": "0 * * * * *",
-            "runOnStartup": true,
             "direction": "in"
         }
     ]

--- a/sample/TimerTrigger/function.json
+++ b/sample/TimerTrigger/function.json
@@ -3,8 +3,7 @@
         {
             "type": "timerTrigger",
             "direction": "in",
-            "schedule": "0 * * * * *",
-            "runOnStartup": true
+            "schedule": "0 * * * * *"
         },
         {
             "type": "queue",

--- a/src/WebJobs.Script/Diagnostics/ConsoleTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/ConsoleTraceWriter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal class ConsoleTraceWriter : TraceWriter
+    {
+        public ConsoleTraceWriter(TraceLevel traceLevel) : base(traceLevel)
+        {
+        }
+
+        public override void Trace(TraceEvent traceEvent)
+        {
+            Console.WriteLine(traceEvent.Message);
+        }
+    }
+}

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -125,9 +125,9 @@ namespace Microsoft.Azure.WebJobs.Script
             ScriptConfig.HostConfig.Tracing.Tracers.Add(traceMonitor);
 
             TraceWriter = ScriptConfig.TraceWriter;
+            TraceLevel hostTraceLevel = ScriptConfig.HostConfig.Tracing.ConsoleLevel;
             if (ScriptConfig.FileLoggingEnabled)
             {
-                TraceLevel hostTraceLevel = ScriptConfig.HostConfig.Tracing.ConsoleLevel;
                 string hostLogFilePath = Path.Combine(ScriptConfig.RootLogPath, "Host");
                 TraceWriter fileTraceWriter = new FileTraceWriter(hostLogFilePath, hostTraceLevel);
                 if (TraceWriter != null)
@@ -147,7 +147,8 @@ namespace Microsoft.Azure.WebJobs.Script
             }
             else
             {
-                TraceWriter = NullTraceWriter.Instance;
+                // if no TraceWriter has been configured, default it to Console
+                TraceWriter = new ConsoleTraceWriter(hostTraceLevel);
             }
 
             TraceWriter.Info(string.Format(CultureInfo.InvariantCulture, "Reading host configuration file '{0}'", hostConfigFilePath));

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
                     newInstance.StartAsync(cancellationToken).GetAwaiter().GetResult();
 
-                    // write any function initialization errors to the log file
+                    // log any function initialization errors
                     LogErrors(newInstance);
 
                     lock (_liveInstances)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -297,6 +297,7 @@
     <Compile Include="Description\Binding\ServiceBusBindingMetadata.cs" />
     <Compile Include="Description\Binding\TableBindingMetadata.cs" />
     <Compile Include="Description\Binding\TimerBindingMetadata.cs" />
+    <Compile Include="Diagnostics\ConsoleTraceWriter.cs" />
     <Compile Include="Diagnostics\FunctionStartedEvent.cs" />
     <Compile Include="Diagnostics\IMetricsLogger.cs" />
     <Compile Include="Diagnostics\MetricEvent.cs" />

--- a/test/WebJobs.Script.Tests/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostManagerTests.cs
@@ -67,8 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             ScriptHostConfiguration config = new ScriptHostConfiguration()
             {
-                RootScriptPath = Environment.CurrentDirectory,
-                TraceWriter = NullTraceWriter.Instance
+                RootScriptPath = Environment.CurrentDirectory
             };
 
             var hostMock = new Mock<TestScriptHost>(config);
@@ -93,8 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             ScriptHostConfiguration config = new ScriptHostConfiguration()
             {
-                RootScriptPath = Environment.CurrentDirectory,
-                TraceWriter = NullTraceWriter.Instance
+                RootScriptPath = Environment.CurrentDirectory
             };
 
             var exception = new Exception("Kaboom!");


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/400. On the Dynamic hosting plan, non CRON formats are not honored.