### PR TITLE
Adding a CLI trace writer

### DIFF
--- a/src/WebJobs.Script.Cli/Common/SelfHostWebHostSettingsFactory.cs
+++ b/src/WebJobs.Script.Cli/Common/SelfHostWebHostSettingsFactory.cs
@@ -2,14 +2,16 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using WebJobs.Script.Cli.Diagnostics;
 
 namespace WebJobs.Script.Cli.Common
 {
     internal static class SelfHostWebHostSettingsFactory
     {
-        public static WebHostSettings Create(int nodeDebugPort)
+        public static WebHostSettings Create(int nodeDebugPort, TraceLevel consoleTraceLevel)
         {
             return new WebHostSettings
             {
@@ -17,7 +19,8 @@ namespace WebJobs.Script.Cli.Common
                 ScriptPath = Path.Combine(Environment.CurrentDirectory),
                 LogPath = Path.Combine(Path.GetTempPath(), @"LogFiles\Application\Functions"),
                 SecretsPath = Path.Combine(Environment.CurrentDirectory, "secrets", "functions", "secrets"),
-                NodeDebugPort = nodeDebugPort
+                NodeDebugPort = nodeDebugPort,
+                TraceWriter = new ConsoleTraceWriter(consoleTraceLevel)
             };
         }
     }

--- a/src/WebJobs.Script.Cli/Diagnostics/ConsoleTraceWriter.cs
+++ b/src/WebJobs.Script.Cli/Diagnostics/ConsoleTraceWriter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Colors.Net;
+using Colors.Net.StringColorExtensions;
+using Microsoft.Azure.WebJobs.Host;
+using static WebJobs.Script.Cli.Common.OutputTheme;
+
+namespace WebJobs.Script.Cli.Diagnostics
+{
+    public class ConsoleTraceWriter : TraceWriter
+    {
+        public ConsoleTraceWriter(TraceLevel level) : base(level)
+        {
+        }
+
+        public override void Trace(TraceEvent traceEvent)
+        {
+            if (Level >= traceEvent.Level)
+            {
+                ColoredConsole.WriteLine(GetMessageString(traceEvent));
+            }
+        }
+
+        private static RichString GetMessageString(TraceEvent traceEvent)
+        {
+            switch (traceEvent.Level)
+            {
+                case TraceLevel.Error:
+                    return ErrorColor(traceEvent.Message);
+                case TraceLevel.Warning:
+                    return traceEvent.Message.Yellow();
+                case TraceLevel.Info:
+                    return AdditionalInfoColor(traceEvent.Message);
+                case TraceLevel.Verbose:
+                    return VerboseColor(traceEvent.Message);
+                default:
+                    return traceEvent.Message.White();
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.Cli/WebJobs.Script.Cli.csproj
+++ b/src/WebJobs.Script.Cli/WebJobs.Script.Cli.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Common\SecretsManager.cs" />
     <Compile Include="ConsoleApp.cs" />
     <Compile Include="Context.cs" />
+    <Compile Include="Diagnostics\ConsoleTraceWriter.cs" />
     <Compile Include="Extensions\FunctionStatusExtensions.cs" />
     <Compile Include="Extensions\GenericExtensions.cs" />
     <Compile Include="Extensions\IEnumerableExtensions.cs" />

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         ReinitializeAppSettings();
                     }
 
-                    _activeScriptHostConfig = GetScriptHostConfiguration(settings.ScriptPath, settings.LogPath);
+                    _activeScriptHostConfig = CreateScriptHostConfiguration(settings);
                     _activeSecretManager = GetSecretManager(_settingsManager, settings.SecretsPath);
                     _activeReceiverManager = new WebHookReceiverManager(_activeSecretManager);
                     _activeHostManager = new WebScriptHostManager(_activeScriptHostConfig, _activeSecretManager, _settingsManager, settings);
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 if (_standbyHostManager == null)
                 {
-                    _standbyScriptHostConfig = GetScriptHostConfiguration(settings.ScriptPath, settings.LogPath);
+                    _standbyScriptHostConfig = CreateScriptHostConfiguration(settings);
                     _standbySecretManager = GetSecretManager(_settingsManager, settings.SecretsPath);
                     _standbyReceiverManager = new WebHookReceiverManager(_standbySecretManager);
                     _standbyHostManager = new WebScriptHostManager(_standbyScriptHostConfig, _standbySecretManager, _settingsManager, settings);
@@ -149,15 +149,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        private static ScriptHostConfiguration GetScriptHostConfiguration(string scriptPath, string logPath)
+        private static ScriptHostConfiguration CreateScriptHostConfiguration(WebHostSettings settings)
         {
-            InitializeFileSystem(scriptPath);
+            InitializeFileSystem(settings.ScriptPath);
 
             var scriptHostConfig = new ScriptHostConfiguration()
             {
-                RootScriptPath = scriptPath,
-                RootLogPath = logPath,
-                FileLoggingMode = FileLoggingMode.DebugOnly
+                RootScriptPath = settings.ScriptPath,
+                RootLogPath = settings.LogPath,
+                FileLoggingMode = FileLoggingMode.DebugOnly,
+                TraceWriter = settings.TraceWriter
             };
 
             // If running on Azure Web App, derive the host ID from the default subdomain

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
@@ -22,5 +22,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         [JsonProperty("nodeDebugPort")]
         public int NodeDebugPort { get; set; }
+
+        [JsonIgnore]
+        public TraceWriter TraceWriter { get; set; }
     }
 }


### PR DESCRIPTION
This is a bit hacky right now. We need to make some changes to the runtime to enable a cleaner way to handle these scenarios (ideally, we'd be able to easily inject our own `ITraceWriterFactory`) but the changes to make that happen would significantly increase the scope of this work. We'll plan for those changes and revisit once we have that in place.