### PR TITLE
Added compilation error for async void functions

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/CSharp/Analyzers/AsyncVoidAnalyzer.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/Analyzers/AsyncVoidAnalyzer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Description.DotNet.CSharp.Analyzers
+{
+    [CLSCompliant(false)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class AsyncVoidAnalyzer : DiagnosticAnalyzer
+    {
+        private const string Title = "Avoid async void";
+        private const string MessageFormat = "This method has the async keyword but it returns void";
+        private readonly DiagnosticDescriptor _supportedRule;
+
+        public AsyncVoidAnalyzer()
+        {
+            _supportedRule = new DiagnosticDescriptor(DotNetConstants.AsyncVoidCode,
+                Title, MessageFormat, "Function", DiagnosticSeverity.Warning, true);
+        }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_supportedRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Method);
+        }
+
+        private void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var methodSymbol = (IMethodSymbol)context.Symbol;
+
+            if (methodSymbol.ReturnsVoid && methodSymbol.IsAsync)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(_supportedRule, methodSymbol.Locations[0], methodSymbol.Name));
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Description/DotNet/CSharp/Analyzers/InvalidFileMetadataReferenceAnalyzer.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/Analyzers/InvalidFileMetadataReferenceAnalyzer.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description.DotNet.CSharp.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterCompilationAction(AnalizeCompilation);
+            context.RegisterCompilationAction(AnalyzeCompilation);
         }
 
-        private void AnalizeCompilation(CompilationAnalysisContext context)
+        private void AnalyzeCompilation(CompilationAnalysisContext context)
         {
             // Find CS0006: Metadata file '{0}' could not be found
             Diagnostic invalidMetadataDiagnostic = context.Compilation

--- a/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         // Simply getting the built in analyzers for now.
         // This should eventually be enhanced to dynamically discover/load analyzers.
-        private static ImmutableArray<DiagnosticAnalyzer> _analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new InvalidFileMetadataReferenceAnalyzer());
+        private static ImmutableArray<DiagnosticAnalyzer> _analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new InvalidFileMetadataReferenceAnalyzer(), new AsyncVoidAnalyzer());
 
         public CSharpCompilation(Compilation compilation)
         {

--- a/src/WebJobs.Script/Description/DotNet/DotNetConstants.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetConstants.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public const string RedundantPackageAssemblyReference = "AF005";
         public const string InvalidFileMetadataReferenceCode = "AF006";
         public const string InvalidEntryPointNameCompilationCode = "AF007";
+        public const string AsyncVoidCode = "AF008";
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Config\FeatureFlags.cs" />
     <Compile Include="Description\Binding\Cardinality.cs" />
     <Compile Include="Description\DiagnosticSeverityExtensions.cs" />
+    <Compile Include="Description\DotNet\CSharp\Analyzers\AsyncVoidAnalyzer.cs" />
     <Compile Include="Description\DotNet\DiagnosticExtensions.cs" />
     <Compile Include="Description\DotNet\CSharp\Analyzers\InvalidFileMetadataReferenceAnalyzer.cs" />
     <Compile Include="Description\DotNet\CSharp\CSharpCompilation.cs" />

--- a/test/WebJobs.Script.Tests/Description/DotNet/CSharp/CSharpCompilationTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/CSharp/CSharpCompilationTests.cs
@@ -46,5 +46,22 @@ public void Run(){
 
             Assert.Equal(1, diagnostics.Count());
         }
+
+        [Fact]
+        public void AsyncVoid_ReturnsExpectedDiagnostics()
+        {
+            string code = @"
+public async void Run(){
+await System.Threading.Tasks.Task.Run(() => {});
+}";
+            Script<object> script = CSharpScript.Create(code);
+            var compilation = new CSharpCompilation(script.GetCompilation());
+
+            var diagnostic = compilation.GetDiagnostics().First();
+
+            Assert.Equal("This method has the async keyword but it returns void",
+                diagnostic.GetMessage());
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        }
     }
 }


### PR DESCRIPTION
resolves #863 

@fabiocav we recompile all functions on host restart, correct? If so, setting this to error will be a breaking change outside of the context of editing function code. Perhaps we should downgrade to 'warning' until we have a breaking release.