### PR TITLE
Capture node stdout and stderr

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/functions.tests.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/functions.tests.js
@@ -233,7 +233,7 @@ describe('functions', () => {
                 expect(logs[0].msg).to.match(/Error: 'done' has already been called.*/);
             });
 
-            func(context, () => {});
+            func(context, () => { });
         });
 
         it('logs if promise and done', (done) => {
@@ -321,6 +321,30 @@ describe('functions', () => {
                 expect(context.res.headers.header).to.equal('val');
                 expect(context._http).to.be.undefined;
                 expect(context._done).to.be.true;
+            });
+        });
+    });
+
+    describe('global init', (done) => {
+        it('captures stdout and stderr if context.console', () => {
+            var stdo = process.stdout;
+            var stde = process.stderr;
+
+            var logs = [];
+            var console = (log) => logs.push(log);
+            var context = {
+                console: console,
+                unauthorizedException: () => { }
+            }
+
+            var func = functions.globalInitialization(context, () => {
+                process.stdout.write("stdout");
+                process.stderr.write("stderr");
+                process.stdout = stdo;
+                process.stderr = stde;
+
+                expect(logs[0]).to.equal("stdout");
+                expect(logs[1]).to.equal("stderr");
             });
         });
     });


### PR DESCRIPTION
resolves #1095 

To capture logs, in host.json: `{ tracing: { consoleLevel: 'verbose' }}`.  I think that is better than adding another configuration knob, but that's up for discussion.

If this setting exists, we pass a 'context.console' logging function to the node global initialization function, which captures `process.stdout/stderr`.  These logs are written to the user host log (they will not appear on a per function basis or in mds)

**edit** appveyor failure was due to it not running 6.5.0 x86, updated the appveyor script and script-UT projects