### PR TITLE
Added expressjs style api for http responses

### DIFF
--- a/src/WebJobs.Script/Binding/HttpBinding.cs
+++ b/src/WebJobs.Script/Binding/HttpBinding.cs
@@ -75,10 +75,11 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                             headers = (JObject)value;
                         }
 
-                        if (jo.TryGetValue("status", StringComparison.OrdinalIgnoreCase, out value) && value is JValue)
+                        if ((jo.TryGetValue("status", StringComparison.OrdinalIgnoreCase, out value) && value is JValue) ||
+                            (jo.TryGetValue("statusCode", StringComparison.OrdinalIgnoreCase, out value) && value is JValue))
                         {
                             statusCode = (HttpStatusCode)(int)value;
-                        } 
+                        }
                     }
                 }
                 catch (JsonException)

--- a/src/WebJobs.Script/Content/Script/functions.js
+++ b/src/WebJobs.Script/Content/Script/functions.js
@@ -3,6 +3,8 @@
 
 var util = require('util');
 var process = require('process');
+var request = require('./http/request');
+var response = require('./http/response');
 
 module.exports = {
     globalInitialization: globalInitialization,
@@ -68,6 +70,15 @@ function createFunction(f) {
         var inputs = context._inputs;
         inputs.unshift(context);
         delete context._inputs;
+
+        var lowercaseTrigger = context._triggerType && context._triggerType.toLowerCase();
+        switch (lowercaseTrigger) {
+            case "httptrigger": 
+                context.req = request(context);
+                context.res = response(context);
+                break;
+        }
+        delete context._triggerType;
 
         var result = f.apply(null, inputs);
         if (result && util.isFunction(result.then)) {

--- a/src/WebJobs.Script/Content/Script/http/request.js
+++ b/src/WebJobs.Script/Content/Script/http/request.js
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+module.exports = (context) => {
+    var req = context.req;
+    req.get = (field) => req.headers[field];
+    return req;
+};

--- a/src/WebJobs.Script/Content/Script/http/response.js
+++ b/src/WebJobs.Script/Content/Script/http/response.js
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+module.exports = (context) => {
+    var res = {
+        headers: {},
+
+        end: (body) => {
+            if (body !== undefined) {
+                res.body = body;
+            }
+            context.done();
+            return res;
+        },
+
+        status: (statusCode) => {
+            res.statusCode = statusCode;
+            return res;
+        },
+
+        set: (field, val) => {
+            res.headers[field] = val;
+            return res;
+        },
+
+        sendStatus: (statusCode) => {
+            return res.status(statusCode)
+                .end();
+        },
+
+        type: (type) => {
+            return res.set('Content-Type', type);
+        },
+
+        json: (body) => {
+            return res.type('application/json')
+                .send(body);
+        },
+
+        get: (field) => {
+            return res.headers[field]
+        }
+    };
+
+    res.send = res.end;
+    res.header = res.set;
+
+    return res;
+};

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -332,11 +332,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     !string.IsNullOrEmpty(httpBinding.WebHookType))
                 {
                     input = requestObject["body"];
-
-                    // make the entire request object available as well
-                    // this is symmetric with context.res which we also support
-                    context["req"] = requestObject;
                 }
+
+                // make the entire request object available as well
+                // this is symmetric with context.res which we also support
+                context["req"] = requestObject;
             }
             else if (input is TimerInfo)
             {
@@ -372,6 +372,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             bindings.Add(_trigger.Name, input);
+
+            context.Add("_triggerType", _trigger.Type);
 
             return context;
         }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -460,6 +460,12 @@
       <Link>edge\edge.js</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Content\Script\http\response.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\Script\http\request.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/test/WebJobs.Script.Tests/TestScripts/Node/HttpTriggerExpressApi/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/HttpTriggerExpressApi/function.json
@@ -1,0 +1,15 @@
+﻿{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "request",
+            "direction": "in",
+            "methods": [ "get", "post" ]
+        },
+        {
+            "type": "http",
+            "name": "response",
+            "direction": "out"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/Node/HttpTriggerExpressApi/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/HttpTriggerExpressApi/index.js
@@ -1,0 +1,19 @@
+﻿var util = require('util');
+
+module.exports = function (context, req) {
+    context.log('Node.js HttpTrigger function invoked.');
+
+    context.res.status(200)
+        .set('test-req-header', context.req.get('test-header'))
+        .set('test-header', 'Test Response Header')
+        .type('application/json; charset=utf-8')
+        .send({
+            reqBodyType: typeof req.body,
+            reqBodyIsArray: util.isArray(req.body),
+            reqBody: req.body,
+            reqRawBodyType: typeof req.rawBody,
+            reqRawBody: req.rawBody,
+            reqHeaders: req.headers,
+            bindingData: context.bindingData
+        });
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -843,6 +843,9 @@
     <None Include="TestScripts\Node\Excluded\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\Node\HttpTriggerExpressApi\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Node\HttpTrigger-Scenarios\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -904,6 +907,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\Excluded\index.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestScripts\Node\HttpTriggerExpressApi\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestScripts\Node\HttpTrigger-Scenarios\index.js">


### PR DESCRIPTION
resolves #160 

Went with a very basic wrapper, can add functionality as necessary but these basic functions cover most use cases.

If there is only one output http binding, we populate context.res, otherwise we populate context.bindings.<httpbindingname>

Not a breaking change as these response objects can be overwritten with `{ headers: ..., status: ..., body: ... }` objects