### PR TITLE
Don't throw if no content for webhook

### DIFF
--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 if (httpBinding != null &&
                     !string.IsNullOrEmpty(httpBinding.WebHookType))
                 {
-                    input = requestObject["body"];
+                    requestObject.TryGetValue("body", out input);
                 }
 
                 // make the entire request object available as well

--- a/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/NodeEndToEndTests.cs
@@ -649,6 +649,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task WebHookTrigger_NoContent()
+        {
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(string.Format("http://localhost/api/webhooktrigger?code=1388a6b0d05eca2237f10e4a4641260b0a08f3a5")),
+                Method = HttpMethod.Post,
+            };
+            request.SetConfiguration(new HttpConfiguration());
+
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "payload", request }
+            };
+            await Fixture.Host.CallAsync("WebHookTrigger", arguments);
+
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal(string.Format("No content"), body);
+        }
+
+        [Fact]
         public async Task TimerTrigger()
         {
             var logs = (await TestHelpers.GetFunctionLogsAsync("TimerTrigger")).ToArray();

--- a/test/WebJobs.Script.Tests/TestScripts/Node/WebHookTrigger/index.js
+++ b/test/WebJobs.Script.Tests/TestScripts/Node/WebHookTrigger/index.js
@@ -1,7 +1,8 @@
 ﻿module.exports = function (context, payload) {
     context.log('Webhook was triggered!');
-    context.res = {
-        body: 'WebHook processed successfully! ' + payload.a
-    };
-    context.done();
+    if (payload) {
+        context.res.send('WebHook processed successfully! ' + payload.a);
+    } else {
+        context.res.send('No content');
+    }
 }


### PR DESCRIPTION
resolves #849 #836 

I decided to pass the empty body along to the user for the webhook and they can choose how to respond, rather than throw some kind of 'content expected' exception.