### PR TITLE
Fixing FSharpCompilationService file checks

### DIFF
--- a/src/WebJobs.Script/Extensions/FileUtility.cs
+++ b/src/WebJobs.Script/Extensions/FileUtility.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public static class FileUtility
+    {
+        public static Task DeleteIfExistsAsync(string path)
+        {
+            return Task.Run(() =>
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            });
+        }
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -408,6 +408,7 @@
     <Compile Include="EnvironmentSettingNames.cs" />
     <Compile Include="ExpandoObjectJsonConverter.cs" />
     <Compile Include="Extensions\ExceptionExtensions.cs" />
+    <Compile Include="Extensions\FileUtility.cs" />
     <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
     <Compile Include="Extensions\IDictionaryExtensions.cs" />
     <Compile Include="Extensions\IMetricsLoggerExtensions.cs" />


### PR DESCRIPTION
*This is a tactical fix, need to revisit*

Fixing issues causing F# compilation failures.