### PR TITLE
add failing F# nuget references test

### DIFF
--- a/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
@@ -173,6 +173,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task NugetChartingReferencesInvokeSucceeds()
+        {
+            TestHelpers.ClearFunctionLogs("NugetChartingReferences");
+
+            string testData = Guid.NewGuid().ToString();
+            string inputName = "input";
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { inputName, testData }
+            };
+            await Fixture.Host.CallAsync("NugetChartingReferences", arguments);
+
+            // make sure the input string made it all the way through
+            var logs = await TestHelpers.GetFunctionLogsAsync("NugetChartingReferences");
+            Assert.True(logs.Any(p => p.Contains(testData)));
+        }
+
+        [Fact]
         public async Task PrivateAssemblyDependenciesAreLoaded()
         {
             var request = new System.Net.Http.HttpRequestMessage();

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/function.json
@@ -1,0 +1,19 @@
+﻿{
+    "bindings": [
+        {
+            "type": "manualTrigger",
+            "name": "input",
+            "direction": "in"
+        }
+    ],
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "FSharp.Data": "2.3.2",
+                "XPlot.Plotly": "1.3.1",
+                "XPlot.GoogleCharts": "1.3.1",
+                "Google.DataTable.Net.Wrapper": "3.1.2"
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/run.fsx
@@ -1,0 +1,60 @@
+//----------------------------------------------------------------------------------------
+// This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
+
+#if !COMPILED
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
+#r "Microsoft.Azure.WebJobs.Host.dll"
+#r "System.Web.Http.dll"
+#r "System.Net.Http.dll"
+#r "System.IO"
+#endif
+
+//----------------------------------------------------------------------------------------
+// This is the implementation of the function 
+
+#r "System.Data.dll"
+#r "Google.DataTable.Net.Wrapper.dll"
+#r "XPlot.GoogleCharts.dll"
+#r "XPlot.Plotly.dll"
+
+open System
+open FSharp.Data
+open Google.DataTable.Net.Wrapper
+open XPlot.GoogleCharts
+open XPlot.Plotly
+open System.Net
+open System.Net.Http
+open Microsoft.Azure.WebJobs.Host
+open System.Data
+open System.Threading.Tasks
+
+type data = {
+    label: string
+    value: float
+}
+
+let Run (input: string, log: TraceWriter) =  
+
+    log.Info(sprintf "Generate chart")
+
+    let mutable Bolivia = [("2015/2016",2);("2016/2017",2);("2017/2018",19)]
+    let mutable Ecuador = [("2015/2016",6);("2016/2017",42);("2017/2018",3)]
+    let mutable Madagascar = [("2015/2016",11);("2016/2017",22);("2017/2018",2)]
+    let mutable Average = [("2015/2016",31);("2016/2017",3);("2017/2018",14)]
+
+    let series = [ "bars"; "bars"; "bars"; "lines" ]
+    let inputs = [ Bolivia; Ecuador; Madagascar; Average ]
+
+    let output =
+        inputs
+        |> Chart.Combo
+        |> Chart.WithOptions 
+            (Options(title = "Coffee Production", series = 
+                [| for typ in series -> Series(typ) |]))
+        |> Chart.WithLabels 
+            ["Bolivia"; "Ecuador"; "Madagascar"; "Average"]
+        |> Chart.WithLegend true
+        |> Chart.WithSize (600, 250)   
+
+    log.Info(output.Html)
+    log.Info(input)


### PR DESCRIPTION
According to #650 this new test should fail. The purpose of these failing tests is to make sure we know we're covering actual new scenarios failing under existing CI when we fix the bugs.

@fabiocav Please add full CI tag, which from #889 I presume is needed to get the other tests to pass?

@fabiocav Can you advise whether this test looks appropriate to add? It adds some particular F# relevant nuget packages and uses one charting library.  It's a bit more like scenario testing but it feels reasonable and stable.  I can put it under "Scenarios" if you like.
