### PR TITLE
Allowing relative script file references

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -425,6 +425,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "json", "json", "{3A4AF861-6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Extensibility.Tests", "test\WebJobs.Extensibility.Tests\WebJobs.Extensibility.Tests.csproj", "{9A8111D1-A7A1-4D60-98D1-705D1C849588}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTriggerShared", "HttpTriggerShared", "{EB76E1C8-C823-4707-BD83-20304425EFC4}"
+	ProjectSection(SolutionItems) = preProject
+		sample\HttpTriggerShared\function.json = sample\HttpTriggerShared\function.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35a2025d-f68a-4b57-83a2-ed4eb9c3894d}*SharedItemsImports = 4
@@ -546,5 +551,6 @@ Global
 		{35C9CCB7-D8B6-4161-BB0D-BCFA7C6DCFFB} = {FD93A1ED-5AC4-4F9B-9087-E1C24320F36E}
 		{3A4AF861-66F2-4C34-BB9E-69F0D392BB1A} = {67174433-2838-460C-9880-419476D02994}
 		{9A8111D1-A7A1-4D60-98D1-705D1C849588} = {FD93A1ED-5AC4-4F9B-9087-E1C24320F36E}
+		{EB76E1C8-C823-4707-BD83-20304425EFC4} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 	EndGlobalSection
 EndGlobal

--- a/sample/HttpTriggerShared/function.json
+++ b/sample/HttpTriggerShared/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "scriptFile": "..\\HttpTrigger\\index.js",
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -289,6 +289,10 @@
       <HintPath>..\..\packages\System.Diagnostics.StackTrace.4.0.1\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.FileSystem.4.0.1\lib\net46\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -59,6 +59,7 @@
   <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
   <package id="System.IO" version="4.1.0" targetFramework="net46" />
+  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -334,12 +334,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(logs[1].Contains("Exports: IsObject=true, Count=1"));
         }
 
-        [Fact]
-        public async Task HttpTrigger_Get()
+        [Theory]
+        [InlineData("httptrigger")]
+        [InlineData("httptriggershared")]
+        public async Task HttpTrigger_Get(string functionName)
         {
             HttpRequestMessage request = new HttpRequestMessage
             {
-                RequestUri = new Uri(string.Format("http://localhost/api/httptrigger?name=Mathew%20Charles&location=Seattle")),
+                RequestUri = new Uri($"http://localhost/api/{functionName}?name=Mathew%20Charles&location=Seattle"),
                 Method = HttpMethod.Get,
             };
             request.SetConfiguration(Fixture.RequestConfiguration);

--- a/test/WebJobs.Script.Tests.Integration/Properties/Resources.Designer.cs
+++ b/test/WebJobs.Script.Tests.Integration/Properties/Resources.Designer.cs
@@ -85,23 +85,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {
-        ///    &quot;scriptFile&quot;:&quot;DotNetFunctionAssembly.dll&quot;,
+        ///   Looks up a localized string similar to {{
+        ///    &quot;scriptFile&quot;:&quot;{0}&quot;,
         ///    &quot;entryPoint&quot;: &quot;TestFunction.Function.Run&quot;,
         ///    &quot;bindings&quot;: [
-        ///        {
+        ///        {{
         ///            &quot;type&quot;: &quot;httpTrigger&quot;,
         ///            &quot;name&quot;: &quot;req&quot;,
         ///            &quot;direction&quot;: &quot;in&quot;,
         ///            &quot;methods&quot;: [ &quot;get&quot; ]
-        ///        },
-        ///        {
+        ///        }},
+        ///        {{
         ///            &quot;type&quot;: &quot;http&quot;,
         ///            &quot;name&quot;: &quot;$return&quot;,
         ///            &quot;direction&quot;: &quot;out&quot;
-        ///        }
+        ///        }}
         ///    ]
-        ///}.
+        ///}}.
         /// </summary>
         internal static string DotNetFunctionJson {
             get {

--- a/test/WebJobs.Script.Tests.Integration/Properties/Resources.resx
+++ b/test/WebJobs.Script.Tests.Integration/Properties/Resources.resx
@@ -149,23 +149,23 @@
 }</value>
   </data>
   <data name="DotNetFunctionJson" xml:space="preserve">
-    <value>{
-    "scriptFile":"DotNetFunctionAssembly.dll",
+    <value>{{
+    "scriptFile":"{0}",
     "entryPoint": "TestFunction.Function.Run",
     "bindings": [
-        {
+        {{
             "type": "httpTrigger",
             "name": "req",
             "direction": "in",
             "methods": [ "get" ]
-        },
-        {
+        }},
+        {{
             "type": "http",
             "name": "$return",
             "direction": "out"
-        }
+        }}
     ]
-}</value>
+}}</value>
   </data>
   <data name="DotNetFunctionSource" xml:space="preserve">
     <value>using System.Net;

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTriggerShared/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTriggerShared/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "scriptFile": "../HttpTrigger/index.js",
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "request",
+            "direction": "in",
+            "methods": [ "get", "post" ]
+        },
+        {
+            "type": "http",
+            "name": "response",
+            "direction": "out"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -566,6 +566,9 @@
     <None Include="TestScripts\DotNet\host.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\Node\HttpTriggerShared\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Node\MultipleOutputs\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Configuration;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
@@ -51,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
             var functionErrors = new Dictionary<string, Collection<string>>();
             var metadata = ScriptHost.ReadFunctionMetadata(config, traceWriter, functionErrors);
-            Assert.Equal(48, metadata.Count);
+            Assert.Equal(49, metadata.Count);
         }
 
         [Fact]
@@ -189,14 +191,40 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { "scriptFile", scriptFileName }
             };
-            string[] functionFiles = new string[]
+
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\queueTrigger.py",
-                @"c:\functions\helper.py",
-                @"c:\functions\test.txt"
+                { @"c:\functions\queueTrigger.py", new MockFileData(string.Empty) },
+                { @"c:\functions\helper.py", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
-            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles);
-            Assert.Equal(@"c:\functions\queueTrigger.py", scriptFile);
+
+            var fileSystem = new MockFileSystem(files);
+
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
+            Assert.Equal(@"c:\functions\queueTrigger.py", scriptFile, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void DeterminePrimaryScriptFile_RelativeSourceFileSpecified()
+        {
+            JObject functionConfig = new JObject()
+            {
+                { "scriptFile", @"..\shared\queuetrigger.py" }
+            };
+
+            var files = new Dictionary<string, MockFileData>
+            {
+                { @"c:\shared\queueTrigger.py", new MockFileData(string.Empty) },
+                { @"c:\functions\queueTrigger.py", new MockFileData(string.Empty) },
+                { @"c:\functions\helper.py", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
+            };
+
+            var fileSystem = new MockFileSystem(files);
+
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
+            Assert.Equal(@"c:\shared\queueTrigger.py", scriptFile, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -206,89 +234,98 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { "scriptFile", "queueTrigger.py" }
             };
-            string[] functionFiles = new string[]
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\run.py",
-                @"c:\functions\queueTrigger.py",
-                @"c:\functions\helper.py",
-                @"c:\functions\test.txt"
+                { @"c:\functions\run.py", new MockFileData(string.Empty) },
+                { @"c:\functions\queueTrigger.py", new MockFileData(string.Empty) },
+                { @"c:\functions\helper.py", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
-            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles);
+            var fileSystem = new MockFileSystem(files);
+
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\queueTrigger.py", scriptFile);
         }
 
         [Fact]
         public void DeterminePrimaryScriptFile_MultipleFiles_NoClearPrimary_ReturnsNull()
         {
-            JObject functionConfig = new JObject();
-            string[] functionFiles = new string[]
+            var functionConfig = new JObject();
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\foo.py",
-                @"c:\functions\queueTrigger.py",
-                @"c:\functions\helper.py",
-                @"c:\functions\test.txt"
+                { @"c:\functions\foo.py", new MockFileData(string.Empty) },
+                { @"c:\functions\queueTrigger.py", new MockFileData(string.Empty) },
+                { @"c:\functions\helper.py", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
-            Assert.Null(ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles));
+            var fileSystem = new MockFileSystem(files);
+            Assert.Throws<ConfigurationErrorsException>(() => ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem));
         }
 
         [Fact]
         public void DeterminePrimaryScriptFile_NoFiles_ReturnsNull()
         {
-            JObject functionConfig = new JObject();
+            var functionConfig = new JObject();
             string[] functionFiles = new string[0];
-            Assert.Null(ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles));
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\functions");
+            Assert.Throws<ConfigurationErrorsException>(() => ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem));
         }
 
         [Fact]
         public void DeterminePrimaryScriptFile_MultipleFiles_RunFilePresent()
         {
-            JObject functionConfig = new JObject();
-            string[] functionFiles = new string[]
+            var functionConfig = new JObject();
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\Run.csx",
-                @"c:\functions\Helper.csx",
-                @"c:\functions\test.txt"
+                { @"c:\functions\Run.csx", new MockFileData(string.Empty) },
+                { @"c:\functions\Helper.csx", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
-            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles);
+            var fileSystem = new MockFileSystem(files);
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\Run.csx", scriptFile);
         }
 
         [Fact]
         public void DeterminePrimaryScriptFile_SingleFile()
         {
-            JObject functionConfig = new JObject();
-            string[] functionFiles = new string[]
+            var functionConfig = new JObject();
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\Run.csx"
+                { @"c:\functions\Run.csx", new MockFileData(string.Empty) }
             };
-            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles);
+            var fileSystem = new MockFileSystem(files);
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\Run.csx", scriptFile);
         }
 
         [Fact]
         public void DeterminePrimaryScriptFile_MultipleFiles_RunTrumpsIndex()
         {
-            JObject functionConfig = new JObject();
-            string[] functionFiles = new string[]
+            var functionConfig = new JObject();
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\run.js",
-                @"c:\functions\index.js",
-                @"c:\functions\test.txt"
+                { @"c:\functions\run.js", new MockFileData(string.Empty) },
+                { @"c:\functions\index.js", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
-            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles);
+            var fileSystem = new MockFileSystem(files);
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\run.js", scriptFile);
         }
 
         [Fact]
         public void DeterminePrimaryScriptFile_MultipleFiles_IndexFilePresent()
         {
-            JObject functionConfig = new JObject();
-            string[] functionFiles = new string[]
+            var functionConfig = new JObject();
+            var files = new Dictionary<string, MockFileData>
             {
-                @"c:\functions\index.js",
-                @"c:\functions\test.txt"
+                { @"c:\functions\index.js", new MockFileData(string.Empty) },
+                { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
-            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, functionFiles);
+            var fileSystem = new MockFileSystem(files);
+            string scriptFile = ScriptHost.DeterminePrimaryScriptFile(functionConfig, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\index.js", scriptFile);
         }
 
@@ -808,16 +845,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }));
             var mappedHttpFunctions = new Dictionary<string, HttpTriggerBindingMetadata>();
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
-            var functionFilesProvider = new Lazy<string[]>(() => new string[] { "run.csx" });
             FunctionMetadata functionMetadata = null;
             string functionError = null;
-            bool result = ScriptHost.TryParseFunctionMetadata("test", functionConfig, mappedHttpFunctions, traceWriter, functionFilesProvider, out functionMetadata, out functionError);
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(@"c:\functions\test\run.csx", new MockFileData(string.Empty));
+            fileSystem.AddFile(@"c:\functions\test2\run.csx", new MockFileData(string.Empty));
+            fileSystem.AddFile(@"c:\functions\test3\run.csx", new MockFileData(string.Empty));
+            fileSystem.AddFile(@"c:\functions\test4\run.csx", new MockFileData(string.Empty));
+            fileSystem.AddFile(@"c:\functions\test5\run.csx", new MockFileData(string.Empty));
+            bool result = ScriptHost.TryParseFunctionMetadata("test", functionConfig, mappedHttpFunctions, traceWriter, @"c:\functions\test", out functionMetadata, out functionError, fileSystem);
             Assert.True(result);
             Assert.NotNull(functionMetadata);
             Assert.Null(functionError);
             Assert.Equal(1, mappedHttpFunctions.Count);
             Assert.True(mappedHttpFunctions.ContainsKey("test"));
-            Assert.Equal("run.csx", functionMetadata.ScriptFile);
+            Assert.Equal(@"c:\functions\test\run.csx", functionMetadata.ScriptFile);
 
             // add another for a completely different route
             functionConfig["bindings"] = new JArray(new JObject
@@ -830,7 +872,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
             functionMetadata = null;
             functionError = null;
-            result = ScriptHost.TryParseFunctionMetadata("test2", functionConfig, mappedHttpFunctions, traceWriter, functionFilesProvider, out functionMetadata, out functionError);
+            result = ScriptHost.TryParseFunctionMetadata("test2", functionConfig, mappedHttpFunctions, traceWriter, @"c:\functions\test2", out functionMetadata, out functionError, fileSystem);
             Assert.True(result);
             Assert.NotNull(functionMetadata);
             Assert.Null(functionError);
@@ -848,7 +890,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
             functionMetadata = null;
             functionError = null;
-            result = ScriptHost.TryParseFunctionMetadata("test3", functionConfig, mappedHttpFunctions, traceWriter, functionFilesProvider, out functionMetadata, out functionError);
+            result = ScriptHost.TryParseFunctionMetadata("test3", functionConfig, mappedHttpFunctions, traceWriter, @"c:\functions\test3", out functionMetadata, out functionError, fileSystem);
             Assert.True(result);
             Assert.NotNull(functionMetadata);
             Assert.Null(functionError);
@@ -866,7 +908,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
             functionMetadata = null;
             functionError = null;
-            result = ScriptHost.TryParseFunctionMetadata("test4", functionConfig, mappedHttpFunctions, traceWriter, functionFilesProvider, out functionMetadata, out functionError);
+            result = ScriptHost.TryParseFunctionMetadata("test4", functionConfig, mappedHttpFunctions, traceWriter, @"c:\functions\test4", out functionMetadata, out functionError, fileSystem);
             Assert.False(result);
             Assert.NotNull(functionMetadata);
             Assert.True(functionError.StartsWith("The route specified conflicts with the route defined by function"));
@@ -882,7 +924,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
             functionMetadata = null;
             functionError = null;
-            result = ScriptHost.TryParseFunctionMetadata("test5", functionConfig, mappedHttpFunctions, traceWriter, functionFilesProvider, out functionMetadata, out functionError);
+            result = ScriptHost.TryParseFunctionMetadata("test5", functionConfig, mappedHttpFunctions, traceWriter, @"c:\functions\test5", out functionMetadata, out functionError, fileSystem);
             Assert.False(result);
             Assert.NotNull(functionMetadata);
             Assert.Equal(3, mappedHttpFunctions.Count);

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -371,6 +371,14 @@
       <HintPath>..\..\packages\System.Diagnostics.StackTrace.4.0.1\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.FileSystem.4.0.1\lib\net46\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -77,6 +77,8 @@
   <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
   <package id="System.IO" version="4.1.0" targetFramework="net46" />
+  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net46" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />


### PR DESCRIPTION
This enables relative references to script files, primarily addressing the need to reference shared precompiled assemblies, but enabling this for other languages as well.

With this changes, relative references like this are now supported:
```"scriptFile":"..\\shared\\myassembly.dll"```