### PR TITLE
Refactor to make function metadata read code publically accessible

### DIFF
--- a/test/WebJobs.Script.Tests/Description/Node/NodeFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Node/NodeFunctionGenerationTests.cs
@@ -202,10 +202,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 FunctionDescriptorProvider[] descriptorProviders = new FunctionDescriptorProvider[]
                 {
-                new NodeFunctionDescriptorProvider(host, scriptConfig)
+                    new NodeFunctionDescriptorProvider(host, scriptConfig)
                 };
 
-                functionDescriptors = host.ReadFunctions(functions, descriptorProviders);
+                functionDescriptors = host.GetFunctionDescriptors(functions, descriptorProviders);
             }
 
             Type t = FunctionGenerator.Generate("TestScriptHost", "Host.Functions", null, functionDescriptors);

--- a/test/WebJobs.Script.Tests/Description/PowerShell/PowerShellFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/Description/PowerShell/PowerShellFunctionGenerationTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 new PowerShellFunctionDescriptorProvider(scriptHostInfo.Host, scriptHostInfo.Configuration)
             };
 
-            var functionDescriptors = scriptHostInfo.Host.ReadFunctions(functions, descriptorProviders);
+            var functionDescriptors = scriptHostInfo.Host.GetFunctionDescriptors(functions, descriptorProviders);
             Type t = FunctionGenerator.Generate("TestScriptHost", "Host.Functions", null, functionDescriptors);
 
             MethodInfo method = t.GetMethods(BindingFlags.Public | BindingFlags.Static).First();

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -42,6 +42,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void ReadFunctionMetadata_Succeeds()
+        {
+            var config = new ScriptHostConfiguration
+            {
+                RootScriptPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\sample")
+            };
+            var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+            var functionErrors = new Dictionary<string, Collection<string>>();
+            var metadata = ScriptHost.ReadFunctionMetadata(config, traceWriter, functionErrors);
+            Assert.Equal(48, metadata.Count);
+        }
+
+        [Fact]
         public async Task OnDebugModeFileChanged_TriggeredWhenDebugFileUpdated()
         {
             ScriptHost host = _fixture.Host;


### PR DESCRIPTION
Primarily because our CLI needs to access function metadata