### PR TITLE
Cardinality Support for Bindings (#618)

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script", "src\WebJobs.Script\WebJobs.Script.csproj", "{1DC670CD-F42F-4D8F-97BD-0E1AA8221094}"
 EndProject
@@ -158,12 +158,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BlobTrigger-FSharp", "BlobT
 	ProjectSection(SolutionItems) = preProject
 		sample\BlobTrigger-FSharp\function.json = sample\BlobTrigger-FSharp\function.json
 		sample\BlobTrigger-FSharp\run.fsx = sample\BlobTrigger-FSharp\run.fsx
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EventHubTrigger", "EventHubTrigger", "{B80C88CF-68EE-4400-A68D-216F1F85179C}"
-	ProjectSection(SolutionItems) = preProject
-		sample\EventHubTrigger\function.json = sample\EventHubTrigger\function.json
-		sample\EventHubTrigger\index.js = sample\EventHubTrigger\index.js
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BlobTrigger-Batch", "BlobTrigger-Batch", "{C23BB3D1-6921-4FCF-8E45-09540E1F986E}"
@@ -373,6 +367,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ServiceBusTopicTrigger", "S
 		sample\ServiceBusTopicTrigger\index.js = sample\ServiceBusTopicTrigger\index.js
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EventHubTrigger", "EventHubTrigger", "{391A580B-AA88-4125-9E83-42B4BC6B9260}"
+	ProjectSection(SolutionItems) = preProject
+		sample\EventHubTrigger-Batch\function.json = sample\EventHubTrigger-Batch\function.json
+		sample\EventHubTrigger-Batch\index.js = sample\EventHubTrigger-Batch\index.js
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -435,7 +435,6 @@ Global
 		{9B95236B-987B-4928-B2CB-561823B38FA2} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{15BA01AE-580C-4FBB-A117-F3B112B4BD02} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{15BA01AE-580C-4FBB-A117-F3B112B4BD03} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
-		{B80C88CF-68EE-4400-A68D-216F1F85179C} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{C23BB3D1-6921-4FCF-8E45-09540E1F986E} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{87E44645-EA02-4F12-8C3E-820B5710292D} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{437EB182-8CB9-42BD-9019-E5F6E69D1DB3} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
@@ -471,5 +470,6 @@ Global
 		{EB3A602B-4B32-4742-B4A2-39445BD2FBE3} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{8E4F0ED5-75E0-4D0C-9469-05F738B1EC38} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{EE27035A-633D-48AE-BB86-597BBDBA706E} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{391A580B-AA88-4125-9E83-42B4BC6B9260} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 	EndGlobalSection
 EndGlobal

--- a/sample/EventHubTrigger/function.json
+++ b/sample/EventHubTrigger/function.json
@@ -3,16 +3,9 @@
         {
             "type": "eventHubTrigger",
             "name": "input",
+            "cardinality": "many",
             "direction": "in",
             "connection": "AzureWebJobsEventHubReceiver",
-            "path": "%AzureWebJobsEventHubPath%",
-            "consumerGroup": "$Default"
-        },
-        {
-            "type": "eventHub",
-            "name": "output",
-            "direction": "out",
-            "connection": "AzureWebJobsEventHubSender",
             "path": "%AzureWebJobsEventHubPath%"
         }
     ]

--- a/sample/EventHubTrigger/index.js
+++ b/sample/EventHubTrigger/index.js
@@ -1,13 +1,12 @@
-module.exports = function (context, input) {
-    context.log('Node.js script processed queue message', input.prop1);
+var util = require('util');
 
-    // prevent an infinite loop (since we're writing back
-    // to the same hub we're triggering on)
-    if (input.val1 < 3)
+module.exports = function (context, input) {
+    context.log(util.format("Node.js script processed %d events", input.length));
+    context.log("IsArray", util.isArray(input));
+
+    for (i = 0; i < input.length; i++)
     {
-        input.val1++;
-        input.prop1 = "third";
-        context.bindings.output = input;
+        context.log(input[i].value);
     }
 
     context.done();

--- a/src/WebJobs.Script.Extensibility/ScriptBindingContext.cs
+++ b/src/WebJobs.Script.Extensibility/ScriptBindingContext.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensibility
             Name = GetMetadataValue<string>("name");
             Type = GetMetadataValue<string>("type");
             DataType = GetMetadataValue<string>("datatype");
+            Cardinality = GetMetadataValue<string>("cardinality");
             IsTrigger = Type.EndsWith("trigger", StringComparison.OrdinalIgnoreCase);
         }
 
@@ -59,6 +60,11 @@ namespace Microsoft.Azure.WebJobs.Script.Extensibility
         /// Gets the data type for the binding.
         /// </summary>
         public string DataType { get; private set; }
+        
+        /// <summary>
+        /// Gets the cardinality for the binding.
+        /// </summary>
+        public string Cardinality { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="FileAccess"/> for this binding.

--- a/src/WebJobs.Script/Binding/BindingContext.cs
+++ b/src/WebJobs.Script/Binding/BindingContext.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         public DataType DataType { get; set; }
 
         /// <summary>
+        /// Gets or sets the cardinality hint for the binding.
+        /// </summary>
+        public Cardinality Cardinality { get; set; }
+
+        /// <summary>
         /// Gets or sets the target value the binding is binding to.
         /// </summary>
         public object Value { get; set; }

--- a/src/WebJobs.Script/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script/Description/Binding/BindingMetadata.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         [JsonConverter(typeof(StringEnumConverter))]
         public DataType? DataType { get; set; }
 
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Cardinality? Cardinality { get; set; }
+
         /// <summary>
         /// Gets a value indicating whether this binding is a trigger binding.
         /// </summary>

--- a/src/WebJobs.Script/Description/Binding/Cardinality.cs
+++ b/src/WebJobs.Script/Description/Binding/Cardinality.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Description
+{
+    /// <summary>
+    /// Enumeration of binding cardinality values.
+    /// </summary>
+    public enum Cardinality
+    {
+        /// <summary>
+        /// Bind to a single element.
+        /// </summary>
+        One,
+
+        /// <summary>
+        /// Bind to many elements.
+        /// </summary>
+        Many
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -335,6 +335,7 @@
     <Compile Include="Binding\TableBinding.cs" />
     <Compile Include="Binding\WebJobsCoreScriptBindingProvider.cs" />
     <Compile Include="Binding\SimpleValueProvider.cs" />
+    <Compile Include="Description\Binding\Cardinality.cs" />
     <Compile Include="Description\DotNet\DiagnosticExtensions.cs" />
     <Compile Include="Description\DotNet\CSharp\Analyzers\InvalidFileMetadataReferenceAnalyzer.cs" />
     <Compile Include="Description\DotNet\CSharp\CSharpCompilation.cs" />

--- a/test/WebJobs.Script.Tests/NodeFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/NodeFunctionInvokerTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class NodeFunctionInvokerTests
     {
         [Fact]
-        public static void ConvertBindingValue_PerformsExpectedConversions()
+        public void ConvertBindingValue_PerformsExpectedConversions()
         {
             var c = new ExpandoObject() as IDictionary<string, object>;
             c["A"] = "Testing";
@@ -29,6 +29,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             string json = (string)NodeFunctionInvoker.ConvertBindingValue(o);
             Assert.Equal("{\"A\":\"Testing\",\"B\":{\"A\":\"Testing\",\"B\":1234,\"C\":[1,\"Two\",3]}}", json.Replace(" ", string.Empty));
+        }
+
+        [Fact]
+        public void TryConvertJson_ArrayOfJsonObjectStrings()
+        {
+            string[] input = new string[]
+            {
+                "{ \"name\": \"Larry\" }",
+                "{ \"name\": \"Moe\" }",
+                "{ \"name\": \"Curly\" }"
+            };
+
+            object result = null;
+            bool didConvert = NodeFunctionInvoker.TryConvertJson(input, out result);
+            Assert.True(didConvert);
+
+            object[] objects = result as object[];
+            Dictionary<string, object> obj = (Dictionary<string, object>)objects[0];
+            Assert.Equal("Larry", obj["name"]);
+
+            obj = (Dictionary<string, object>)objects[1];
+            Assert.Equal("Moe", obj["name"]);
+
+            obj = (Dictionary<string, object>)objects[2];
+            Assert.Equal("Curly", obj["name"]);
         }
     }
 }


### PR DESCRIPTION
Addresses #618 and #683. We now support a Cardinality binding property which serves as a type hint languages other than C#/F# where this is specified via parameter type. This compliments the existing DataType support, allowing the correct type for the binding to be determined fully.