### PR TITLE
Fixing issue with $return handling for HTTP binding in .NET

### DIFF
--- a/sample/HttpTrigger-CSharp/function.json
+++ b/sample/HttpTrigger-CSharp/function.json
@@ -8,7 +8,7 @@
         },
         {
             "type": "http",
-            "name": "res",
+            "name": "$return",
             "direction": "out"
         }
     ]

--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             descriptor = null;
 
             var returnBinding = bindings.SingleOrDefault(p => p.Metadata.IsReturn);
-            if (returnBinding == null)
+            if (returnBinding == null || returnBinding is IResultProcessingBinding)
             {
                 return false;
             }

--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // if a return value binding was specified, copy the return value
             // into the output binding slot (by convention the last parameter)
             var returnValueBinding = Metadata.Bindings.SingleOrDefault(p => p.IsReturn);
-            if (returnValueBinding != null)
+            if (returnValueBinding != null && !(returnValueBinding is IResultProcessingBinding))
             {
                 originalParameters[originalParameters.Length - 1] = result;
             }


### PR DESCRIPTION
Resolves #741 

This is a very simple fix to make sure `$return` **also** works with HTTP output bindings in .NET 

I have some comments in the referenced issue about possibly removing `IResultProcessingBinding`, but we'll need to discuss the approach as there will be behavior changes.