### PR TITLE
Workaround for Promise.resolve and process.nextTick edgejs issue

### DIFF
--- a/src/WebJobs.Script/Description/Node/Script/functionTemplate.js
+++ b/src/WebJobs.Script/Description/Node/Script/functionTemplate.js
@@ -5,6 +5,9 @@ var f = require('{0}'),
     util = require('util');
 
 return function (context, callback) {{
+    // TEMP HACK: workaround for https://github.com/tjanczuk/edge/issues/325
+    setImmediate(() => {{}});
+
     f = getEntryPoint(f, context);
 
     var origLog = context.log;

--- a/src/WebJobs.Script/Description/Node/Script/globalInitialization.js
+++ b/src/WebJobs.Script/Description/Node/Script/globalInitialization.js
@@ -8,9 +8,6 @@ return function (context, callback) {{
         context.handleUncaughtException(err.stack);
     }});
 
-    // TEMP HACK: workaround for https://github.com/tjanczuk/edge/issues/325
-    process.nextTick = global.setImmediate;
-
     callback();
 }};
 

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -703,13 +703,34 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     { "input", input.ToString() }
                 });
 
-            await TestHelpers.Await(() =>
+            Task result = await Task.WhenAny(t, Task.Delay(5000));
+            Assert.Same(t, result);
+            if (t.IsFaulted)
             {
-                return t.IsCompleted;
-            }, timeout: 5000, pollingInterval: 1000);
+                throw t.Exception;
+            }
+        }
 
-            // Await the task to force any exception to be thrown
-            await t;
+        [Fact]
+        public async Task PromiseResolve()
+        {
+            JObject input = new JObject
+            {
+                { "scenario", "promiseResolve" }
+            };
+
+            Task t = Fixture.Host.CallAsync("Scenarios",
+                new Dictionary<string, object>()
+                {
+                    { "input", input.ToString() }
+                });
+
+            Task result = await Task.WhenAny(t, Task.Delay(5000));
+            Assert.Same(t, result);
+            if (t.IsFaulted)
+            {
+                throw t.Exception;
+            }
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
@@ -15,6 +15,9 @@ var assert = require('assert');
             context.done();
         });
     }
+    else if (scenario == 'promiseResolve') {
+        Promise.resolve().then(() => context.done());
+    }
     else if (scenario == 'randGuid') {
         context.bindings.blob = input.value;
         context.done();


### PR DESCRIPTION
addresses #223 #241 #596 

`process.nextTick = global.setImmediate` could break packages which use `nextTick` and it doesn't fix issues with `Promise.resolve(...)`, so I'm removing it.

A call to `setImmediate` with a dummy function adds an item to the back of the event queue, which unblocks `process.nextTick` and `Promise.resolve(...)`.  I've tested this workaround with YQL, request, Promise, Q, Bluebird, and nextTick, and it unblocks all issues even in nested or chained workflows.  

I believe that the problems with the event loop are due to edge.js' initialization.  However, it is possible that this hung state can be encountered from some order of an events which I haven't tested, in which case the single `setImmediate` call won't be enough.

I've filed an issue with edge.js (https://github.com/tjanczuk/edge/issues/485) and I may follow up trying to pinpoint the root cause as I get more time.