### PR TITLE
Adding process ID to log file names

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FileTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileTraceWriter.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script
         internal const int LogFlushIntervalMs = 1000;
         private readonly string _logFilePath;
         private readonly string _instanceId;
+        private readonly int _processId;
+
         private readonly DirectoryInfo _logDirectory;
         private static object _syncLock = new object();
         private FileInfo _currentLogFileInfo;
@@ -33,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             _logFilePath = logFilePath;
             _instanceId = GetInstanceId();
+            _processId = Process.GetCurrentProcess().Id;
 
             _logDirectory = new DirectoryInfo(logFilePath);
             if (!_logDirectory.Exists)
@@ -204,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // we include a machine identifier in the log file name to ensure we don't have any
             // log file contention between scaled out instances
-            string filePath = Path.Combine(_logFilePath, string.Format(CultureInfo.InvariantCulture, "{0}-{1}.log", DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssK"), _instanceId));
+            string filePath = Path.Combine(_logFilePath, string.Format(CultureInfo.InvariantCulture, "{0}-{1}-{2}.log", DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssK"), _instanceId, _processId));
             _currentLogFileInfo = new FileInfo(filePath);
         }
 


### PR DESCRIPTION
@davidebbo, @suwatch this is from the conversation we had earlier.

Enhancing the change to log file names to add the process id, so log files will have the following format: `<timestamp>-<instanceid>-<processed>.log`