### PR TITLE
When Http methods property is an empty array, disallow all methods

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -89,13 +89,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     return new HttpResponseMessage(HttpStatusCode.Unauthorized);
                 }
 
-                // Validate the HttpMethod
-                // Note that for WebHook requests, WebHook receiver does its own validation
-                if (httpFunctionMetadata.Methods != null && !httpFunctionMetadata.Methods.Contains(request.Method))
-                {
-                    return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
-                }
-
                 // Not a WebHook request so dispatch directly
                 response = await _scriptHostManager.HandleRequestAsync(function, request, cancellationToken);
             }

--- a/src/WebJobs.Script/Binding/Http/HttpRouteFactory.cs
+++ b/src/WebJobs.Script/Binding/Http/HttpRouteFactory.cs
@@ -30,8 +30,11 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         {
             var routeBuilder = CreateRouteBuilder(routeTemplate);
             var constraints = routeBuilder.Constraints;
-            if (methods != null && methods.Count() > 0)
+            if (methods != null)
             {
+                // if the methods collection is not null, apply the constraint
+                // if the methods collection is empty, we'll create a constraint
+                // that disallows ALL methods
                 constraints.Add("httpMethod", new HttpMethodConstraint(methods.ToArray()));
             }
             var httpRoute = routes.CreateRoute(routeBuilder.Template, routeBuilder.Defaults, constraints);

--- a/test/WebJobs.Script.Tests/HttpRouteFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/HttpRouteFactoryTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public static void AddRoute_AppliesHttpMethodConstraints()
+        public static void AddRoute_AppliesHttpMethodConstraint()
         {
             HttpRouteFactory routeFactory = new HttpRouteFactory("api");
 
@@ -58,6 +58,40 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             request = new HttpRequestMessage(HttpMethod.Post, "http://host/api/products/electronics/123");
             routeData = routes.GetRouteData(request);
             Assert.Same(route2, routeData.Route);
+        }
+
+        [Fact]
+        public static void AddRoute_MethodsCollectionNull_DoesNotApplyHttpMethodConstraint()
+        {
+            HttpRouteFactory routeFactory = new HttpRouteFactory("api");
+
+            HttpRouteCollection routes = new HttpRouteCollection();
+            var route = routeFactory.AddRoute("route1", "products/{category}/{id?}", null, routes);
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://host/api/products/electronics/123");
+            var routeData = routes.GetRouteData(request);
+            Assert.Same(route, routeData.Route);
+
+            request = new HttpRequestMessage(HttpMethod.Post, "http://host/api/products/electronics/123");
+            routeData = routes.GetRouteData(request);
+            Assert.Same(route, routeData.Route);
+        }
+
+        [Fact]
+        public static void AddRoute_MethodsCollectionEmpty_AppliesHttpMethodConstraint()
+        {
+            HttpRouteFactory routeFactory = new HttpRouteFactory("api");
+
+            HttpRouteCollection routes = new HttpRouteCollection();
+            var route = routeFactory.AddRoute("route1", "products/{category}/{id?}", new HttpMethod[0], routes);
+
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://host/api/products/electronics/123");
+            var routeData = routes.GetRouteData(request);
+            Assert.Null(routeData);
+
+            request = new HttpRequestMessage(HttpMethod.Post, "http://host/api/products/electronics/123");
+            routeData = routes.GetRouteData(request);
+            Assert.Null(routeData);
         }
     }
 }


### PR DESCRIPTION
Minor cleanup. Previously, we interpreted both null and empty as the same thing and would allow all methods.