### PR TITLE
remove json serialization for fastlogger

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FastLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FastLogger.cs
@@ -28,12 +28,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public async Task AddAsync(FunctionInstanceLogEntry item, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Convert Host to Protocol so we can log it 
-            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
-            var jsonClone = JsonConvert.SerializeObject(item, settings);
-            var item2 = JsonConvert.DeserializeObject<FunctionInstanceLogItem>(jsonClone);
-            item2.FunctionName = Utility.GetFunctionShortName(item2.FunctionName);
-            await _writer.AddAsync(item2);
+            await _writer.AddAsync(new FunctionInstanceLogItem
+            {
+                FunctionInstanceId = item.FunctionInstanceId,
+                FunctionName = Utility.GetFunctionShortName(item.FunctionName),
+                StartTime = item.StartTime,
+                EndTime = item.EndTime,
+                TriggerReason = item.TriggerReason,
+                Arguments = item.Arguments,
+                ErrorDetails = item.ErrorDetails,
+                LogOutput = item.LogOutput,
+                ParentId = item.ParentId
+            });
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
resolves #903 

Not sure that this is worth the optimization.  Both FunctionInstanceLogItem and FunctionInstanceLogEntry are types in the core sdk, not the script repo.  If they are changed the JSON serialize code here will automatically propagate changes, whereas the new code would not.

Essentially, as you can see below, this will save ~250ms on script host startup.  It is 100x faster for all logs thereafter, but the cost of the current implementation is quite small (~250ms per 10000 logs).

**Perf Comparison**

For 10000 FunctionInstanceLogEntries:

|Iteration|JSON Serialize|Direct Assign|Comment|
|-|-|-|-|
first|500ms|3ms|JSON.net takes ~250ms for type reflection on first call, which is then cached|
repeat|250ms|2ms||
