### PR TITLE
Fixing tests leaking host

### DIFF
--- a/test/WebJobs.Script.Tests/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionDescriptorProviderTests.cs
@@ -12,9 +12,10 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class FunctionDescriptorProviderTests
+    public class FunctionDescriptorProviderTests : IDisposable
     {
         private readonly FunctionDescriptorProvider _provider;
+        private readonly ScriptHost _host;
 
         public FunctionDescriptorProviderTests()
         {
@@ -23,8 +24,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 RootScriptPath = rootPath
             };
-            ScriptHost host = ScriptHost.Create(config);
-            _provider = new TestDescriptorProvider(host, config);
+
+            _host = ScriptHost.Create(config);
+            _provider = new TestDescriptorProvider(_host, config);
         }
 
         [Fact]
@@ -87,6 +89,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
 
             Assert.Equal("A valid name must be assigned to the binding.", ex.Message);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _host?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
         }
 
         private class TestDescriptorProvider : FunctionDescriptorProvider

--- a/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/NodeFunctionGenerationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -192,13 +193,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 RootScriptPath = rootPath
             };
-            ScriptHost host = ScriptHost.Create(scriptConfig);
-            FunctionDescriptorProvider[] descriptorProviders = new FunctionDescriptorProvider[]
-            {
-                new NodeFunctionDescriptorProvider(host, scriptConfig)
-            };
 
-            var functionDescriptors = host.ReadFunctions(metadatas, descriptorProviders);
+            Collection<FunctionDescriptor> functionDescriptors = null;
+            using (ScriptHost host = ScriptHost.Create(scriptConfig))
+            {
+                FunctionDescriptorProvider[] descriptorProviders = new FunctionDescriptorProvider[]
+                {
+                new NodeFunctionDescriptorProvider(host, scriptConfig)
+                };
+
+                functionDescriptors = host.ReadFunctions(metadatas, descriptorProviders);
+            }
+
             Type t = FunctionGenerator.Generate("TestScriptHost", "Host.Functions", functionDescriptors);
 
             MethodInfo method = t.GetMethods(BindingFlags.Public | BindingFlags.Static).First();

--- a/test/WebJobs.Script.Tests/TestScripts/PowerShellFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/TestScripts/PowerShellFunctionGenerationTests.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.TestScripts
                 Type = "HttpTrigger",
                 Name = inputBindingName
             };
-            var scriptHostInfo = GetScriptHostInfo();
-            MethodInfo method = GenerateMethod(trigger, scriptHostInfo);
 
+            MethodInfo method = method = GenerateMethod(trigger);
+           
             VerifyCommonProperties(method);
 
             // verify trigger parameter
@@ -54,8 +54,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.TestScripts
                 { "direction", "in" },
                 { "queueName", "test" }
             });
-            var scriptHostInfo = GetScriptHostInfo();
-            MethodInfo method = GenerateMethod(trigger, scriptHostInfo);
+
+            MethodInfo method = method = GenerateMethod(trigger);
 
             VerifyCommonProperties(method);
 
@@ -86,12 +86,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.TestScripts
                 { "QueueName", "test" }
             };
 
-            var scriptHostInfo = GetScriptHostInfo();
-            Exception ex = Assert.Throws<InvalidOperationException>(() => GenerateMethod(trigger, scriptHostInfo));
-            Assert.Equal("Sequence contains no elements", ex.Message);
-            
-            var functionError = scriptHostInfo.Host.FunctionErrors[FunctionName];
-            Assert.True(functionError.Contains(expectedError));
+            using (var scriptHostInfo = GetScriptHostInfo())
+            {
+                Exception ex = Assert.Throws<InvalidOperationException>(() => GenerateMethod(trigger, scriptHostInfo));
+                Assert.Equal("Sequence contains no elements", ex.Message);
+
+                var functionError = scriptHostInfo.Host.FunctionErrors[FunctionName];
+                Assert.True(functionError.Contains(expectedError));
+            }
         }
 
         private static void VerifyCommonProperties(MethodInfo method)
@@ -115,6 +117,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.TestScripts
             parameter = parameters[3];
             Assert.Equal("context", parameter.Name);
             Assert.Equal(typeof(ExecutionContext), parameter.ParameterType);
+        }
+
+        private static MethodInfo GenerateMethod(BindingMetadata trigger)
+        {
+            using (var scriptHostInfo = GetScriptHostInfo())
+            {
+                return GenerateMethod(trigger, scriptHostInfo);
+            }
         }
 
         private static MethodInfo GenerateMethod(BindingMetadata trigger, ScriptHostInfo scriptHostInfo)
@@ -146,18 +156,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.TestScripts
             {
                 RootScriptPath = rootPath
             };
-            ScriptHost host = ScriptHost.Create(scriptConfig);
-            return new ScriptHostInfo { Host = host, Configuration = scriptConfig, RootPath = rootPath };
+            var host = ScriptHost.Create(scriptConfig);
+            return new ScriptHostInfo(host, scriptConfig, rootPath);
         }
     }
 
     [SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
-    internal class ScriptHostInfo
+    internal class ScriptHostInfo : IDisposable
     {
-        public ScriptHost Host { get; set; }
+        public ScriptHostInfo(ScriptHost host, ScriptHostConfiguration config, string rootPath)
+        {
+            Host = host;
+            Configuration = config;
+            RootPath = rootPath;
+        }
 
-        public ScriptHostConfiguration Configuration { get; set; }
+        public ScriptHost Host { get; }
 
-        public string RootPath { get; set; }
+        public ScriptHostConfiguration Configuration { get; }
+
+        public string RootPath { get; }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Host.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
     }
 }


### PR DESCRIPTION
Fixing some tests that were failing to dispose of the `ScriptHost`. This was causing multiple instances of the host to run over each other and stick around longer than needed.