### PR TITLE
Adding Microsoft.Azure.WebJobs.ServiceBus to built in assemblies

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 typeof(object).Assembly.Location,
                 typeof(IAsyncCollector<>).Assembly.Location, /*Microsoft.Azure.WebJobs*/
                 typeof(JobHost).Assembly.Location, /*Microsoft.Azure.WebJobs.Host*/
+                typeof(ServiceBusAttribute).Assembly.Location /*Microsoft.Azure.WebJobs.ServiceBus*/,
                 typeof(CoreJobHostConfigurationExtensions).Assembly.Location, /*Microsoft.Azure.WebJobs.Extensions*/
                 typeof(System.Web.Http.ApiController).Assembly.Location, /*System.Web.Http*/
                 typeof(System.Net.Http.HttpClientExtensions).Assembly.Location /*System.Net.Http.Formatting*/


### PR DESCRIPTION
This issue came up in a recent customer query, where they're trying to use Binder to do dynamic bindings (see code below). To use `Binder` for dynamic bindings, you need to reference the associated attribute (e.g. ServiceBusAttribute). The below full assembly path reference is a workaround - no `#r` should be needed at all.

I've verified with this change that the below function works w/o the `#r`. I also verified that we're good with all the other assemblies. We have logic [here](https://github.com/Azure/azure-webjobs-sdk-script/blob/dev/src/WebJobs.Script/Description/DotNet/ExtensionSharedAssemblyProvider.cs#L38) to automatically add the extension assembly, but ServiceBus is a special case, since its ScriptBindingProvider lives in this repo, not in core SDK.

```csharp
#r "D:\Program Files (x86)\SiteExtensions\Functions\0.6.10487\bin\Microsoft.Azure.WebJobs.ServiceBus.dll"

using System;
using Microsoft.Azure.WebJobs;

public static async Task Run(string input, Binder binder, TraceWriter log)
{
    log.Info($"C# manually triggered function called with input: {input}");

    var attributes = new Attribute[]
    {
        new ServiceBusAttribute("myqueue")
    };

    var collector = await binder.BindAsync<IAsyncCollector<string>>(attributes);
    await collector.AddAsync(input);
}
```