### PR TITLE
HttpBinding improvements

### DIFF
--- a/sample/HttpTrigger-Powershell/run.ps1
+++ b/sample/HttpTrigger-Powershell/run.ps1
@@ -7,4 +7,4 @@ else
 	$message = "Please pass a name on the query string"
 }
 
-Out-File -Encoding Ascii $res -inputObject $message;
+[io.file]::WriteAllText($res, $message)

--- a/sample/HttpTrigger/index.js
+++ b/sample/HttpTrigger/index.js
@@ -9,16 +9,19 @@
     if (typeof req.query.name == 'undefined') {
         context.res = {
             status: 400,
-            body: "Please pass a name on the query string"
+            body: "Please pass a name on the query string",
+            headers: {
+                'Content-Type': 'text/plain'
+            }
         };
     }
     else {
         context.res = {
             status: 200,
-            body: "Hello " + req.query.name
-        };
-        context.res.headers = {
-            'Content-Type': 'text/plain'
+            body: "Hello " + req.query.name,
+            headers: {
+                'Content-Type': 'text/plain'
+            }
         };
     }
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             // Get the response
             HttpResponseMessage response = null;
-            if (!request.Properties.TryGetValue<HttpResponseMessage>("MS_AzureFunctionsHttpResponse", out response))
+            if (!request.Properties.TryGetValue<HttpResponseMessage>(ScriptConstants.AzureFunctionsHttpResponseKey, out response))
             {
                 // the function was successful but did not write an explicit response
                 response = new HttpResponseMessage(HttpStatusCode.OK);

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -211,7 +211,17 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 // get the output value from the script
                 object value = null;
-                if (bindings.TryGetValue(binding.Metadata.Name, out value) && value != null)
+                bool haveValue = bindings.TryGetValue(binding.Metadata.Name, out value);
+                if (!haveValue && binding.Metadata.Type == "http")
+                {
+                    // http bindings support a special context.req/context.res programming
+                    // model, so we must map that back to the actual binding name if a value
+                    // wasn't provided using the binding name itself
+                    haveValue = bindings.TryGetValue("res", out value);
+                }
+
+                // apply the value to the binding
+                if (haveValue && value != null)
                 {
                     value = ConvertBindingValue(value);
 

--- a/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
@@ -11,9 +11,7 @@ using Microsoft.Azure.WebJobs.Script.Tests.ApiHub;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Queue;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Tests.ApiHub;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -97,6 +98,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new ByteArrayContent(inputBytes)
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
@@ -105,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("HttpTriggerByteArray", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             JObject testResult = await GetFunctionTestResult("HttpTriggerByteArray");
@@ -344,15 +346,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RequestUri = new Uri(string.Format("http://localhost/api/httptrigger?name=Mathew%20Charles&location=Seattle")),
                 Method = HttpMethod.Get,
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Headers.Add("test-header", "Test Request Header");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
-                { "req", request }
+                { "request", request }
             };
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             Assert.Equal("Test Response Header", response.Headers.GetValues("test-header").SingleOrDefault());
@@ -374,6 +377,71 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task HttpTrigger_Scenarios_ScalarReturn_InBody()
+        {
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(string.Format("http://localhost/api/httptrigger-scenarios")),
+                Method = HttpMethod.Post,
+            };
+            request.SetConfiguration(new HttpConfiguration());
+
+            JObject value = new JObject()
+            {
+                { "status", "200" },
+                { "body", 123 }
+            };
+            JObject input = new JObject()
+            {
+                { "scenario", "echo" },
+                { "value", value }
+            };
+            request.Content = new StringContent(input.ToString());
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "req", request }
+            };
+            await Fixture.Host.CallAsync("HttpTrigger-Scenarios", arguments);
+
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(123, await response.Content.ReadAsAsync<int>());
+        }
+
+        [Fact]
+        public async Task HttpTrigger_Scenarios_ScalarReturn()
+        {
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(string.Format("http://localhost/api/httptrigger-scenarios")),
+                Method = HttpMethod.Post,
+            };
+            request.SetConfiguration(new HttpConfiguration());
+
+            JObject input = new JObject()
+            {
+                { "scenario", "echo" },
+                { "value", 123 }
+            };
+            request.Content = new StringContent(input.ToString());
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "req", request }
+            };
+            await Fixture.Host.CallAsync("HttpTrigger-Scenarios", arguments);
+
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(123, await response.Content.ReadAsAsync<int>());
+        }
+
+        [Fact]
         public async Task HttpTrigger_Post_PlainText()
         {
             string testData = Guid.NewGuid().ToString();
@@ -383,14 +451,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(testData)
             };
+            request.SetConfiguration(new HttpConfiguration());
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
-                { "req", request }
+                { "request", request }
             };
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();
@@ -416,15 +485,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(rawBody)
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
-                { "req", request }
+                { "request", request }
             };
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();
@@ -486,15 +556,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(rawBody)
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
-                { "req", request }
+                { "request", request }
             };
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();
@@ -527,6 +598,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(testObject.ToString())
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
@@ -535,7 +607,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("WebHookTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();

--- a/test/WebJobs.Script.Tests/PowerShellEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/PowerShellEndToEndTests.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json.Linq;
@@ -48,6 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RequestUri = new Uri("http://localhost/api/httptrigger-powershell?code=1388a6b0d05eca2237f10e4a4641260b0a08f3a5&name=testuser"),
                 Method = HttpMethod.Get
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Headers.Add(testHeader, testHeaderValue);
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
@@ -56,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("HttpTrigger-PowerShell", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string result = await response.Content.ReadAsStringAsync();
@@ -78,6 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                         "http://localhost/api/httptrigger-powershellwitherror?code=1388a6b0d05eca2237f10e4a4641260b0a08f3a5&name=testuser"),
                 Method = HttpMethod.Get
             };
+            request.SetConfiguration(new HttpConfiguration());
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
@@ -112,6 +115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(testData)
             };
+            request.SetConfiguration(new HttpConfiguration());
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
@@ -119,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("HttpTrigger-PowerShell", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string result = await response.Content.ReadAsStringAsync();

--- a/test/WebJobs.Script.Tests/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/SamplesEndToEndTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string body = await response.Content.ReadAsStringAsync();
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal("Hello testuser", body.Trim());
+            Assert.Equal("Hello testuser", body);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/TestScripts/Node/HttpTrigger-Scenarios/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/HttpTrigger-Scenarios/function.json
@@ -2,13 +2,13 @@
     "bindings": [
         {
             "type": "httpTrigger",
-            "name": "request",
+            "name": "req",
             "direction": "in",
             "methods": [ "get", "post" ]
         },
         {
             "type": "http",
-            "name": "response",
+            "name": "res",
             "direction": "out"
         }
     ]

--- a/test/WebJobs.Script.Tests/TestScripts/Node/HttpTrigger-Scenarios/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/HttpTrigger-Scenarios/index.js
@@ -1,0 +1,16 @@
+﻿var util = require('util');
+
+module.exports = function (context, req) {
+    var scenario = req.body.scenario;
+
+    if (scenario == "echo") {
+        context.res = req.body.value;
+    }
+    else {
+        context.res = {
+            status: 400
+        };
+    }
+
+    context.done();
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -668,6 +668,9 @@
     <None Include="TestScripts\Node\Excluded\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\Node\HttpTrigger-Scenarios\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Node\HttpTriggerByteArray\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -717,6 +720,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\Excluded\index.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestScripts\Node\HttpTrigger-Scenarios\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\HttpTriggerByteArray\index.js">

--- a/test/WebJobs.Script.Tests/WindowsBatchEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/WindowsBatchEndToEndTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -34,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(testObject.ToString(Formatting.None))
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
@@ -42,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("WebHookTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();
@@ -59,6 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RequestUri = new Uri(string.Format("http://localhost/api/httptrigger?value={0}", testData)),
                 Method = HttpMethod.Get
             };
+            request.SetConfiguration(new HttpConfiguration());
             request.Headers.Add("test-header", "Test Request Header");
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
@@ -67,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();
@@ -78,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             request.RequestUri = new Uri(string.Format("http://localhost/api/httptrigger", testData));
             request.Headers.Clear();
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
-            response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             body = await response.Content.ReadAsStringAsync();   
             Assert.Equal("Please pass a value on the query string", body.Trim());
@@ -94,6 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Method = HttpMethod.Post,
                 Content = new StringContent(testData)
             };
+            request.SetConfiguration(new HttpConfiguration());
 
             Dictionary<string, object> arguments = new Dictionary<string, object>
             {
@@ -101,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await Fixture.Host.CallAsync("HttpTrigger", arguments);
 
-            HttpResponseMessage response = (HttpResponseMessage)request.Properties["MS_AzureFunctionsHttpResponse"];
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string body = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
Cleaning up + improving HttpBinding. Previously you couldn't return a simple scalar value from a function, e.g.:

```javascript
module.exports = function (context, req) {
    context.res = 123;
    context.done();
}
```

This now works. We now use HttpRequestMessage.CreateResponse and let WebApi do its default thing in these scenarios.