### PR TITLE
Fixing compilation warning for $return bindings

### DIFF
--- a/sample/DocumentDB-CSharp/run.csx
+++ b/sample/DocumentDB-CSharp/run.csx
@@ -1,6 +1,6 @@
 ﻿using System;
 
-public static object Run(string input, out object newItem)
+public static object Run(string input)
 {
     return new 
     {

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionDescriptorProviderTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -25,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { "direction", "out" },
                 { "path", "foo/bar" }
             };
-            FunctionBinding functionBinding = CreateTestBlobBinding(json);
+            FunctionBinding functionBinding = TestHelpers.CreateTestBinding(json);
             FunctionBinding[] bindings = new FunctionBinding[] { functionBinding };
 
             ParameterDescriptor descriptor = null;
@@ -60,23 +58,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { "direction", "out" },
                 { "path", "foo/bar" }
             };
-            FunctionBinding functionBinding = CreateTestBlobBinding(json);
+            FunctionBinding functionBinding = TestHelpers.CreateTestBinding(json);
             FunctionBinding[] bindings = new FunctionBinding[] { functionBinding };
 
             ParameterDescriptor descriptor = null;
             var result = DotNetFunctionDescriptorProvider.TryCreateReturnValueParameterDescriptor(typeof(string), bindings, out descriptor);
             Assert.False(result);
-        }
-
-        private static FunctionBinding CreateTestBlobBinding(JObject json)
-        {
-            ScriptBindingContext context = new ScriptBindingContext(json);
-            WebJobsCoreScriptBindingProvider provider = new WebJobsCoreScriptBindingProvider(new JobHostConfiguration(), new JObject(), new TestTraceWriter(TraceLevel.Verbose));
-            ScriptBinding scriptBinding = null;
-            provider.TryCreate(context, out scriptBinding);
-            BindingMetadata bindingMetadata = BindingMetadata.Create(json);
-            ScriptHostConfiguration config = new ScriptHostConfiguration();
-            return new ExtensionBinding(config, scriptBinding, bindingMetadata);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests/TestHelpers.cs
@@ -4,11 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.WindowsAzure.Storage.Blob;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -120,6 +125,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             string functionLogsPath = Path.Combine(Path.GetTempPath(), "Functions", "Function", functionName);
             return new DirectoryInfo(functionLogsPath);
+        }
+
+        public static FunctionBinding CreateTestBinding(JObject json)
+        {
+            ScriptBindingContext context = new ScriptBindingContext(json);
+            WebJobsCoreScriptBindingProvider provider = new WebJobsCoreScriptBindingProvider(new JobHostConfiguration(), new JObject(), new TestTraceWriter(TraceLevel.Verbose));
+            ScriptBinding scriptBinding = null;
+            provider.TryCreate(context, out scriptBinding);
+            BindingMetadata bindingMetadata = BindingMetadata.Create(json);
+            ScriptHostConfiguration config = new ScriptHostConfiguration();
+            return new ExtensionBinding(config, scriptBinding, bindingMetadata);
         }
     }
 }


### PR DESCRIPTION
With the addition of the new $return output binding support, we were outputting incorrect compilation warnings:

2016-09-21T20:58:54.590 warning AF004: Missing binding argument named '$return'. Mismatched binding argument names may lead to function indexing errors.