### PR TITLE
Updating AuthorizationLevelAttribute to make proper use of new secret manager async API

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
             // Determine the authorization level of the request
             ISecretManager secretManager = controllerContext.Configuration.DependencyResolver.GetService<ISecretManager>();
-            AuthorizationLevel authorizationLevel = AuthorizationLevelAttribute.GetAuthorizationLevel(request, secretManager, functionName: function.Name);
+            AuthorizationLevel authorizationLevel = await AuthorizationLevelAttribute.GetAuthorizationLevelAsync(request, secretManager, functionName: function.Name);
 
             if (function.Metadata.IsExcluded ||
                 (function.Metadata.IsDisabled && authorizationLevel != AuthorizationLevel.Admin))


### PR DESCRIPTION
This updates the `AuthorizationLevelAttribute` to consume the new async API exposed by the `SecretManager` in its `OnAuthorizationAsync` method, making proper use (non-blocking) of the async API and avoiding potential deadlock issues.