### PR TITLE
Add the ability to exclude functions

### DIFF
--- a/sample/SendGrid-CSharp/function.json
+++ b/sample/SendGrid-CSharp/function.json
@@ -1,4 +1,5 @@
 ﻿{
+    "excluded": true,
     "bindings": [
         {
             "type": "queueTrigger",

--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -45,10 +45,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             SecretManager secretManager = (SecretManager)controllerContext.Configuration.DependencyResolver.GetService(typeof(SecretManager));
             AuthorizationLevel authorizationLevel = AuthorizationLevelAttribute.GetAuthorizationLevel(request, secretManager, functionName: function.Name);
 
-            if (function.Metadata.IsDisabled && 
-                authorizationLevel != AuthorizationLevel.Admin)
+            if (function.Metadata.IsExcluded ||
+                (function.Metadata.IsDisabled && authorizationLevel != AuthorizationLevel.Admin))
             {
-                // disabled functions are not publically addressable w/o Admin level auth
+                // disabled functions are not publically addressable w/o Admin level auth,
+                // and excluded functions are also ignored here (though the check above will
+                // already exclude them)
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
             }
 

--- a/src/WebJobs.Script/Description/FunctionMetadata.cs
+++ b/src/WebJobs.Script/Description/FunctionMetadata.cs
@@ -24,7 +24,23 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public ScriptType ScriptType { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the function is disabled.
+        /// <remarks>
+        /// A disabled function is still compiled and loaded into the host, but it will not
+        /// be triggered automatically, and is not publically addressable (except via admin invoke requests).
+        /// </remarks>
+        /// </summary>
         public bool IsDisabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the function is excluded.
+        /// <remarks>
+        /// An excluded function is completely skipped during function loading. It will not be compiled
+        /// and will not be loaded into the host.
+        /// </remarks>
+        /// </summary>
+        public bool IsExcluded { get; set; }
 
         public Collection<BindingMetadata> Bindings { get; private set; }
 

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -406,6 +406,13 @@ namespace Microsoft.Azure.WebJobs.Script
                 functionMetadata.IsDisabled = true;
             }
 
+            JToken value = null;
+            if (configMetadata.TryGetValue("excluded", StringComparison.OrdinalIgnoreCase, out value) &&
+                value.Type == JTokenType.Boolean)
+            {
+                functionMetadata.IsExcluded = (bool)value;
+            }
+
             return functionMetadata;
         }
 
@@ -445,6 +452,12 @@ namespace Microsoft.Azure.WebJobs.Script
                     string json = File.ReadAllText(functionConfigPath);
                     JObject functionConfig = JObject.Parse(json);
                     FunctionMetadata metadata = ParseFunctionMetadata(functionName, config.HostConfig.NameResolver, functionConfig);
+
+                    if (metadata.IsExcluded)
+                    {
+                        TraceWriter.Info(string.Format("Function '{0}' is marked as excluded", functionName));
+                        continue;
+                    }
 
                     // determine the primary script
                     string[] functionFiles = Directory.EnumerateFiles(scriptDir).Where(p => Path.GetFileName(p).ToLowerInvariant() != ScriptConstants.FunctionMetadataFileName).ToArray();

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -495,6 +495,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 textArgValue, ApiHubTestHelper.EntityId5);
         }
 
+        [Fact]
+        public void ExcludedFunction_NotAddedToHost()
+        {
+            // Make sure the function was not registered
+            var function = Fixture.Host.Functions.SingleOrDefault(p => string.Compare(p.Name, "Excluded") == 0);
+            Assert.Null(function);
+
+            // Make sure the host log was written
+            var trace = Fixture.TraceWriter.Traces.SingleOrDefault(p => p.Message == "Function 'Excluded' is marked as excluded");
+            Assert.NotNull(trace);
+            Assert.Equal(TraceLevel.Info, trace.Level);
+        }
+
         public class TestFixture : EndToEndTestFixture
         {
             public TestFixture() : base(@"TestScripts\Node", "node")

--- a/test/WebJobs.Script.Tests/TestScripts/Node/Excluded/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Excluded/function.json
@@ -1,0 +1,10 @@
+﻿{
+    "excluded": true,
+    "bindings": [
+        {
+            "type": "manualTrigger",
+            "name": "input",
+            "direction": "in"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/Excluded/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Excluded/index.js
@@ -1,0 +1,3 @@
+﻿module.exports = function (context, input) {
+    context.done();
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -467,6 +467,9 @@
     <None Include="TestScripts\Node\DocumentDBIn\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\Node\Excluded\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Node\HttpTriggerByteArray\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -510,6 +513,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\BlobTriggerToBlob\index.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestScripts\Node\Excluded\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\HttpTriggerByteArray\index.js">


### PR DESCRIPTION
Adding a simple way to mark a function in metadata so that it will be completely ignored by the runtime. An **excluded** function will not be compiled (in the case of C#) and is not loaded into the host. That contrasts with a **disabled** function, which IS compiled and loaded into the host, but is not automatically triggered or publically addressable (except via admin requests).

This can be useful for many reasons, however the reason I needed this is because the SendGrid binding is only loaded if the SendGrid API key is configured. That meant that the sample I have checked in would actually generate a compilation error. I can now exclude this - to run the sample, a user just configures the SendGrid key correctly, and enables the function.

Note that if you guys like this feature, I'll also have to make a corresponding Kudu update [here](https://github.com/projectkudu/kudu/blob/master/Kudu.Core/Functions/FunctionManager.cs#L54).