### PR TITLE
Mitigate flaky context.done tests

### DIFF
--- a/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/Scenarios/index.js
@@ -5,11 +5,7 @@ var assert = require('assert');
     var scenario = input.scenario;
     context.log("Running scenario '%s'", scenario);
 
-    if (scenario == 'doubleDone') {
-        context.done();
-        context.done();
-    }
-    else if (scenario == 'nextTick') {
+    if (scenario == 'nextTick') {
         process.nextTick(function () {
             // without the workaround this would hang
             context.done();


### PR DESCRIPTION
resolves #795 

The two failing tests (double done & promise done) test the same code path: that multiple calls to context.done log an error.  I removed double done, as it seemed to be flakier.  This logic is still tested in the [mocha tests](https://github.com/Azure/azure-webjobs-sdk-script/blob/dev/test/WebJobs.Script.Tests/TestScripts/Node/functions.tests.js#L91), so only testing it once in the end to end scenario should be ok.

For the remaining end to end test, added more loops and a short circuit mechanism.