### PR TITLE
Avoid loading a number of assemblies on start

### DIFF
--- a/src/WebJobs.Script.WebHost/Web.Release.config
+++ b/src/WebJobs.Script.WebHost/Web.Release.config
@@ -6,31 +6,11 @@
   <appSettings>
     <add key="Microsoft.Azure.NotificationHubs.ConnectionString" xdt:Locator="Match(key)" xdt:Transform="Remove" />
   </appSettings>
-  <!--
-    In the example below, the "SetAttributes" transform will change the value of 
-    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
-    finds an attribute "name" that has a value of "MyDB".
-    
-    <connectionStrings>
-      <add name="MyDB" 
-        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
-        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
-    </connectionStrings>
-  -->
-  <system.web>
-    <compilation xdt:Transform="RemoveAttributes(debug)" />
-    <hostingEnvironment shadowCopyBinAssemblies="false" xdt:Transform="Insert" />
 
-    <!--
-      In the example below, the "Replace" transform will replace the entire 
-      <customErrors> section of your web.config file.
-      Note that because there is only one customErrors section under the 
-      <system.web> node, there is no need to use the "xdt:Locator" attribute.
-      
-      <customErrors defaultRedirect="GenericError.htm"
-        mode="RemoteOnly" xdt:Transform="Replace">
-        <error statusCode="500" redirect="InternalError.htm"/>
-      </customErrors>
-    -->
-  </system.web>
+  <location path="." inheritInChildApplications="false">
+    <system.web>
+      <compilation xdt:Transform="RemoveAttributes(debug)" />
+      <hostingEnvironment shadowCopyBinAssemblies="false" xdt:Transform="Insert" />
+    </system.web>
+  </location>
 </configuration>

--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -13,10 +13,31 @@
         <httpRuntime targetFramework="4.5" />
       </system.Web>
   -->
-  <system.web>
-    <compilation debug="true" targetFramework="4.6" />
-    <httpRuntime targetFramework="4.5" maxRequestLength="16384" />
-  </system.web>
+  <location path="." inheritInChildApplications="false">
+    <system.web>
+      <compilation debug="true" targetFramework="4.6">
+        <assemblies>
+          <!-- Don't load a few assemblies inherited from root config that we have no need for -->
+          <remove assembly="System.ServiceModel.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+          <remove assembly="System.WorkflowServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+          <remove assembly="System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+          <remove assembly="System.Data.DataSetExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+          <remove assembly="System.Web.DynamicData, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+          <remove assembly="System.Web.WebPages.Deployment, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+
+          <!-- Don't load all the bin assemblies, except for the only one we need -->
+          <remove assembly="*" />
+          <add assembly="Microsoft.Azure.WebJobs.Script.WebHost" />
+        </assemblies>
+      </compilation>
+      <pages>
+        <namespaces>
+          <clear />
+        </namespaces>
+      </pages>
+      <httpRuntime targetFramework="4.5" maxRequestLength="16384" />
+    </system.web>
+  </location>
   <system.webServer>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />


### PR DESCRIPTION
Also, move `<system.web>` into `<location>` section to avoid affecting child virtual apps