### PR TITLE
Adding SendGrid binding extension

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -265,6 +265,24 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "modules", "modules", "{A751
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Extensibility", "src\WebJobs.Script.Extensibility\WebJobs.Script.Extensibility.csproj", "{479B0873-CBDC-4AE9-85BA-DD6CF2DCA29D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SendGrid", "SendGrid", "{23E6C413-FCFB-4727-8F4A-5AFEA63090A7}"
+	ProjectSection(SolutionItems) = preProject
+		sample\SendGrid\function.json = sample\SendGrid\function.json
+		sample\SendGrid\index.js = sample\SendGrid\index.js
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SendGrid-CSharp", "SendGrid-CSharp", "{B69D3A0B-829B-4721-B034-8ECECB264458}"
+	ProjectSection(SolutionItems) = preProject
+		sample\SendGrid-CSharp\function.json = sample\SendGrid-CSharp\function.json
+		sample\SendGrid-CSharp\run.csx = sample\SendGrid-CSharp\run.csx
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SendGrid-PowerShell", "SendGrid-PowerShell", "{5C25CC30-5E4B-4E17-A0CB-AB0E72B70D8E}"
+	ProjectSection(SolutionItems) = preProject
+		sample\SendGrid-PowerShell\function.json = sample\SendGrid-PowerShell\function.json
+		sample\SendGrid-PowerShell\run.ps1 = sample\SendGrid-PowerShell\run.ps1
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -345,5 +363,8 @@ Global
 		{CDF316B9-AB36-42CB-859B-FCDB56E083B0} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{A751A732-ACCE-4B1F-8244-8DD161619483} = {CDF316B9-AB36-42CB-859B-FCDB56E083B0}
 		{479B0873-CBDC-4AE9-85BA-DD6CF2DCA29D} = {16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}
+		{23E6C413-FCFB-4727-8F4A-5AFEA63090A7} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{B69D3A0B-829B-4721-B034-8ECECB264458} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{5C25CC30-5E4B-4E17-A0CB-AB0E72B70D8E} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 	EndGlobalSection
 EndGlobal

--- a/sample/SendGrid-CSharp/function.json
+++ b/sample/SendGrid-CSharp/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "bindings": [
+        {
+            "type": "queueTrigger",
+            "name": "order",
+            "direction": "in",
+            "queueName": "samples-orders-csharp"
+        },
+        {
+            "type": "sendGrid",
+            "name": "message",
+            "direction": "out",
+            "to": "{CustomerEmail}"
+        }
+    ]
+}

--- a/sample/SendGrid-CSharp/run.csx
+++ b/sample/SendGrid-CSharp/run.csx
@@ -1,0 +1,24 @@
+#r "SendGridMail"
+
+using System;
+using SendGrid;
+using Microsoft.Azure.WebJobs.Host;
+
+public static void Run(Order order, out SendGridMessage message, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed order: {order.OrderId}");
+
+    message = new SendGridMessage()
+    {
+        Subject = string.Format("Thanks for your order (#{0})!", order.OrderId),
+        Text = string.Format("{0}, your order ({1}) is being processed!", order.CustomerName, order.OrderId)
+    };
+    message.AddTo(order.CustomerEmail);
+}
+
+public class Order
+{
+    public string OrderId { get; set; }
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+}

--- a/sample/SendGrid-PowerShell/function.json
+++ b/sample/SendGrid-PowerShell/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "bindings": [
+        {
+            "type": "queueTrigger",
+            "name": "order",
+            "direction": "in",
+            "queueName": "samples-orders-powershell"
+        },
+        {
+            "type": "sendGrid",
+            "name": "message",
+            "direction": "out",
+            "to": "{CustomerEmail}"
+        }
+    ]
+}

--- a/sample/SendGrid-PowerShell/run.ps1
+++ b/sample/SendGrid-PowerShell/run.ps1
@@ -1,0 +1,6 @@
+$in = Get-Content $order
+
+$order = $in | ConvertFrom-Json
+$content = [string]::Format('{{ "Subject": "Thanks for your order (#{0})", "Text": "{1}, your order ({0}) is being processed!" }}', $order.OrderId, $order.CustomerName)
+
+$content | Out-File -Encoding Ascii $message

--- a/sample/SendGrid/function.json
+++ b/sample/SendGrid/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "bindings": [
+        {
+            "type": "queueTrigger",
+            "name": "order",
+            "direction": "in",
+            "queueName": "samples-orders"
+        },
+        {
+            "type": "sendGrid",
+            "name": "message",
+            "direction": "out",
+            "to": "{customerEmail}"
+        }
+    ]
+}

--- a/sample/SendGrid/index.js
+++ b/sample/SendGrid/index.js
@@ -1,0 +1,12 @@
+﻿var util = require('util');
+
+module.exports = function (context, order) {
+    context.log('Node.js queue trigger function processed order', order.orderId);
+
+    context.done(null, {
+        message: {
+            subject: util.format('Thanks for your order (#%d)!', order.orderId),
+            text: util.format("%s, your order (%d) is being processed!", order.customerName, order.orderId)
+        }
+    });
+}

--- a/sample/host.json
+++ b/sample/host.json
@@ -1,3 +1,6 @@
 {
-    "id": "5a709861cab44e68bfed5d2c2fe7fc0c"
+    "id": "5a709861cab44e68bfed5d2c2fe7fc0c",
+    "sendGrid": {
+        "from": "samples@functions.com:AzureFunctions"
+    } 
 }

--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -81,27 +81,27 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.MobileApps, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -12,12 +12,12 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.1.5" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10309" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10312" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1-10307" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -142,27 +142,27 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.MobileApps, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -30,12 +30,12 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.1.5" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10309" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10312" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1-10307" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-alpha-10343" targetFramework="net46" />

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -67,27 +67,27 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.MobileApps, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -11,12 +11,12 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.1.5" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10309" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10312" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1-10307" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -72,27 +72,27 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.MobileApps, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.NotificationHubs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.1.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10309\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.SendGrid.2.0.0-alpha-10312\lib\net45\Microsoft.Azure.WebJobs.Extensions.SendGrid.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -14,12 +14,12 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.1.5" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10309" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10309" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.0-alpha-10312" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.0-alpha-10312" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1-10307" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-alpha-10343" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />


### PR DESCRIPTION
Addresses existing issue #132. We were already referencing the SendGrid Extension package. To enable the binding, I just added a ScriptBindingProvider to the extension (in the extensions repo, [commit here](https://github.com/Azure/azure-webjobs-sdk-extensions/commit/eaa0056c4740957bffa149405d1ca8ca2b45339d)).

I'll add a tempate for this to the templates repo as well.