### PR TITLE
fix express api and return binding

### DIFF
--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 // get the output value from the script
                 object value = null;
                 bool haveValue = bindings.TryGetValue(binding.Metadata.Name, out value);
-                if (!haveValue && string.Compare(binding.Metadata.Type, "http", StringComparison.OrdinalIgnoreCase) == 0)
+                if (value == null && string.Compare(binding.Metadata.Type, "http", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     // http bindings support a special context.req/context.res programming
                     // model, so we must map that back to the actual binding name if a value

--- a/src/WebJobs.Script/azurefunctions/functions.js
+++ b/src/WebJobs.Script/azurefunctions/functions.js
@@ -107,7 +107,7 @@ function getEntryPoint(f, context) {
             f = f[context._entryPoint];
             delete context._entryPoint;
         }
-        else if (Object.keys(f).length == 1) {
+        else if (Object.keys(f).length === 1) {
             // a single named function was exported
             var name = Object.keys(f)[0];
             f = f[name];

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -562,6 +562,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task HttpTriggerExpressApi_Return()
+        {
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(string.Format("http://localhost/api/httptrigger")),
+                Method = HttpMethod.Get
+            };
+            request.SetConfiguration(new HttpConfiguration());
+
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "request", request }
+            };
+            await Fixture.Host.CallAsync("HttpTriggerReturn", arguments);
+
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("test", content);
+        }
+
+        [Fact]
         public async Task HttpTriggerPromise_TestBinding()
         {
             HttpRequestMessage request = new HttpRequestMessage

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTriggerReturn/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTriggerReturn/function.json
@@ -1,0 +1,15 @@
+﻿{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "request",
+            "direction": "in",
+            "methods": [ "get", "post" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTriggerReturn/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTriggerReturn/index.js
@@ -1,0 +1,3 @@
+﻿module.exports = function (context, req) {
+    context.res.type("text/plain").send("test");
+}

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -479,6 +479,9 @@
     <Content Include="TestScripts\Node\functions.tests.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestScripts\Node\HttpTriggerReturn\index.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestScripts\Node\HttpTrigger-Scenarios\index.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -564,6 +567,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="TestScripts\DotNet\host.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\Node\HttpTriggerReturn\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestScripts\Node\HttpTriggerShared\function.json">


### PR DESCRIPTION
resolves #1182 

If `$return` is a null value default back to the context.res object