### PR TITLE
Add entry point defaulting for "index" functions

### DIFF
--- a/WebJobs.Script.proj
+++ b/WebJobs.Script.proj
@@ -174,7 +174,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BuildConfiguration>Debug</BuildConfiguration>
+    <BuildConfiguration>Release</BuildConfiguration>
     <BuildConfiguration Condition=" $(Configuration) != '' ">$(Configuration)</BuildConfiguration>
   </PropertyGroup>
 

--- a/runNodeTests.cmd
+++ b/runNodeTests.cmd
@@ -1,1 +1,1 @@
-msbuild Webjobs.Script.proj /t:MochaTest /property:Configuration=Release
+msbuild Webjobs.Script.proj /t:MochaTest

--- a/src/WebJobs.Script/Content/Script/functions.js
+++ b/src/WebJobs.Script/Content/Script/functions.js
@@ -92,8 +92,8 @@ function getEntryPoint(f, context) {
         }
         else {
             // finally, see if there is an exported function named
-            // 'run' by convention
-            f = f['run'];
+            // 'run' or 'index' by convention
+            f = f['run'] || f['index'];
         }
     }
     else if (!util.isFunction(f)) {

--- a/test/WebJobs.Script.Tests/TestScripts/Node/functions.tests.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/functions.tests.js
@@ -64,6 +64,18 @@ describe('functions', () => {
             expect(run).to.be.true;
         });
 
+        it('falls back to index function', () => {
+            var run = false;
+            var func = functions.createFunction({
+                index: () => run = true,
+                other: () => run = false
+            });
+
+            func(context);
+
+            expect(run).to.be.true;
+        });
+
         it('throws if no function', () => {
             var func = functions.createFunction(1);
 


### PR DESCRIPTION
It's a common pattern for people to name their entry functions "index". This is also in line with our "run"/"index" name defaulting for entrypoint files.