### PR TITLE
Fixing bug in optional route parameter binding

### DIFF
--- a/sample/HttpTrigger-CSharp-CustomRoute/run.csx
+++ b/sample/HttpTrigger-CSharp-CustomRoute/run.csx
@@ -13,7 +13,7 @@ public class ProductInfo
 
 public static ProductInfo Run(ProductInfo info, string category, int? id, TraceWriter log)
 {
-    log.Info($"ProductInfo: Category={category} Id={id}");
+    log.Info($"ProductInfo: Category={info.Category} Id={info.Id}");
     log.Info($"Parameters: category={category} id={id}");
 
     return info;


### PR DESCRIPTION
I noticed this bug in some local testing. Basically, if you have a route template like `csharp/products/{category:alpha}/{id:int?}` defined (id is optional/nullable) we don't let you bind to it as in the below signature.

```csharp
public static HttpResponseMessage Run(HttpRequestMessage request, string category, int? id)
```

The reason I didn't catch this before was because the scenario test I have in place ([here](https://github.com/Azure/azure-webjobs-sdk-script/tree/dev/sample/HttpTrigger-CSharp-CustomRoute)) was also binding to a POCO, so the static binding contract was filled in from the POCO Id property and things worked. If in that sample you remove the POCO binding, you'll hit this bug.
