### PR TITLE
Remove double brackets from node scripts

### DIFF
--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -37,12 +37,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private Func<object, Task<object>> _scriptFunc;
         private static Func<object, Task<object>> _clearRequireCache;
         private static Func<object, Task<object>> _globalInitializationFunc;
+        private static string _scriptRequire;
         private static string _functionTemplate;
         private static string _clearRequireCacheScript;
         private static string _globalInitializationScript;
 
         static NodeFunctionInvoker()
         {
+            _scriptRequire = ReadResourceString("scriptRequire.js");
             _functionTemplate = ReadResourceString("functionTemplate.js");
             _clearRequireCacheScript = ReadResourceString("clearRequireCache.js");
             _globalInitializationScript = ReadResourceString("globalInitialization.js");
@@ -56,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             _trigger = trigger;
             string scriptFilePath = functionMetadata.ScriptFile.Replace('\\', '/');
-            _script = string.Format(CultureInfo.InvariantCulture, _functionTemplate, scriptFilePath);
+            _script = string.Format(CultureInfo.InvariantCulture, _scriptRequire, scriptFilePath, _functionTemplate);
             _inputBindings = inputBindings;
             _outputBindings = outputBindings;
             _entryPoint = functionMetadata.EntryPoint;

--- a/src/WebJobs.Script/Description/Node/Script/functionTemplate.js
+++ b/src/WebJobs.Script/Description/Node/Script/functionTemplate.js
@@ -1,77 +1,78 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-var f = require('{0}'),
-    util = require('util');
+// Included from scriptRequire.js
+// var f = require('path-to-function');
+var util = require('util');
 
-return function (context, callback) {{
+return function (context, callback) {
     f = getEntryPoint(f, context);
 
     var origLog = context.log;
-    context.log = function() {{
+    context.log = function() {
         value = util.format.apply(null, arguments);
         origLog(value);
-    }};
+    };
 
-    context.done = function(err, result) {{
-        if (context._done) {{
+    context.done = function(err, result) {
+        if (context._done) {
             context.log("Error: 'done' has already been called. Please check your script for extraneous calls to 'done'.");
             return;
-        }}
+        }
         context._done = true;
 
-        if (err) {{
+        if (err) {
             callback(err);
-        }}
-        else {{
-            var values = {{}};
-            if (context.res) {{
+        }
+        else {
+            var values = {};
+            if (context.res) {
                 context.bindings.res = context.res;
-            }}
-            for (var name in context.bindings) {{
+            }
+            for (var name in context.bindings) {
                 values[name] = context.bindings[name];
-            }}
-            context.bind(values, function(err) {{
+            }
+            context.bind(values, function(err) {
                 callback(err, result);
-            }});
-        }}
-    }};
+            });
+        }
+    };
 
     var inputs = context._inputs;
     inputs.unshift(context);
     delete context._inputs;
 
     f.apply(null, inputs);
-}};
+};
 
-function getEntryPoint(f, context) {{
-    if (util.isObject(f)) {{
-        if (context._entryPoint) {{
+function getEntryPoint(f, context) {
+    if (util.isObject(f)) {
+        if (context._entryPoint) {
             // the module exports multiple functions
             // and an explicit entry point was named
             f = f[context._entryPoint];
             delete context._entryPoint;
-        }}
-        else if (Object.keys(f).length == 1) {{
+        }
+        else if (Object.keys(f).length == 1) {
             // a single named function was exported
             f = f[Object.keys(f)[0]];
-        }}
-        else {{
+        }
+        else {
             // finally, see if there is an exported function named
             // 'run' by convention
             f = f['run'];
-        }}
-    }}
-    else if (!util.isFunction(f)) {{
+        }
+    }
+    else if (!util.isFunction(f)) {
         // the module must export an object or a function
         f = null;
-    }}
+    }
 
-    if (!f) {{
+    if (!f) {
         throw "Unable to determine function entry point. If multiple functions are exported, " +
               "you must indicate the entry point, either by naming it 'run', or by naming it " +
               "explicitly via the 'entryPoint' metadata property.";
-    }}
+    }
 
     return f;
-}}
+}

--- a/src/WebJobs.Script/Description/Node/Script/globalInitialization.js
+++ b/src/WebJobs.Script/Description/Node/Script/globalInitialization.js
@@ -3,14 +3,14 @@
 
 var process = require('process');
 
-return function (context, callback) {{
-    process.on('uncaughtException', function (err) {{
+return function (context, callback) {
+    process.on('uncaughtException', function (err) {
         context.handleUncaughtException(err.stack);
-    }});
+    });
 
     // TEMP HACK: workaround for https://github.com/tjanczuk/edge/issues/325
     process.nextTick = global.setImmediate;
 
     callback();
-}};
+};
 

--- a/src/WebJobs.Script/Description/Node/Script/scriptRequire.js
+++ b/src/WebJobs.Script/Description/Node/Script/scriptRequire.js
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+var f = require('{0}');
+
+// Include contents of functionTemplate.js
+{1}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -449,6 +449,7 @@
       <Link>edge\edge.js</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Description\Node\Script\scriptRequire.js" />
     <EmbeddedResource Include="Description\Node\Script\globalInitialization.js" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
Reordered formatting to make (most) of the node wrapper code a bit cleaner