### PR TITLE
Normalizing the ServiceBus binding to use byte[] 

### DIFF
--- a/sample/ServiceBusQueueTrigger/function.json
+++ b/sample/ServiceBusQueueTrigger/function.json
@@ -10,6 +10,12 @@
             "name": "message",
             "direction": "out",
             "queueName": "samples-input"
+        },
+        {
+            "type": "blob",
+            "name": "output",
+            "direction": "out",
+            "path": "samples-output/{id}"
         }
     ]
 }

--- a/sample/ServiceBusQueueTrigger/index.js
+++ b/sample/ServiceBusQueueTrigger/index.js
@@ -1,12 +1,16 @@
-﻿module.exports = function (context, message) {
+﻿var util = require('util');
+
+module.exports = function (context, message) {
     context.log('Node.js ServiceBus queue trigger function processed message', message);
 
-    if (message.count < 2)
+    if (message.count < message.max)
     {
-        // write a message back to the queue that this function is triggered on
-        // ensuring that we only loop on this twice
+        // write a message back to the queue that this function is triggered
         message.count += 1;
         context.bindings.message = message;
+    }
+    else {
+        context.bindings.output = util.format('%d messages processed', message.count);
     }
 
     context.done();

--- a/src/WebJobs.Script/Binding/ServiceBusBinding.cs
+++ b/src/WebJobs.Script/Binding/ServiceBusBinding.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             }
             RuntimeBindingContext runtimeContext = new RuntimeBindingContext(attribute, additionalAttributes);
 
-            await BindAsyncCollectorAsync<string>(context, runtimeContext);
+            await BindAsyncCollectorAsync<byte[]>(context, runtimeContext);
         }
 
         internal static void AddServiceBusAccountAttribute(Collection<CustomAttributeBuilder> attributes, string connection)


### PR DESCRIPTION
This is part of the DataType work I did recently. I had already standardized the other bindings onto `byte[]`/`IAsyncCollector<byte[]>` but was unable to do so for ServiceBus due to an SDK restriction. I've addressed that in a separate PR in the SDK repo ([here](https://github.com/Azure/azure-webjobs-sdk/pull/733)), and verified that the updated SDK fixes the issues in Script.

This allows the ServiceBus binding to also write byte[] messages.

Note that the AppVeyor PR build will fail on this because it depends on the updated SDK package :)