### PR TITLE
Handle json arrays for script languages

### DIFF
--- a/src/WebJobs.Script/Binding/HttpBinding.cs
+++ b/src/WebJobs.Script/Binding/HttpBinding.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             {
                 try
                 {
-                    // attempt to read the content as json
-                    content = JObject.Parse(stringContent);
+                    // attempt to read the content as JObject/JArray
+                    content = JsonConvert.DeserializeObject(stringContent);
                 }
                 catch (JsonException)
                 {

--- a/test/WebJobs.Script.Tests.Integration/PhpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/PhpEndToEndTests.cs
@@ -1,8 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Microsoft.WindowsAzure.Storage.Blob;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -37,6 +44,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task QueueTriggerToBlob()
         {
             await QueueTriggerToBlobTest();
+        }
+
+        [Fact]
+        public async Task HttpTrigger_Get_Array()
+        {
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri("http://localhost/api/httptrigger"),
+                Method = HttpMethod.Get
+            };
+            request.SetConfiguration(new HttpConfiguration());
+
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "req", request }
+            };
+            await Fixture.Host.CallAsync("HttpTrigger", arguments);
+
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var contentType = response.Content.Headers.ContentType;
+            Assert.Equal("application/json", contentType.MediaType);
+            Assert.Equal("utf-8", contentType.CharSet);
+
+            ObjectContent objectContent = response.Content as ObjectContent;
+            Assert.NotNull(objectContent);
+            Assert.Equal(typeof(JArray), objectContent.ObjectType);
+            JArray content = await response.Content.ReadAsAsync<JArray>();
+            Assert.Equal("[{\"a\":\"b\"}]", content.ToString(Formatting.None));
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Php/HttpTrigger/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Php/HttpTrigger/function.json
@@ -1,0 +1,15 @@
+{
+    "bindings": [
+      {
+          "type": "httpTrigger",
+          "direction": "in",
+          "name": "req",
+          "methods": [ "get" ]
+      },
+      {
+          "type": "http",
+          "name": "res",
+          "direction": "out"
+      }
+    ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Php/HttpTrigger/run.php
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Php/HttpTrigger/run.php
@@ -1,0 +1,5 @@
+<?php
+  $json = '[{"a":"b"}]';
+  $res = getenv('res');
+  file_put_contents($res, $json);
+?>

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -945,6 +945,12 @@
     <None Include="TestScripts\Php\host.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\Php\HttpTrigger\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <Content Include="TestScripts\Php\HttpTrigger\run.php">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="TestScripts\Php\ManualTrigger\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
resolves #1116 

Basically JObject.Parse throws an exception for json arrays.

JsonConvert.DeserializeObject will return a JObject/JArray, and the rest of the logic flows from there.  

Still issues with returning binary content from script languages, as it needs to be written to an intermediate json file.