### PR TITLE
Adding config option to enable/disable role detection

### DIFF
--- a/src/WebJobs.Script.Host/Program.cs
+++ b/src/WebJobs.Script.Host/Program.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Azure.WebJobs.Script.Host
 
             ScriptHostConfiguration config = new ScriptHostConfiguration()
             {
-                RootScriptPath = rootPath
+                RootScriptPath = rootPath,
+                RoleDetectionEnabled = true
             };
 
             ScriptHostManager scriptHostManager = new ScriptHostManager(config);

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -184,7 +184,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 RootScriptPath = scriptPath,
                 RootLogPath = logPath,
                 FileLoggingEnabled = true,
-                FileWatchingEnabled = !ScriptHost.InStandbyMode
+                FileWatchingEnabled = !ScriptHost.InStandbyMode,
+                RoleDetectionEnabled = !ScriptHost.InStandbyMode
             };
 
             // If running on Azure Web App, derive the host ID from the site name

--- a/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
+++ b/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
@@ -55,6 +55,13 @@ namespace Microsoft.Azure.WebJobs.Script
         public bool FileLoggingEnabled { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether host role detection should be enabled.
+        /// The default is false, which will disable automatic primary host detection,
+        /// and <see cref="ScriptHost.IsPrimary"/> will be true.
+        /// </summary>
+        public bool RoleDetectionEnabled { get; set; }
+
+        /// <summary>
         /// Gets the list of functions that should be run. This list can be used to filter
         /// the set of functions that will be enabled - it can be a subset of the actual
         /// function directories. When left null (the default) all discovered functions will


### PR DESCRIPTION
Adding a host config setting to disable the automatic role/primary host detection and having the feature disabled in the end-to-end tests.