### PR TITLE
Implement Flush for Composed TraceWriters

### DIFF
--- a/src/WebJobs.Script/Diagnostics/ConditionalTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/ConditionalTraceWriter.cs
@@ -42,5 +42,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 InnerWriter.Trace(traceEvent);
             }
         }
+
+        public override void Flush()
+        {
+            InnerWriter.Flush();
+            base.Flush();
+        }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/InterceptingTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/InterceptingTraceWriter.cs
@@ -40,5 +40,11 @@ namespace Microsoft.Azure.WebJobs.Script
             _interceptor(traceEvent);
             InnerWriter.Trace(traceEvent);
         }
+
+        public override void Flush()
+        {
+            InnerWriter.Flush();
+            base.Flush();
+        }
     }
 }


### PR DESCRIPTION
resolves #751 

tests are a no go because unhandled exceptions crash the process, but I've manually tested