### PR TITLE
ServiceBus: exposing AutoRenewTimeout setting to host.json

### DIFF
--- a/src/WebJobs.Script/Binding/ServiceBusScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/ServiceBusScriptBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Microsoft.Azure.WebJobs.Host;
@@ -54,6 +55,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 if (configSection.TryGetValue("maxConcurrentCalls", StringComparison.OrdinalIgnoreCase, out value))
                 {
                     serviceBusConfig.MessageOptions.MaxConcurrentCalls = (int)value;
+                }
+
+                if (configSection.TryGetValue("autoRenewTimeout", StringComparison.OrdinalIgnoreCase, out value))
+                {
+                    serviceBusConfig.MessageOptions.AutoRenewTimeout = TimeSpan.Parse((string)value, CultureInfo.InvariantCulture);
                 }
 
                 if (configSection.TryGetValue("prefetchCount", StringComparison.OrdinalIgnoreCase, out value))


### PR DESCRIPTION
Addresses #1026 

I was able to verify that the default Service Bus `AutoRenewTimeout` value is 5 minutes, which explains the timing in the filed bug. This allows you to override that. 