### PR TITLE
Adding flag to toggle compilation optimization level (debug/release)

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DotNetConstants.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetConstants.cs
@@ -6,23 +6,17 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     public static class DotNetConstants
     {
         public const string PrivateAssembliesFolderName = "bin";
-
         public const string ProjectFileName = "project.json";
-
         public const string ProjectLockFileName = "project.lock.json";
 
         public const string MissingFunctionEntryPointCompilationCode = "AF001";
-
         public const string AmbiguousFunctionEntryPointsCompilationCode = "AF002";
-
         public const string MissingTriggerArgumentCompilationCode = "AF003";
-
         public const string MissingBindingArgumentCompilationCode = "AF004";
-
         public const string RedundantPackageAssemblyReference = "AF005";
-
         public const string InvalidFileMetadataReferenceCode = "AF006";
-
         public const string InvalidEntryPointNameCompilationCode = "AF007";
+
+        public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";
     }
 }

--- a/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompiler.cs
+++ b/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompiler.cs
@@ -24,9 +24,12 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private static readonly Lazy<InteractiveAssemblyLoader> AssemblyLoader
         = new Lazy<InteractiveAssemblyLoader>(() => new InteractiveAssemblyLoader(), LazyThreadSafetyMode.ExecutionAndPublication);
 
-        public FSharpCompiler(IFunctionMetadataResolver metadataResolver)
+        private readonly OptimizationLevel _optimizationLevel;
+
+        public FSharpCompiler(IFunctionMetadataResolver metadataResolver, OptimizationLevel optimizationLevel)
         {
             _metadataResolver = metadataResolver;
+            _optimizationLevel = optimizationLevel;
         }
 
         public string Language
@@ -47,9 +50,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public ICompilation GetFunctionCompilation(FunctionMetadata functionMetadata)
         {
-            // TODO: Get debug flag from context. Set to true for now.
-            bool debug = true;
-
             // First use the C# compiler to resolve references, to get consistenct with the C# Azure Functions programming model
             Script<object> script = CodeAnalysis.CSharp.Scripting.CSharpScript.Create("using System;", options: _metadataResolver.CreateScriptOptions(), assemblyLoader: AssemblyLoader.Value);
             Compilation compilation = script.GetCompilation();
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 otherFlags.Add("-r:System.Runtime.dll");
                 otherFlags.Add("-r:System.Numerics.dll");
 
-                if (debug)
+                if (_optimizationLevel == OptimizationLevel.Debug)
                 {
                     otherFlags.Add("--optimize-");
                     otherFlags.Add("--debug+");


### PR DESCRIPTION
This change introduces the ability to enable *Release* mode compilation for .NET functions (C# and F#) by setting an App Setting/Environment variable:

`AzureWebJobsDotNetReleaseCompilation` : True|False (defaults to false)