### PR TITLE
Creating function default function secret if file does not exist

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretManager.cs
@@ -120,8 +120,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 string secretsFilePath = GetFunctionSecretsFilePath(functionName);
                 if (!TryLoadFunctionSecrets(functionName, out secrets, secretsFilePath))
                 {
-                    // initialize an empty FunctionSecrets instance
-                    secrets = new FunctionSecrets();
+                    secrets = new FunctionSecrets
+                    {
+                        Keys = new List<Key>
+                        {
+                            GenerateKey(ScriptConstants.DefaultFunctionKeyName)
+                        }
+                    };
+
+                    PersistSecrets(secrets, secretsFilePath);
                 }
 
                 // Read all secrets, which will run the keys through the appropriate readers

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         }
 
         [Fact]
-        public void GetFunctionSecrets_WhenNoSecretFileExists_ReturnsEmptySecretsAndDoesNotPersistsFile()
+        public void GetFunctionSecrets_WhenNoSecretFileExists_CreatesDefaultSecretAndPersistsFile()
         {
             var secretsPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
@@ -234,8 +234,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     bool functionSecretsExists = File.Exists(Path.Combine(secretsPath, "testfunction.json"));
 
                     Assert.NotNull(functionSecrets);
-                    Assert.False(functionSecretsExists);
-                    Assert.Equal(0, functionSecrets.Count);
+                    Assert.True(functionSecretsExists);
+                    Assert.Equal(1, functionSecrets.Count);
+                    Assert.Equal(ScriptConstants.DefaultFunctionKeyName, functionSecrets.Keys.First());
                 }
             }
             finally


### PR DESCRIPTION
This restores the original behavior where a default function key will be created if a secret file does not exist.

@mathewc based on some feedback, this differs a bit from what we've discussed since we're still creating a host level function key. Everything else is the same.