### PR TITLE
Logging compilation errors in invocation path

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
@@ -129,10 +129,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
             catch (CompilationErrorException exc)
             {
-                compilationResult = compilationResult.AddRange(exc.Diagnostics);
+                compilationResult = AddFunctionDiagnostics(compilationResult.AddRange(exc.Diagnostics));
             }
 
-            TraceCompilationDiagnostics(compilationResult);
+            TraceCompilationDiagnostics(compilationResult, LogTargets.User);
 
             bool compilationSucceeded = !compilationResult.Any(d => d.Severity == DiagnosticSeverity.Error);
 
@@ -150,7 +150,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        internal Task<MethodInfo> GetFunctionTargetAsync() => _functionLoader.GetFunctionTargetAsync();
+        internal async Task<MethodInfo> GetFunctionTargetAsync()
+        {
+            try
+            {
+                return await _functionLoader.GetFunctionTargetAsync().ConfigureAwait(false);
+            }
+            catch (CompilationErrorException exc)
+            {
+                TraceOnPrimaryHost("Function compilation error", TraceLevel.Error);
+                TraceCompilationDiagnostics(exc.Diagnostics, LogTargets.User);
+                throw;
+            }
+        }
 
         private void RestorePackages()
         {
@@ -186,7 +198,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             // Separate system parameters from the actual method parameters
             object[] originalParameters = parameters;
-            MethodInfo function = await _functionLoader.GetFunctionTargetAsync();
+            MethodInfo function = await GetFunctionTargetAsync();
+
             int actualParameterCount = function.GetParameters().Length;
             object[] systemParameters = parameters.Skip(actualParameterCount).ToArray();
             parameters = parameters.Take(actualParameterCount).ToArray();
@@ -261,11 +274,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     return _functionEntryPointResolver.GetFunctionEntryPoint(scriptType.DeclaredMethods.ToList());
                 }
             }
-            catch (CompilationErrorException ex)
+            catch (CompilationErrorException exc)
             {
-                TraceOnPrimaryHost("Function compilation error", TraceLevel.Error);
-                TraceCompilationDiagnostics(ex.Diagnostics);
-                throw;
+                ImmutableArray<Diagnostic> diagnostics = AddFunctionDiagnostics(exc.Diagnostics);
+
+                // Here we only need to trace to system logs
+                TraceCompilationDiagnostics(diagnostics, LogTargets.System);
+
+                throw new CompilationErrorException(exc.Message, diagnostics);
             }
         }
 
@@ -290,19 +306,48 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        private void TraceCompilationDiagnostics(ImmutableArray<Diagnostic> diagnostics)
+        internal void TraceCompilationDiagnostics(ImmutableArray<Diagnostic> diagnostics, LogTargets logTarget = LogTargets.All)
         {
+            if (logTarget == LogTargets.None)
+            {
+                return;
+            }
+
+            TraceWriter traceWriter = TraceWriter;
+            IDictionary<string, object> properties = PrimaryHostTraceProperties;
+
+            if (!logTarget.HasFlag(LogTargets.User))
+            {
+                traceWriter = Host.TraceWriter;
+                properties = PrimaryHostSystemTraceProperties;
+            }
+            else if (!logTarget.HasFlag(LogTargets.System))
+            {
+                properties = PrimaryHostUserTraceProperties;
+            }
+
             foreach (var diagnostic in diagnostics.Where(d => !d.IsSuppressed))
             {
-                TraceWriter.Trace(diagnostic.ToString(), diagnostic.Severity.ToTraceLevel(), PrimaryHostTraceProperties);
-
-                ImmutableArray<Diagnostic> scriptDiagnostics = GetFunctionDiagnostics(diagnostic);
-
-                if (!scriptDiagnostics.IsEmpty)
-                {
-                    TraceCompilationDiagnostics(scriptDiagnostics);
-                }
+                traceWriter.Trace(diagnostic.ToString(), diagnostic.Severity.ToTraceLevel(), properties);
             }
+        }
+
+        private ImmutableArray<Diagnostic> AddFunctionDiagnostics(ImmutableArray<Diagnostic> diagnostics)
+        {
+            var result = diagnostics.Aggregate(new List<Diagnostic>(), (a, d) =>
+            {
+                a.Add(d);
+                ImmutableArray<Diagnostic> functionsDiagnostics = GetFunctionDiagnostics(d);
+
+                if (!functionsDiagnostics.IsEmpty)
+                {
+                    a.AddRange(functionsDiagnostics);
+                }
+
+                return a;
+            });
+
+            return ImmutableArray.CreateRange(result);
         }
 
         private ImmutableArray<Diagnostic> GetFunctionDiagnostics(Diagnostic diagnostic)
@@ -433,6 +478,15 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             return processor ?? ((_, __, ___, ____) => { /*noop*/ });
+        }
+
+        [Flags]
+        internal enum LogTargets
+        {
+            None = 0,
+            System = 1,
+            User = 2,
+            All = System | User
         }
     }
 }

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -45,14 +45,16 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 { ScriptConstants.TracePropertyFunctionNameKey, Metadata.Name }
             };
             TraceWriter = TraceWriter.Apply(functionTraceProperties);
-
-            PrimaryHostTraceProperties = new Dictionary<string, object>
-            {
-                { ScriptConstants.TracePropertyPrimaryHostKey, true }
-            };
         }
 
-        protected IDictionary<string, object> PrimaryHostTraceProperties { get; }
+        protected static IDictionary<string, object> PrimaryHostTraceProperties { get; }
+            = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { ScriptConstants.TracePropertyPrimaryHostKey, true } });
+
+        protected static IDictionary<string, object> PrimaryHostUserTraceProperties { get; }
+            = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>(PrimaryHostTraceProperties) { { ScriptConstants.TracePropertyIsUserTraceKey, true } });
+
+        protected static IDictionary<string, object> PrimaryHostSystemTraceProperties { get; }
+            = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>(PrimaryHostTraceProperties) { { ScriptConstants.TracePropertyIsSystemTraceKey, true } });
 
         public ScriptHost Host { get; }
 

--- a/src/WebJobs.Script/Description/FunctionLoader.cs
+++ b/src/WebJobs.Script/Description/FunctionLoader.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly ReaderWriterLockSlim _functionValueLoaderLock = new ReaderWriterLockSlim();
         private readonly Func<CancellationToken, Task<T>> _valueFactory;
         private FunctionValueLoader<T> _functionValueLoader;
-        private bool disposed = false;
+        private bool _disposed = false;
 
         public FunctionLoader(Func<CancellationToken, Task<T>> valueFactory)
         {
@@ -69,10 +69,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         void Dispose(bool disposing)
         {
-            if (!disposed && disposing)
+            if (!_disposed && disposing)
             {
                 _functionValueLoader.Dispose();
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script
             ScriptConfig = scriptConfig;
             FunctionErrors = new Dictionary<string, Collection<string>>(StringComparer.OrdinalIgnoreCase);
             NodeFunctionInvoker.UnhandledException += OnUnhandledException;
+            TraceWriter = ScriptConfig.TraceWriter;
         }
 
         public static readonly string Version = GetAssemblyFileVersion(typeof(ScriptHost).Assembly);
@@ -236,7 +237,6 @@ namespace Microsoft.Azure.WebJobs.Script
                     .Subscribe(HandleHostError);
                 ScriptConfig.HostConfig.Tracing.Tracers.Add(traceMonitor);
 
-                TraceWriter = ScriptConfig.TraceWriter;
                 TraceLevel hostTraceLevel = ScriptConfig.HostConfig.Tracing.ConsoleLevel;
                 if (ScriptConfig.FileLoggingMode != FileLoggingMode.Never)
                 {


### PR DESCRIPTION
Resolves #924 

With this changes, when a function with compilation failures is invokec, user logs will change from this:
```
2016-12-12T23:26:44.824 Function started (Id=d49d6446-c7b7-4222-a005-9d770b24dd9a)
2016-12-12T23:26:44.824 Function completed (Failure, Id=d49d6446-c7b7-4222-a005-9d770b24dd9a)
2016-12-12T23:26:44.839 Exception while executing function: Functions.ManualTriggerCSharp4. Microsoft.Azure.WebJobs.Script: Script compilation failed.
```

To this:
```
2016-12-12T23:20:55.128 Function started (Id=3a28d9bc-f933-428e-a789-147d11460f73)
2016-12-12T23:20:55.191 Function compilation error
2016-12-12T23:20:55.191 (5,9): error CS1061: 'TraceWriter' does not contain a definition for 'Test' and no extension method 'Test' accepting a first argument of type 'TraceWriter' could be found (are you missing a using directive or an assembly reference?)
2016-12-12T23:20:55.191 Function completed (Failure, Id=3a28d9bc-f933-428e-a789-147d11460f73)
2016-12-12T23:20:55.206 Exception while executing function: Functions.ManualTriggerCSharp4. Microsoft.Azure.WebJobs.Script: Script compilation failed.
```

The changes also reduce the number compilation related logs against system logs. Limiting them to function target creation only (when first compiling the function for execution).