### PR TITLE
Improve ResolveAfterDone flakiness

### DIFF
--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -850,13 +850,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
 
             // call multiple times to reduce flakiness (function can exit before Promise.resolve executes)
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < 5; i++)
             {
-                await Task.WhenAny(Fixture.Host.CallAsync("Scenarios", arguments), Task.Delay(5000));
+                await Task.WhenAny(Fixture.Host.CallAsync("Scenarios", arguments), Task.Delay(3000));
             }
 
             var logs = await TestHelpers.GetFunctionLogsAsync("Scenarios");
-
             Assert.True(logs.Any(p => p.Contains("Error: Choose either to return a promise or call 'done'.  Do not use both in your script.")));
             Assert.True(logs.Any(p => p.Contains("Function completed (Success")));
         }

--- a/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
@@ -25,8 +25,7 @@ var assert = require('assert');
         return Promise.reject('reject');
     }
     else if (scenario == 'promiseApiDone') {
-        context.done();
-        return Promise.resolve();
+        return Promise.resolve().then(() => context.done());
     }
     else if (scenario == 'randGuid') {
         context.bindings.blob = input.value;


### PR DESCRIPTION
Tested, after changing to `Promise.resolve().then(() => context.done())` I get logs on ~90% of individual scenario runs.  Bumping the scenario run count to 5 as well.  Still not promising five 9s haha.