### PR TITLE
Fixing a few issues that were primarily impacting F#

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilationService.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilationService.cs
@@ -18,12 +18,13 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     [CLSCompliant(false)]
     public class CSharpCompilationService : ICompilationService
     {
-        private readonly IFunctionMetadataResolver _metadataResolver;
+        private static readonly string[] FileTypes = { ".csx", ".cs" };
         private static readonly Encoding UTF8WithNoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         private static readonly Lazy<InteractiveAssemblyLoader> AssemblyLoader
           = new Lazy<InteractiveAssemblyLoader>(() => new InteractiveAssemblyLoader(), LazyThreadSafetyMode.ExecutionAndPublication);
 
         private readonly OptimizationLevel _optimizationLevel;
+        private readonly IFunctionMetadataResolver _metadataResolver;
 
         public CSharpCompilationService(IFunctionMetadataResolver metadataResolver, OptimizationLevel optimizationLevel)
         {
@@ -31,21 +32,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _optimizationLevel = optimizationLevel;
         }
 
-        public string Language
-        {
-            get
-            {
-                return "CSharp";
-            }
-        }
+        public string Language => "CSharp";
 
-        public IEnumerable<string> SupportedFileTypes
-        {
-            get
-            {
-                return new[] { ".csx", ".cs" };
-            }
-        }
+        public IEnumerable<string> SupportedFileTypes => FileTypes;
 
         public ICompilation GetFunctionCompilation(FunctionMetadata functionMetadata)
         {

--- a/src/WebJobs.Script/Description/DotNet/DotNetCompilationServiceFactory.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetCompilationServiceFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.CodeAnalysis;
 
@@ -14,14 +15,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         private static readonly ImmutableArray<ScriptType> SupportedScriptTypes = new[] { ScriptType.CSharp, ScriptType.FSharp, ScriptType.DotNetAssembly }.ToImmutableArray();
         private static OptimizationLevel? _optimizationLevel;
+        private readonly TraceWriter _traceWriter;
 
-        ImmutableArray<ScriptType> ICompilationServiceFactory.SupportedScriptTypes
+        public DotNetCompilationServiceFactory(TraceWriter traceWriter)
         {
-            get
-            {
-                return SupportedScriptTypes;
-            }
+            _traceWriter = traceWriter;
         }
+
+        ImmutableArray<ScriptType> ICompilationServiceFactory.SupportedScriptTypes => SupportedScriptTypes;
 
         internal static OptimizationLevel OptimizationLevel
         {
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 case ScriptType.CSharp:
                     return new CSharpCompilationService(metadataResolver, OptimizationLevel);
                 case ScriptType.FSharp:
-                    return new FSharpCompiler(metadataResolver, OptimizationLevel);
+                    return new FSharpCompiler(metadataResolver, OptimizationLevel, _traceWriter);
                 case ScriptType.DotNetAssembly:
                     return new RawAssemblyCompilationService();
                 default:

--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly ICompilationServiceFactory _compilationServiceFactory;
 
         public DotNetFunctionDescriptorProvider(ScriptHost host, ScriptHostConfiguration config)
-           : this(host, config, new DotNetCompilationServiceFactory())
+           : this(host, config, new DotNetCompilationServiceFactory(host.TraceWriter))
         {
         }
 

--- a/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 "System.Configuration",
                 "System.Xml",
                 "System.Net.Http",
+                "System.Runtime",
+                "System.Threading.Tasks",
                 "Microsoft.CSharp",
-                typeof(object).Assembly.Location,
                 typeof(IAsyncCollector<>).Assembly.Location, /*Microsoft.Azure.WebJobs*/
                 typeof(JobHost).Assembly.Location, /*Microsoft.Azure.WebJobs.Host*/
                 typeof(CoreJobHostConfigurationExtensions).Assembly.Location, /*Microsoft.Azure.WebJobs.Extensions*/
@@ -117,13 +118,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public IReadOnlyCollection<string> GetCompilationReferences()
         {
-            // Add package reference assemblies
-            var result = new List<string>(_packageAssemblyResolver.AssemblyReferences);
+            // Combine our default references with package references
+            var combinedReferences = DefaultAssemblyReferences
+                .Union(_packageAssemblyResolver.AssemblyReferences);
 
-            // Add default references
-            result.AddRange(DefaultAssemblyReferences);
-
-            return result.AsReadOnly();
+            return new ReadOnlyCollection<string>(combinedReferences.ToList());
         }
 
         /// <summary>
@@ -189,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 bool externalReference = false;
                 string basePath = _privateAssembliesPath;
-                
+
                 // If this is a relative assembly reference, use the function directory as the base probing path
                 if (reference.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }) > -1)
                 {

--- a/src/WebJobs.Script/Description/DotNet/PackageAssemblyResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/PackageAssemblyResolver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     assemblies.AddRange(p.Assemblies.Values);
                     assemblies.AddRange(p.FrameworkAssemblies.Values);
                     return assemblies;
-                });
+                }).Distinct();
             }
         }
 


### PR DESCRIPTION
1 - Ensuring that package resolver does not return duplicate references
2 - Ensuring that the MetadataResolver handles duplicates when adding default references
3 - Fixing F# compilation service to get the script references and removing dependency on C# compilation
4 - Fixing issue preventing the load context from being initialized for F#, which would trigger dependency resolution failures.

Resolves #1044 
Resolves #1027 
Resolves #985 
Mitigates #178 (this addresses the most common scenarios)