### PR TITLE
Updating lock container name

### DIFF
--- a/src/WebJobs.Script/Host/BlobLeaseManager.cs
+++ b/src/WebJobs.Script/Host/BlobLeaseManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script
     internal sealed class BlobLeaseManager : IDisposable
     {
         internal const string LockBlobName = "host";
-        internal const string HostContainerName = "azure-functions-host";
+        internal const string HostContainerName = "azure-webjobs-hosts";
 
         private readonly Timer _timer;
         private readonly TimeSpan _leaseTimeout;


### PR DESCRIPTION
This change updates the container name to match what is used by the core WebJobs SDK