### PR TITLE
Improve node function traces

### DIFF
--- a/src/WebJobs.Script/Content/Script/functions.js
+++ b/src/WebJobs.Script/Content/Script/functions.js
@@ -26,15 +26,17 @@ function clearRequireCache(context, callback) {
     callback();
 }
 
-function createFunction(f) {
+function createFunction(func) {
     return function (context, callback) {
         // TEMP HACK: workaround for https://github.com/tjanczuk/edge/issues/325
         setImmediate(() => { });
 
-        f = getEntryPoint(f, context);
-
         // configure loggers
         var origLog = context.log;
+        var systemLog = function () {
+            var message = util.format.apply(null, arguments);
+            origLog({ lvl: 4, msg: message, sys: true });
+        }
         var logLevel = function (traceLevel) {
             return function () {
                 var message = util.format.apply(null, arguments);
@@ -49,7 +51,15 @@ function createFunction(f) {
         });
         context.log = log;
 
+        if (typeof func === "string") {
+            systemLog("Requiring user function script.");
+            func = require(func);
+        }
+
+        func = getEntryPoint(func, context);
+
         context.done = function (err, result) {
+            systemLog("context.done called.");
             if (context._done) {
                 if (context._promise) {
                     context.log("Error: Choose either to return a promise or call 'done'.  Do not use both in your script.");
@@ -90,7 +100,8 @@ function createFunction(f) {
         }
         delete context._triggerType;
 
-        var result = f.apply(null, inputs);
+        systemLog("Executing exported user function.");
+        var result = func.apply(null, inputs);
         if (result && util.isFunction(result.then)) {
             context._promise = true;
             result.then((result) => context.done(null, result))
@@ -99,31 +110,31 @@ function createFunction(f) {
     };
 }
 
-function getEntryPoint(f, context) {
-    if (util.isObject(f)) {
+function getEntryPoint(func, context) {
+    if (util.isObject(func)) {
         if (context._entryPoint) {
             // the module exports multiple functions
             // and an explicit entry point was named
-            f = f[context._entryPoint];
+            func = func[context._entryPoint];
             delete context._entryPoint;
         }
-        else if (Object.keys(f).length == 1) {
+        else if (Object.keys(func).length == 1) {
             // a single named function was exported
-            var name = Object.keys(f)[0];
-            f = f[name];
+            var name = Object.keys(func)[0];
+            func = func[name];
         }
         else {
             // finally, see if there is an exported function named
             // 'run' or 'index' by convention
-            f = f.run || f.index;
+            func = func.run || func.index;
         }
     }
 
-    if (!util.isFunction(f)) {
+    if (!util.isFunction(func)) {
         throw "Unable to determine function entry point. If multiple functions are exported, " +
             "you must indicate the entry point, either by naming it 'run' or 'index', or by naming it " +
             "explicitly via the 'entryPoint' metadata property.";
     }
 
-    return f;
+    return func;
 }

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTests.cs
@@ -50,15 +50,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { "input", input }
             };
             await host.CallAsync("ManualTrigger", parameters);
-
-            Assert.Equal(4, _fixture.EventGenerator.Events.Count);
-            Assert.True(_fixture.EventGenerator.Events[0].StartsWith("Info WebJobs.Execution Executing 'Functions.ManualTrigger' (Reason='This function was programmatically called via the host APIs.', Id="));
-            Assert.True(_fixture.EventGenerator.Events[1].StartsWith("Info ManualTrigger Function started (Id="));
-            Assert.True(_fixture.EventGenerator.Events[2].StartsWith("Info ManualTrigger Function completed (Success, Id="));
-            Assert.True(_fixture.EventGenerator.Events[3].StartsWith("Info WebJobs.Execution Executed 'Functions.ManualTrigger' (Succeeded, Id="));
+            var events = _fixture.EventGenerator.Events;
+            Assert.Equal(9, events.Count);
+            Assert.True(events[0].StartsWith("Info WebJobs.Execution Executing 'Functions.ManualTrigger' (Reason='This function was programmatically called via the host APIs.', Id="));
+            Assert.True(events[1].StartsWith("Info ManualTrigger Function started (Id="));
+            Assert.True(events[2].StartsWith("Verbose ManualTrigger Executing Edge.Func."));
+            Assert.True(events[3].StartsWith("Verbose ManualTrigger Requiring user function script."));
+            Assert.True(events[4].StartsWith("Verbose ManualTrigger Executing exported user function."));
+            Assert.True(events[5].StartsWith("Verbose ManualTrigger context.done called."));
+            Assert.True(events[6].StartsWith("Verbose ManualTrigger Edge.Func completed."));
+            Assert.True(events[7].StartsWith("Info ManualTrigger Function completed (Success, Id="));
+            Assert.True(events[8].StartsWith("Info WebJobs.Execution Executed 'Functions.ManualTrigger' (Succeeded, Id="));
 
             // make sure the user log wasn't traced
-            Assert.False(_fixture.EventGenerator.Events.Any(p => p.Contains("ManualTrigger function invoked!")));
+            Assert.False(events.Any(p => p.Contains("ManualTrigger function invoked!")));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -312,9 +312,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await Fixture.Host.CallAsync("MultipleExports", arguments);
 
             var logs = await TestHelpers.GetFunctionLogsAsync("MultipleExports");
+            var log = logs.Where(l => l.Contains("Exports:"));
 
-            Assert.Equal(3, logs.Count);
-            Assert.True(logs[1].Contains("Exports: IsObject=true, Count=4"));
+            Assert.True(log.First().Contains("Exports: IsObject=true, Count=4"));
         }
 
         [Fact]
@@ -330,8 +330,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var logs = await TestHelpers.GetFunctionLogsAsync("SingleNamedExport");
 
-            Assert.Equal(3, logs.Count);
-            Assert.True(logs[1].Contains("Exports: IsObject=true, Count=1"));
+            var log = logs.Where(l => l.Contains("Exports:"));
+            Assert.True(log.First().Contains("Exports: IsObject=true, Count=1"));
         }
 
         [Fact]
@@ -850,7 +850,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var logs = (await TestHelpers.GetFunctionLogsAsync("TimerTrigger")).ToArray();
 
-            Assert.True(logs[1].Contains("Timer function ran!"));
+            Assert.True(logs.Any(l => l.Contains("Timer function ran!")));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/functions.tests.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/functions.tests.js
@@ -230,7 +230,7 @@ describe('functions', () => {
             var func = functions.createFunction((context) => {
                 context.done();
                 context.done();
-                expect(logs[0].msg).to.match(/Error: 'done' has already been called.*/);
+                expect(logs.pop().msg).to.match(/Error: 'done' has already been called.*/);
             });
 
             func(context, () => {});
@@ -244,7 +244,7 @@ describe('functions', () => {
 
             func(context, () => {
                 setImmediate(() => {
-                    expect(logs[0].msg).to.match(/Error: Choose either to return a promise or call 'done'.*/);
+                    expect(logs.pop().msg).to.match(/Error: Choose either to return a promise or call 'done'.*/);
                     done();
                 });
             });
@@ -262,11 +262,13 @@ describe('functions', () => {
 
             func(context, () => {
                 expect(logs).to.eql([
+                    { lvl: 4, msg: "Executing exported user function.", sys: true},
                     { lvl: 3, msg: 'default' },
                     { lvl: 1, msg: 'error' },
                     { lvl: 2, msg: 'warn' },
                     { lvl: 3, msg: 'info' },
                     { lvl: 4, msg: 'verbose' },
+                    { lvl: 4, msg: "context.done called.", sys: true },
                 ])
                 done();
             });


### PR DESCRIPTION
resolves #1092 

Logging at a verbose level, so to see these traces users will need to set 
`      "tracing": {
      "consoleLevel": "verbose"
    }` in their host.json.  We'll get them in mds/kusto automatically.

Output looks something like:

2017-01-11T22:36:12.832 Function started (Id=99ace4a1-d7ff-4a1f-b3cc-c9ed9556e39f)
2017-01-11T22:36:12.879 Initializing node environment.
2017-01-11T22:36:13.132 Processing table binding myTableBinding.
2017-01-11T22:36:14.245 Executing Edge.Func.
2017-01-11T22:36:14.259 Requiring user function script.
2017-01-11T22:36:22.915 Executing exported user function.
... user logs, not logged in mds/kusto ...
2017-01-11T22:36:22.934 context.done called.
2017-01-11T22:36:22.934 Edge.Func completed.
2017-01-11T22:36:22.946 Function completed (Success, Id=99ace4a1-d7ff-4a1f-b3cc-c9ed9556e39f)
