### PR TITLE
Fixing file logging issue

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FileTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileTraceWriter.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.WebJobs.Script
         internal const int LogFlushIntervalMs = 1000;
         private readonly string _logFilePath;
         private readonly string _instanceId;
-        private readonly int _processId;
 
         private readonly DirectoryInfo _logDirectory;
         private static object _syncLock = new object();
@@ -35,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             _logFilePath = logFilePath;
             _instanceId = GetInstanceId();
-            _processId = Process.GetCurrentProcess().Id;
 
             _logDirectory = new DirectoryInfo(logFilePath);
             if (!_logDirectory.Exists)
@@ -207,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // we include a machine identifier in the log file name to ensure we don't have any
             // log file contention between scaled out instances
-            string filePath = Path.Combine(_logFilePath, string.Format(CultureInfo.InvariantCulture, "{0}-{1}-{2}.log", DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssK"), _instanceId, _processId));
+            string filePath = Path.Combine(_logFilePath, string.Format(CultureInfo.InvariantCulture, "{0}-{1}.log", DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssK"), _instanceId));
             _currentLogFileInfo = new FileInfo(filePath);
         }
 

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -86,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
                     if (_traceWriter != null)
                     {
-                        _traceWriter.Info(string.Format("Starting Host (Id={0})", newInstance.ScriptConfig.HostConfig.HostId));
+                        _traceWriter.Info(string.Format("Starting Host (HostId={0}, ProcessId={1})", newInstance.ScriptConfig.HostConfig.HostId, Process.GetCurrentProcess().Id));
                     }
                     newInstance.StartAsync(cancellationToken).GetAwaiter().GetResult();
 

--- a/src/src.ruleset
+++ b/src/src.ruleset
@@ -21,5 +21,6 @@
     <Rule Id="CA1800" Action="None" />
     <Rule Id="CA1307" Action="None" />
     <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA2204" Action="None" />
   </Rules>
 </RuleSet>

--- a/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/FileTraceWriterTests.cs
@@ -116,6 +116,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(1, files.Length);
         }
 
+        [Fact]
+        public void WriteLogs_ReusesLastFile()
+        {
+            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
+            directory.Create();
+
+            int count = directory.EnumerateFiles().Count();
+            Assert.Equal(0, count);
+
+            for (int i = 0; i < 3; i++)
+            {
+                FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose);
+                traceWriter.Verbose("Testing");
+                traceWriter.Flush();
+            }
+
+            count = directory.EnumerateFiles().Count();
+            Assert.Equal(1, count);
+
+            string logFile = directory.EnumerateFiles().First().FullName;
+            string[] fileLines = File.ReadAllLines(logFile);
+            Assert.Equal(3, fileLines.Length);
+        }
+
         private void WriteLogs(string logFilePath, int numLogs)
         {
             FileTraceWriter traceWriter = new FileTraceWriter(logFilePath, TraceLevel.Verbose);


### PR DESCRIPTION
Commit https://github.com/Azure/azure-webjobs-sdk-script/commit/f5b12d970863a487aa204c7d6730bae779293a26  introduced a bad regression where each time the host starts/restarts, it will create a new host log file.