### PR TITLE
[WIP] upgrade to FSharp.Compiler.Service 8.0.0, remove msbuild dependency

### DIFF
--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -25,7 +25,7 @@
       <dependency id="Edge.js" version="6.5.1" />
       <dependency id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.3.2" />
       <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
-      <dependency id="FSharp.Compiler.Service" version="6.0.2" />
+      <dependency id="FSharp.Compiler.Service" version="8.0.0" />
       <dependency id="FSharp.Core" version="4.0.0.1" />
     </dependencies>
   </metadata>

--- a/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompiler.cs
+++ b/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompiler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             Script<object> script = CodeAnalysis.CSharp.Scripting.CSharpScript.Create("using System;", options: _metadataResolver.CreateScriptOptions(), assemblyLoader: AssemblyLoader.Value);
             Compilation compilation = script.GetCompilation();
 
-            var compiler = new SimpleSourceCodeServices();
+            var compiler = new SimpleSourceCodeServices(msbuildEnabled: FSharpOption<bool>.Some(false));
 
             FSharpErrorInfo[] errors = null;
             FSharpOption<Assembly> assemblyOption = null;
@@ -135,7 +135,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 otherFlags.Add("--out:" + Path.ChangeExtension(Path.GetTempFileName(), "dll"));
 
                 // Get the #load closure
-                var loadFileOptionsAsync = FSharpChecker.Create().GetProjectOptionsFromScript(functionMetadata.ScriptFile, scriptSource, null, null, null);
+                FSharpChecker checker = FSharpChecker.Create(null, null, null, msbuildEnabled: FSharpOption<bool>.Some(false));
+                var loadFileOptionsAsync = checker.GetProjectOptionsFromScript(functionMetadata.ScriptFile, scriptSource, null, null, null);
                 var loadFileOptions = FSharp.Control.FSharpAsync.RunSynchronously(loadFileOptionsAsync, null, null);
                 foreach (var loadedFileName in loadFileOptions.ProjectFileNames)
                 {

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\Edge.js.6.5.1\lib\net40\EdgeJs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FSharp.Compiler.Service, Version=6.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FSharp.Compiler.Service.6.0.2\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+    <Reference Include="FSharp.Compiler.Service, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FSharp.Compiler.Service.8.0.0\lib\net45\FSharp.Compiler.Service.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Edge.js" version="6.5.1" targetFramework="net46" />
-  <package id="FSharp.Compiler.Service" version="6.0.2" targetFramework="net46" />
+  <package id="FSharp.Compiler.Service" version="8.0.0" targetFramework="net46" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
This should fix #600 - my understanding is that there will now be no dependency on any version of MSBuild.