### PR TITLE
Ensure reinitialize appSettings after standby mode

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -40,6 +40,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _webHostSettings = webHostSettings;
         }
 
+        // Same as Kudu logic
+        public static bool IsAzureEnvironment
+        {
+            get { return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID")); }
+        }
+
         private IDictionary<string, FunctionDescriptor> HttpFunctions { get; set; }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
We need to reinitialize appSettings once switch from standby warmup to actual mode.  This change scopes to Azure only.