### PR TITLE
Improving error handling in http route registration

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _secretManager.PurgeOldFiles(Instance.ScriptConfig.RootScriptPath, Instance.TraceWriter);
         }
 
-        internal void InitializeHttpFunctions(Collection<FunctionDescriptor> functions)
+        internal void InitializeHttpFunctions(IEnumerable<FunctionDescriptor> functions)
         {
             // we must initialize the route factory here AFTER full configuration
             // has been resolved so we apply any route prefix customizations
@@ -423,8 +423,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 var httpTriggerBinding = function.Metadata.InputBindings.OfType<HttpTriggerBindingMetadata>().SingleOrDefault();
                 if (httpTriggerBinding != null)
                 {
-                    var httpRoute = httpRouteFactory.AddRoute(function.Metadata.Name, httpTriggerBinding.Route, httpTriggerBinding.Methods, _httpRoutes);
-                    _httpFunctions.Add(httpRoute, function);
+                    IHttpRoute httpRoute = null;
+                    if (httpRouteFactory.TryAddRoute(function.Metadata.Name, httpTriggerBinding.Route, httpTriggerBinding.Methods, _httpRoutes, out httpRoute))
+                    {
+                        _httpFunctions.Add(httpRoute, function);
+                    }
                 }
             }
         }

--- a/src/WebJobs.Script/Binding/HttpBinding.cs
+++ b/src/WebJobs.Script/Binding/HttpBinding.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                     // serialized as json by WebApi below
                     content = jo;
 
+                    // TODO: Improve this logic
                     // Sniff the object to see if it looks like a response object
                     // by convention
                     JToken value = null;

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 // get the output value from the script
                 object value = null;
                 bool haveValue = bindings.TryGetValue(binding.Metadata.Name, out value);
-                if (!haveValue && binding.Metadata.Type == "http")
+                if (!haveValue && string.Compare(binding.Metadata.Type, "http", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     // http bindings support a special context.req/context.res programming
                     // model, so we must map that back to the actual binding name if a value
@@ -340,6 +340,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
             else if (input is TimerInfo)
             {
+                // TODO: Need to generalize this model rather than hardcode
+                // so other extensions can also express their Node.js object model
                 TimerInfo timerInfo = (TimerInfo)input;
                 var inputValues = new Dictionary<string, object>()
                 {

--- a/src/WebJobs.Script/Extensions/ExceptionExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace System
+{
+    internal static class ExceptionExtensions
+    {
+        public static bool IsFatal(this Exception exception)
+        {
+            while (exception != null)
+            {
+                if ((exception is OutOfMemoryException && !(exception is InsufficientMemoryException)) ||
+                    exception is ThreadAbortException ||
+                    exception is AccessViolationException ||
+                    exception is SEHException ||
+                    exception is StackOverflowException)
+                {
+                    return true;
+                }
+
+                if (exception is TypeInitializationException &&
+                    exception is TargetInvocationException)
+                {
+                    break;
+                }
+
+                exception = exception.InnerException;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -395,6 +395,7 @@
     <Compile Include="Diagnostics\HostStartedEvent.cs" />
     <Compile Include="EnvironmentSettingNames.cs" />
     <Compile Include="ExpandoObjectJsonConverter.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Extensions\IDictionaryExtensions.cs" />
     <Compile Include="Extensions\IMetricsLoggerExtensions.cs" />
     <Compile Include="Extensions\TraceWriterExtensions.cs" />


### PR DESCRIPTION
If the route for an http function is invalid, we want to log the error to function log, but allow the host to start up.