### PR TITLE
Registering provided instance of settings manager

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/AutofacBootstrap.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/AutofacBootstrap.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
     {
         internal static void Initialize(ScriptSettingsManager settingsManager, ContainerBuilder builder, WebHostSettings settings)
         {
-            builder.RegisterType<ScriptSettingsManager>().SingleInstance();
+            builder.RegisterInstance(settingsManager);
 
             // register the resolver so that it is disposed when the container
             // is disposed


### PR DESCRIPTION
Small change to the settings manager registration so we register the same instance we pass into the `WebHostResolver`