### PR TITLE
Formatting exception source to simplify assembly name output

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
@@ -94,6 +94,22 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
+        public override void OnError(Exception ex)
+        {
+            string error = Utility.FlattenException(ex, s =>
+            {
+                string baseAssemblyName = FunctionAssemblyLoader.GetAssemblyNameFromMetadata(Metadata, string.Empty);
+                if (s != null && s.StartsWith(baseAssemblyName))
+                {
+                    return Metadata.Name;
+                }
+
+                return s;
+            });
+
+            TraceError(error);
+        }
+
         private void ReloadScript()
         {
             // Reset cached function

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -50,7 +50,13 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public virtual void OnError(Exception ex)
         {
             string error = Utility.FlattenException(ex);
-            TraceWriter.Error(error);
+
+            TraceError(error);
+        }
+
+        protected virtual void TraceError(string errorMessage)
+        {
+            TraceWriter.Error(errorMessage);
 
             // when any errors occur, we want to flush immediately
             TraceWriter.Flush();

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -26,10 +26,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return functionName;
         }
 
-        public static string FlattenException(Exception ex)
+        public static string FlattenException(Exception ex, Func<string, string> sourceFormatter = null)
         {
             StringBuilder flattenedErrorsBuilder = new StringBuilder();
             string lastError = null;
+            sourceFormatter = sourceFormatter ?? ((s) => s);
 
             if (ex is AggregateException)
             {
@@ -41,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 StringBuilder currentErrorBuilder = new StringBuilder();
                 if (!string.IsNullOrEmpty(ex.Source))
                 {
-                    currentErrorBuilder.AppendFormat("{0}: ", ex.Source);
+                    currentErrorBuilder.AppendFormat("{0}: ", sourceFormatter(ex.Source));
                 }
 
                 currentErrorBuilder.Append(ex.Message);


### PR DESCRIPTION
Resolves #378 

With this change, exception sources using the dynamically generated assembly name (e.g. `ƒ-HttpTrigger-CSharp#ℛ*9f68e571-38dc-4f3c-93d9-d21c43f2c5db#3-0`) will be converted to the simple function name.