### PR TITLE
Fixing Node value serialization issue (#520)

### DIFF
--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly Collection<FunctionBinding> _outputBindings;
         private readonly string _script;
         private readonly DictionaryJsonConverter _dictionaryJsonConverter = new DictionaryJsonConverter();
+        private static readonly ExpandoObjectJsonConverter _expandoObjectJsonConverter = new ExpandoObjectJsonConverter();
         private readonly BindingMetadata _trigger;
         private readonly IMetricsLogger _metrics;
         private readonly string _entryPoint;
@@ -186,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             executionContext["_inputs"] = inputs;
         }
 
-        private static async Task ProcessOutputBindingsAsync(Collection<FunctionBinding> outputBindings, object input, Binder binder, 
+        private static async Task ProcessOutputBindingsAsync(Collection<FunctionBinding> outputBindings, object input, Binder binder,
             Dictionary<string, object> bindingData, Dictionary<string, object> scriptExecutionContext, object functionResult)
         {
             if (outputBindings == null)
@@ -212,11 +213,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 object value = null;
                 if (bindings.TryGetValue(binding.Metadata.Name, out value) && value != null)
                 {
-                    if (value.GetType() == typeof(ExpandoObject) ||
-                        (value is Array && value.GetType() != typeof(byte[])))
-                    {
-                        value = JsonConvert.SerializeObject(value);
-                    }
+                    value = ConvertBindingValue(value);
 
                     BindingContext bindingContext = new BindingContext
                     {
@@ -228,6 +225,23 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     await binding.BindAsync(bindingContext);
                 }
             }
+        }
+
+        /// <summary>
+        /// Perform any necessary conversions on the binding value received
+        /// from the script.
+        /// </summary>
+        internal static object ConvertBindingValue(object value)
+        {
+            if (value.GetType() == typeof(ExpandoObject) ||
+               (value is Array && value.GetType() != typeof(byte[])))
+            {
+                // objects and arrays we serialize to string before
+                // passing to the binding layer
+                value = JsonConvert.SerializeObject(value, _expandoObjectJsonConverter);
+            }
+
+            return value;
         }
 
         protected override void OnScriptFileChanged(object sender, FileSystemEventArgs e)
@@ -274,7 +288,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                         // TraceWriter. Might happen if a function tries to
                         // log after calling done()
                     }
-                } 
+                }
 
                 return Task.FromResult<object>(null);
             });
@@ -395,10 +409,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private static bool IsEdgeSupportedType(Type type)
         {
-            if (type == typeof(int) || 
-                type == typeof(double) || 
-                type == typeof(string) || 
-                type == typeof(bool) || 
+            if (type == typeof(int) ||
+                type == typeof(double) ||
+                type == typeof(string) ||
+                type == typeof(bool) ||
                 type == typeof(byte[]) ||
                 type == typeof(object[]))
             {

--- a/src/WebJobs.Script/ExpandoObjectJsonConverter.cs
+++ b/src/WebJobs.Script/ExpandoObjectJsonConverter.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal class ExpandoObjectJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ExpandoObject);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            WriteExpandoObject(writer, (ExpandoObject)value, serializer);
+        }
+
+        private static void WriteExpandoObject(JsonWriter writer, ExpandoObject value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            var values = value as IDictionary<string, object>;
+            foreach (var pair in values)
+            {
+                if (pair.Value != null && pair.Value is Delegate)
+                {
+                    // skip types like Functions, etc.
+                    continue;
+                }
+
+                writer.WritePropertyName(pair.Key);
+
+                if (pair.Value is ExpandoObject)
+                {
+                    WriteExpandoObject(writer, (ExpandoObject)pair.Value, serializer);
+                }
+                else
+                {
+                    serializer.Serialize(writer, pair.Value);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Diagnostics\MetricEvent.cs" />
     <Compile Include="Diagnostics\MetricsLogger.cs" />
     <Compile Include="Diagnostics\HostStartedEvent.cs" />
+    <Compile Include="ExpandoObjectJsonConverter.cs" />
     <Compile Include="Extensions\TraceWriterExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Extensions\INameResolverExtensions.cs" />

--- a/test/WebJobs.Script.Tests/NodeFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/NodeFunctionInvokerTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class NodeFunctionInvokerTests
+    {
+        [Fact]
+        public static void ConvertBindingValue_PerformsExpectedConversions()
+        {
+            var c = new ExpandoObject() as IDictionary<string, object>;
+            c["A"] = "Testing";
+            c["B"] = 1234;
+            c["C"] = new object[] { 1, "Two", 3 };
+
+            // don't expect functions to be serialized
+            c["D"] = (Func<object, Task<object>>)(p => { return Task.FromResult<object>(null); });
+
+            var o = new ExpandoObject() as IDictionary<string, object>;
+            o["A"] = "Testing";
+            o["B"] = c;
+
+            string json = (string)NodeFunctionInvoker.ConvertBindingValue(o);
+            Assert.Equal("{\"A\":\"Testing\",\"B\":{\"A\":\"Testing\",\"B\":1234,\"C\":[1,\"Two\",3]}}", json.Replace(" ", string.Empty));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -336,6 +336,7 @@
     <Compile Include="FunctionGeneratorTests.cs" />
     <Compile Include="Description\DotNet\CSharp\PackageAssemblyResolverTests.cs" />
     <Compile Include="MetricsEventManagerTests.cs" />
+    <Compile Include="NodeFunctionInvokerTests.cs" />
     <Compile Include="PowerShellInvokerTests.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
See https://github.com/Azure/azure-webjobs-sdk-script/issues/520 for details.

The issue was that if the value returned from script had a function property, it blew up in Json serialization.