### PR TITLE
Reuse analyzers to fix memory leak

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         private readonly Compilation _compilation;
 
+        // Simply getting the built in analyzers for now.
+        // This should eventually be enhanced to dynamically discover/load analyzers.
+        private static ImmutableArray<DiagnosticAnalyzer> _analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new InvalidFileMetadataReferenceAnalyzer());
+
         public CSharpCompilation(Compilation compilation)
         {
             _compilation = compilation;
@@ -105,9 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private static ImmutableArray<DiagnosticAnalyzer> GetAnalyzers()
         {
-            // Simply getting the built in analyzers for now.
-            // This should eventually be enhanced to dynamically discover/load analyzers.
-            return ImmutableArray.Create<DiagnosticAnalyzer>(new InvalidFileMetadataReferenceAnalyzer());
+            return _analyzers;
         }
     }
 }


### PR DESCRIPTION
Every compilation was creating a new analyzer array which was getting forever rooted by Roslyn.