### PR TITLE
Emitting metric events for binding type/direction usage

### DIFF
--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HostStartupLatency = "host.startup.latency";
 
         // function level events
-        public const string FunctionInvokeByTriggerFormat = "function.invoke.{0}";
+        public const string FunctionInvoke = "function.invoke";
+        public const string FunctionBindingTypeFormat = "function.binding.{0}";
+        public const string FunctionBindingTypeDirectionFormat = "function.binding.{0}.{1}";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
     }
 }

--- a/test/WebJobs.Script.Tests/FunctionInvokerBaseTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionInvokerBaseTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class FunctionInvokerBaseTests
+    {
+        [Fact]
+        public void LogInvocationMetrics_EmitsExpectedEvents()
+        {
+            var metrics = new TestMetricsLogger();
+            Collection<BindingMetadata> bindings = new Collection<BindingMetadata>
+            {
+                new BindingMetadata { Type = "httpTrigger" },
+                new BindingMetadata { Type = "blob", Direction = BindingDirection.In },
+                new BindingMetadata { Type = "blob", Direction = BindingDirection.Out },
+                new BindingMetadata { Type = "table", Direction = BindingDirection.In },
+                new BindingMetadata { Type = "table", Direction = BindingDirection.In }
+            };
+
+            FunctionInvokerBase.LogInvocationMetrics(metrics, bindings);
+
+            Assert.Equal(6, metrics.LoggedEvents.Count);
+            Assert.Equal("function.invoke", metrics.LoggedEvents[0]);
+            Assert.Equal("function.binding.httpTrigger", metrics.LoggedEvents[1]);
+            Assert.Equal("function.binding.blob.In", metrics.LoggedEvents[2]);
+            Assert.Equal("function.binding.blob.Out", metrics.LoggedEvents[3]);
+            Assert.Equal("function.binding.table.In", metrics.LoggedEvents[4]);
+            Assert.Equal("function.binding.table.In", metrics.LoggedEvents[5]);
+        }
+
+        private class TestMetricsLogger : IMetricsLogger
+        {
+            public TestMetricsLogger()
+            {
+                LoggedEvents = new Collection<string>();
+            }
+
+            public Collection<string> LoggedEvents { get; }
+
+            public void BeginEvent(MetricEvent metricEvent)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object BeginEvent(string eventName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void EndEvent(object eventHandle)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void EndEvent(MetricEvent metricEvent)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void LogEvent(string eventName)
+            {
+                LoggedEvents.Add(eventName);
+            }
+
+            public void LogEvent(MetricEvent metricEvent)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -429,6 +429,7 @@
     <Compile Include="FunctionEntryPointResolverTests.cs" />
     <Compile Include="FunctionGeneratorTests.cs" />
     <Compile Include="Description\DotNet\PackageAssemblyResolverTests.cs" />
+    <Compile Include="FunctionInvokerBaseTests.cs" />
     <Compile Include="HttpRouteFactoryTests.cs" />
     <Compile Include="HttpTriggerAttributeBindingProviderTests.cs" />
     <Compile Include="MetricsEventManagerTests.cs" />


### PR DESCRIPTION
Previously I was only emitting trigger type events. Generalizing this so we get counts across all binding types, including in/out bindings.