### PR TITLE
Address F# Assembly Resolution Issues

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompilationService.cs
+++ b/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompilationService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
@@ -25,11 +26,13 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         = new Lazy<InteractiveAssemblyLoader>(() => new InteractiveAssemblyLoader(), LazyThreadSafetyMode.ExecutionAndPublication);
 
         private readonly OptimizationLevel _optimizationLevel;
+        private readonly Regex _hashRRegex;
 
         public FSharpCompiler(IFunctionMetadataResolver metadataResolver, OptimizationLevel optimizationLevel)
         {
             _metadataResolver = metadataResolver;
             _optimizationLevel = optimizationLevel;
+            _hashRRegex = new Regex(@"^\s*#r\s+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
 
         public string Language
@@ -50,8 +53,28 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public ICompilation GetFunctionCompilation(FunctionMetadata functionMetadata)
         {
-            // First use the C# compiler to resolve references, to get consistenct with the C# Azure Functions programming model
-            Script<object> script = CodeAnalysis.CSharp.Scripting.CSharpScript.Create("using System;", options: _metadataResolver.CreateScriptOptions(), assemblyLoader: AssemblyLoader.Value);
+            // First use the C# compiler to resolve references, to get consistency with the C# Azure Functions programming model
+            // Add the #r statements from the .fsx file to the resolver source
+            string scriptSource = GetFunctionSource(functionMetadata);
+            var resolverSourceBuilder = new StringBuilder();
+
+            using (StringReader sr = new StringReader(scriptSource))
+            {
+                string line;
+
+                while ((line = sr.ReadLine()) != null)
+                {
+                    if (_hashRRegex.IsMatch(line))
+                    {
+                        resolverSourceBuilder.AppendLine(line);
+                    }
+                }
+            }
+
+            resolverSourceBuilder.AppendLine("using System;");
+            var resolverSource = resolverSourceBuilder.ToString();
+
+            Script<object> script = CodeAnalysis.CSharp.Scripting.CSharpScript.Create(resolverSource, options: _metadataResolver.CreateScriptOptions(), assemblyLoader: AssemblyLoader.Value);
             Compilation compilation = script.GetCompilation();
 
             var compiler = new SimpleSourceCodeServices(msbuildEnabled: FSharpOption<bool>.Some(false));
@@ -77,7 +100,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 scriptFileBuilder.AppendLine("# 0 @\"" + functionMetadata.ScriptFile + "\"");
 
                 // Add our original script
-                string scriptSource = GetFunctionSource(functionMetadata);
                 scriptFileBuilder.AppendLine(scriptSource);
 
                 File.WriteAllText(scriptFilePath, scriptFileBuilder.ToString());
@@ -132,7 +154,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 }
 
                 // This output DLL isn't actually written by FSharp.Compiler.Service when CompileToDynamicAssembly is called
-                otherFlags.Add("--out:" + Path.ChangeExtension(Path.GetTempFileName(), "dll"));
+                var asmName = FunctionAssemblyLoader.GetAssemblyNameFromMetadata(functionMetadata, compilation.AssemblyName);
+                var dllName = Path.GetTempPath() + asmName + ".dll";
+                var pdbName = Path.ChangeExtension(dllName, "pdb");
+                otherFlags.Add("--out:" + dllName);
 
                 // Get the #load closure
                 FSharpChecker checker = FSharpChecker.Create(null, null, null, msbuildEnabled: FSharpOption<bool>.Some(false));
@@ -149,14 +174,18 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 // Add the (adjusted) script file itself
                 otherFlags.Add(scriptFilePath);
 
-                // Make the output streams (unused)
-                var outStreams = FSharpOption<Tuple<TextWriter, TextWriter>>.Some(new Tuple<TextWriter, TextWriter>(Console.Out, Console.Error));
-
-                // Compile the script to a dynamic assembly
-                var result = compiler.CompileToDynamicAssembly(otherFlags: otherFlags.ToArray(), execute: outStreams);
-
+                // Compile the script to a static assembly
+                var result = compiler.Compile(otherFlags.ToArray());
                 errors = result.Item1;
-                assemblyOption = result.Item3;
+                var code = result.Item2;
+
+                if (code == 0)
+                {
+                    var assemblyBytes = File.ReadAllBytes(dllName);
+                    var pdbBytes = File.ReadAllBytes(pdbName);
+                    var assembly = Assembly.Load(assemblyBytes, pdbBytes);
+                    assemblyOption = FSharpOption<Assembly>.Some(assembly);
+                }
             }
             finally
             {

--- a/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompilationService.cs
+++ b/src/WebJobs.Script/Description/DotNet/FSharp/FSharpCompilationService.cs
@@ -83,6 +83,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             FSharpOption<Assembly> assemblyOption = null;
             string scriptFilePath = Path.Combine(Path.GetTempPath(), Path.GetFileName(functionMetadata.ScriptFile));
 
+            var asmName = FunctionAssemblyLoader.GetAssemblyNameFromMetadata(functionMetadata, compilation.AssemblyName);
+            var dllName = Path.GetTempPath() + asmName + ".dll";
+            var pdbName = Path.ChangeExtension(dllName, "pdb");
+
             try
             {
                 var scriptFileBuilder = new StringBuilder();
@@ -153,10 +157,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     otherFlags.Add("--lib:" + Path.Combine(Path.GetDirectoryName(functionMetadata.ScriptFile), DotNetConstants.PrivateAssembliesFolderName));
                 }
 
-                // This output DLL isn't actually written by FSharp.Compiler.Service when CompileToDynamicAssembly is called
-                var asmName = FunctionAssemblyLoader.GetAssemblyNameFromMetadata(functionMetadata, compilation.AssemblyName);
-                var dllName = Path.GetTempPath() + asmName + ".dll";
-                var pdbName = Path.ChangeExtension(dllName, "pdb");
                 otherFlags.Add("--out:" + dllName);
 
                 // Get the #load closure
@@ -190,6 +190,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             finally
             {
                 File.Delete(scriptFilePath);
+                File.Delete(dllName);
+                File.Delete(pdbName);
             }
             return new FSharpCompilation(errors, assemblyOption);
         }

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoader.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoader.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         // Prefix that uniquely identifies our assemblies
         // i.e.: "ƒ-<functionname>"
-        public const string AssemblyPrefix = "\u0192-";
+        public const string AssemblyPrefix = "f-";
+        public const string AssemblySeparator = "__";
 
         private readonly ConcurrentDictionary<string, FunctionAssemblyLoadContext> _functionContexts = new ConcurrentDictionary<string, FunctionAssemblyLoadContext>();
         private readonly Regex _functionNameFromAssemblyRegex;
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             _rootScriptUri = new Uri(rootScriptPath, UriKind.RelativeOrAbsolute);
             AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
-            _functionNameFromAssemblyRegex = new Regex(string.Format(CultureInfo.InvariantCulture, "^{0}(?<name>.*?)#", AssemblyPrefix), RegexOptions.Compiled);
+            _functionNameFromAssemblyRegex = new Regex(string.Format(CultureInfo.InvariantCulture, "^{0}(?<name>.*?){1}", AssemblyPrefix, AssemblySeparator), RegexOptions.Compiled);
         }
 
         public void Dispose()
@@ -51,22 +52,33 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             FunctionAssemblyLoadContext context = GetFunctionContext(args.RequestingAssembly);
             Assembly result = null;
 
-            if (context != null)
+            try
             {
-                result = context.ResolveAssembly(args.Name);
-            }
-
-            // If we were unable to resolve the assembly, apply the current App Domain policy and attempt to load it.
-            // This allows us to correctly handle retargetable assemblies, redirects, etc.
-            if (result == null)
-            {
-                string assemblyName = ((AppDomain)sender).ApplyPolicy(args.Name);
-
-                // If after applying the current policy, we now have a different target assembly name, attempt to load that 
-                // assembly
-                if (string.Compare(assemblyName, args.Name) != 0)
+                if (context != null)
                 {
-                    result = Assembly.Load(assemblyName);
+                    result = context.ResolveAssembly(args.Name);
+                }
+
+                // If we were unable to resolve the assembly, apply the current App Domain policy and attempt to load it.
+                // This allows us to correctly handle retargetable assemblies, redirects, etc.
+                if (result == null)
+                {
+                    string assemblyName = ((AppDomain)sender).ApplyPolicy(args.Name);
+
+                    // If after applying the current policy, we now have a different target assembly name, attempt to load that 
+                    // assembly
+                    if (string.Compare(assemblyName, args.Name) != 0)
+                    {
+                        result = Assembly.Load(assemblyName);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                if (context != null)
+                {
+                    context.TraceWriter.Warning(string.Format(CultureInfo.InvariantCulture,
+                        "Exception during runtime resolution of assembly '{0}': '{1}'", args.Name, e.ToString()));
                 }
             }
 
@@ -165,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public static string GetAssemblyNameFromMetadata(FunctionMetadata metadata, string suffix)
         {
-            return AssemblyPrefix + metadata.Name + "#" + suffix;
+            return AssemblyPrefix + metadata.Name + AssemblySeparator + suffix.GetHashCode().ToString();
         }
 
         public string GetFunctionNameFromAssembly(Assembly assembly)

--- a/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/CSharpEndToEndTests.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task TwilioReferenceInvokeSucceeds()
+        {
+            await TwilioReferenceInvokeSucceedsImpl(isDotNet: true);
+        }
+
+        [Fact]
         public async Task MobileTables()
         {
             await MobileTablesTest(isDotNet: true);

--- a/test/WebJobs.Script.Tests/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests/EndToEndTestsBase.cs
@@ -157,6 +157,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(trace.Replace(" ", string.Empty).Contains(messageContent.Replace(" ", string.Empty)));
         }
 
+        protected async Task TwilioReferenceInvokeSucceedsImpl(bool isDotNet)
+        {
+            if (isDotNet)
+            {
+                TestHelpers.ClearFunctionLogs("TwilioReference");
+
+                string testData = Guid.NewGuid().ToString();
+                string inputName = "input";
+                Dictionary<string, object> arguments = new Dictionary<string, object>
+                {
+                    { inputName, testData }
+                };
+                await Fixture.Host.CallAsync("TwilioReference", arguments);
+
+                // make sure the input string made it all the way through
+                var logs = await TestHelpers.GetFunctionLogsAsync("TwilioReference");
+                Assert.True(logs.Any(p => p.Contains(testData)));
+            }
+        }
+
         protected async Task DocumentDBTest()
         {
             // DocumentDB tests need the following environment vars:

--- a/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
@@ -178,23 +178,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("secondary type value", request.Properties["DependencyOutput"]);
         }
 
-        [Fact]
-        public async Task NugetChartingReferencesInvokeSucceeds()
-        {
-            TestHelpers.ClearFunctionLogs("NugetChartingReferences");
+        //[Fact]
+        //public async Task NugetChartingReferencesInvokeSucceeds()
+        //{
+        //    TestHelpers.ClearFunctionLogs("NugetChartingReferences");
 
-            string testData = Guid.NewGuid().ToString();
-            string inputName = "input";
-            Dictionary<string, object> arguments = new Dictionary<string, object>
-            {
-                { inputName, testData }
-            };
-            await Fixture.Host.CallAsync("NugetChartingReferences", arguments);
+        //    string testData = Guid.NewGuid().ToString();
+        //    string inputName = "input";
+        //    Dictionary<string, object> arguments = new Dictionary<string, object>
+        //    {
+        //        { inputName, testData }
+        //    };
+        //    await Fixture.Host.CallAsync("NugetChartingReferences", arguments);
 
-            // make sure the input string made it all the way through
-            var logs = await TestHelpers.GetFunctionLogsAsync("NugetChartingReferences");
-            Assert.True(logs.Any(p => p.Contains(testData)));
-        }
+        //    // make sure the input string made it all the way through
+        //    var logs = await TestHelpers.GetFunctionLogsAsync("NugetChartingReferences");
+        //    Assert.True(logs.Any(p => p.Contains(testData)));
+        //}
 
         [Fact]
         public async Task PrivateAssemblyDependenciesAreLoaded()

--- a/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
@@ -179,6 +179,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task NugetChartingReferencesInvokeSucceeds()
+        {
+            TestHelpers.ClearFunctionLogs("NugetChartingReferences");
+
+            string testData = Guid.NewGuid().ToString();
+            string inputName = "input";
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { inputName, testData }
+            };
+            await Fixture.Host.CallAsync("NugetChartingReferences", arguments);
+
+            // make sure the input string made it all the way through
+            var logs = await TestHelpers.GetFunctionLogsAsync("NugetChartingReferences");
+            Assert.True(logs.Any(p => p.Contains(testData)));
+        }
+
+        [Fact]
         public async Task PrivateAssemblyDependenciesAreLoaded()
         {
             var request = new System.Net.Http.HttpRequestMessage();

--- a/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests/FSharpEndToEndTests.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await ServiceBusQueueTriggerToBlobTestImpl();
         }
 
+        [Fact]
+        public async Task TwilioReferenceInvokeSucceeds()
+        {
+            await TwilioReferenceInvokeSucceedsImpl(isDotNet: true);
+        }
+
         //[Fact]
         //public async Task MobileTables()
         //{

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/function.json
@@ -1,0 +1,9 @@
+﻿{
+    "bindings": [
+        {
+            "type": "manualTrigger",
+            "name": "input",
+            "direction": "in"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/function.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "bindings": [
         {
             "type": "manualTrigger",

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
@@ -1,4 +1,4 @@
-﻿//#r "Twilio.Api"
+//#r "Twilio.Api"
 
 using System;
 using Microsoft.Azure.WebJobs.Host;

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
@@ -1,8 +1,8 @@
-﻿#r "Twilio.Api"
+﻿//#r "Twilio.Api"
 
 using System;
 using Microsoft.Azure.WebJobs.Host;
-using Twilio;
+//using Twilio;
 
 public static void Run(string input, TraceWriter log)
 {

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
@@ -1,0 +1,10 @@
+﻿#r "Twilio.Api"
+
+using System;
+using Microsoft.Azure.WebJobs.Host;
+using Twilio;
+
+public static void Run(string input, TraceWriter log)
+{
+    log.Info(input);
+}

--- a/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
+++ b/test/WebJobs.Script.Tests/TestScripts/CSharp/TwilioReference/run.csx
@@ -1,8 +1,8 @@
-//#r "Twilio.Api"
+#r "Twilio.Api"
 
 using System;
 using Microsoft.Azure.WebJobs.Host;
-//using Twilio;
+using Twilio;
 
 public static void Run(string input, TraceWriter log)
 {

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubFileTrigger/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubFileTrigger/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubTable/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubTable/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubTableClient/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubTableClient/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubTableEntity/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/ApiHubTableEntity/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/AssembliesFromSharedLocation/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/AssembliesFromSharedLocation/run.fsx
@@ -3,7 +3,7 @@
 
 #if !COMPILED
 open System.Runtime.InteropServices
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/DocumentDBIn/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/DocumentDBIn/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/DocumentDBOut/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/DocumentDBOut/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/LoadScriptReference/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/LoadScriptReference/run.fsx
@@ -3,7 +3,7 @@
 
 #if !COMPILED
 open System.Runtime.InteropServices
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/ManualTrigger/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/ManualTrigger/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/MobileTableIn/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/MobileTableIn/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/MobileTableOut/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/MobileTableOut/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/MobileTableTable/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/MobileTableTable/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NotificationHubNative/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NotificationHubNative/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NotificationHubOut/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NotificationHubOut/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NotificationHubOutNotification/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NotificationHubOutNotification/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/function.json
@@ -1,0 +1,19 @@
+﻿{
+    "bindings": [
+        {
+            "type": "manualTrigger",
+            "name": "input",
+            "direction": "in"
+        }
+    ],
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "FSharp.Data": "2.3.2",
+                "XPlot.Plotly": "1.3.1",
+                "XPlot.GoogleCharts": "1.3.1",
+                "Google.DataTable.Net.Wrapper": "3.1.2"
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/function.json
@@ -5,15 +5,5 @@
             "name": "input",
             "direction": "in"
         }
-    ],
-    "frameworks": {
-        "net46": {
-            "dependencies": {
-                "FSharp.Data": "2.3.2",
-                "XPlot.Plotly": "1.3.1",
-                "XPlot.GoogleCharts": "1.3.1",
-                "Google.DataTable.Net.Wrapper": "3.1.2"
-            }
-        }
-    }
+    ]
 }

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/project.json
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/project.json
@@ -1,0 +1,12 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "FSharp.Data": "2.3.2",
+                "XPlot.Plotly": "1.3.1",
+                "XPlot.GoogleCharts": "1.3.1",
+                "Google.DataTable.Net.Wrapper": "3.1.2"
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/NugetChartingReferences/run.fsx
@@ -1,0 +1,60 @@
+//----------------------------------------------------------------------------------------
+// This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
+
+#if !COMPILED
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
+#r "Microsoft.Azure.WebJobs.Host.dll"
+#r "System.Web.Http.dll"
+#r "System.Net.Http.dll"
+#r "System.IO"
+#endif
+
+//----------------------------------------------------------------------------------------
+// This is the implementation of the function 
+
+#r "System.Data.dll"
+#r "Google.DataTable.Net.Wrapper.dll"
+#r "XPlot.GoogleCharts.dll"
+#r "XPlot.Plotly.dll"
+
+open System
+open FSharp.Data
+open Google.DataTable.Net.Wrapper
+open XPlot.GoogleCharts
+open XPlot.Plotly
+open System.Net
+open System.Net.Http
+open Microsoft.Azure.WebJobs.Host
+open System.Data
+open System.Threading.Tasks
+
+type data = {
+    label: string
+    value: float
+}
+
+let Run (input: string, log: TraceWriter) =  
+
+    log.Info(sprintf "Generate chart")
+
+    let mutable Bolivia = [("2015/2016",2);("2016/2017",2);("2017/2018",19)]
+    let mutable Ecuador = [("2015/2016",6);("2016/2017",42);("2017/2018",3)]
+    let mutable Madagascar = [("2015/2016",11);("2016/2017",22);("2017/2018",2)]
+    let mutable Average = [("2015/2016",31);("2016/2017",3);("2017/2018",14)]
+
+    let series = [ "bars"; "bars"; "bars"; "lines" ]
+    let inputs = [ Bolivia; Ecuador; Madagascar; Average ]
+
+    let output =
+        inputs
+        |> Chart.Combo
+        |> Chart.WithOptions 
+            (Options(title = "Coffee Production", series = 
+                [| for typ in series -> Series(typ) |]))
+        |> Chart.WithLabels 
+            ["Bolivia"; "Ecuador"; "Madagascar"; "Average"]
+        |> Chart.WithLegend true
+        |> Chart.WithSize (600, 250)   
+
+    log.Info(output.Html)
+    log.Info(input)

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/PrivateAssemblyReference/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/PrivateAssemblyReference/run.fsx
@@ -3,7 +3,7 @@
 
 #if !COMPILED
 open System.Runtime.InteropServices
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/QueueTriggerToBlob/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/QueueTriggerToBlob/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/Scenarios/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/Scenarios/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/ServiceBusQueueTriggerToBlob/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/ServiceBusQueueTriggerToBlob/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/TwilioReference/function.json
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/TwilioReference/function.json
@@ -1,0 +1,9 @@
+﻿{
+    "bindings": [
+        {
+            "type": "manualTrigger",
+            "name": "input",
+            "direction": "in"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests/TestScripts/FSharp/TwilioReference/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FSharp/TwilioReference/run.fsx
@@ -1,4 +1,4 @@
-﻿//----------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
@@ -7,13 +7,15 @@
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif
 
+#r "Twilio.Api"
+
+open Twilio
+
 //----------------------------------------------------------------------------------------
 // This is the implementation of the function 
 
 open System
 open Microsoft.Azure.WebJobs.Host
 
-let Run(input: string, log: TraceWriter) =
-    log.Info "F# ApiHub trigger function processed a file..."
-    input
-
+let Run(input: string, log: TraceWriter) =   
+    log.Info(input)

--- a/test/WebJobs.Script.Tests/TestScripts/FunctionGeneration/HttpTrigger-FSharp/run.fsx
+++ b/test/WebJobs.Script.Tests/TestScripts/FunctionGeneration/HttpTrigger-FSharp/run.fsx
@@ -2,7 +2,7 @@
 // This prelude allows scripts to be edited in Visual Studio or another F# editing environment 
 
 #if !COMPILED
-#I "../../../../../bin/Binaries/WebJobs.Script.Host"
+#I "../../../../../src/WebJobs.Script.Host/bin/Debug"
 #r "Microsoft.Azure.WebJobs.Host.dll"
 #r "Microsoft.Azure.WebJobs.Extensions.dll"
 #endif

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -835,10 +835,10 @@
     <Content Include="TestScripts\FSharp\PrivateAssemblyReference\run.fsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <None Include="TestScripts\FSharp\TwilioReference\run.csx">
+    <None Include="TestScripts\FSharp\TwilioReference\run.fsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="TestScripts\FSharp\NugetChartingReferences\run.csx">
+    <None Include="TestScripts\FSharp\NugetChartingReferences\run.fsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Content Include="TestScripts\Node\ApiHubTableEntityIn\index.js">

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -682,6 +682,9 @@
     <None Include="TestScripts\CSharp\TwilioReference\run.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\CSharp\TwilioReference\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Empty\host.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -838,7 +841,13 @@
     <None Include="TestScripts\FSharp\TwilioReference\run.fsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\FSharp\TwilioReference\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\FSharp\NugetChartingReferences\run.fsx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\FSharp\NugetChartingReferences\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Content Include="TestScripts\Node\ApiHubTableEntityIn\index.js">

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -679,6 +679,9 @@
     <None Include="TestScripts\CSharp\AssembliesFromSharedLocation\run.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\CSharp\TwilioReference\run.csx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Empty\host.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -832,6 +835,12 @@
     <Content Include="TestScripts\FSharp\PrivateAssemblyReference\run.fsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="TestScripts\FSharp\TwilioReference\run.csx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\FSharp\NugetChartingReferences\run.csx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Content Include="TestScripts\Node\ApiHubTableEntityIn\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -850,6 +850,9 @@
     <None Include="TestScripts\FSharp\NugetChartingReferences\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\FSharp\NugetChartingReferences\project.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Content Include="TestScripts\Node\ApiHubTableEntityIn\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Previously, F# was compiling to a dynamic assembly, which was causing
assembly resolution issues. Now, F# compiles to a static assembly, then
loads the bytes from disk, emulating the way the C# compile works.

In order to make this work, the mangled assembly name had to be changed
to create a name with no illegal path characters in it.