### PR TITLE
Allow 'code' value to be specified via headers for WebHooks (#1098)

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
@@ -614,6 +614,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task GenericWebHook_Post_NamedKey_Headers_Succeeds()
+        {
+            // Authenticate using values specified via headers,
+            // rather than URI query params
+            string uri = "api/webhook-generic";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+            request.Headers.Add("x-functions-key", "1388a6b0d05eca2237f10e4a4641260b0a08f3a6");
+            request.Headers.Add("x-functions-clientid", "testclient");
+            request.Content = new StringContent("{ 'value': 'Foobar' }");
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            HttpResponseMessage response = await this._fixture.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+            string body = await response.Content.ReadAsStringAsync();
+            JObject jsonObject = JObject.Parse(body);
+            Assert.Equal("Value: Foobar", jsonObject["result"]);
+        }
+
+        [Fact]
         public async Task GenericWebHook_Post_NamedKeyInHeader_Succeeds()
         {
             // Authenticate using a named key (client id)

--- a/test/WebJobs.Script.Tests/WebHooks/WebHookReceiverManagerTests.cs
+++ b/test/WebJobs.Script.Tests/WebHooks/WebHookReceiverManagerTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
+using Microsoft.Azure.WebJobs.Script.WebHost.WebHooks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.WebHooks
+{
+    public class WebHookReceiverManagerTests
+    {
+        private const string TestKey = "1388a6b0d05eca2237f10e4a4641260b0a08f3a6";
+        private const string TestId = "testclient";
+
+        [Fact]
+        public void ApplyHeaderValuesToQuery_NoHeadersPresent_ReturnsExpectedValue()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "http://test.com/api/test");
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test", request.RequestUri.ToString());
+
+            request = new HttpRequestMessage(HttpMethod.Post, $"http://test.com/api/test?code={TestKey}&clientid={TestId}");
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?code={TestKey}&clientid={TestId}", request.RequestUri.ToString());   
+        }
+
+        [Fact]
+        public void ApplyHeaderValuesToQuery_CodeInHeaders_ReturnsExpectedValue()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, $"http://test.com/api/test?clientid={TestId}");
+            request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, TestKey);
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?clientid={TestId}&code={TestKey}", request.RequestUri.ToString());
+        }
+
+        [Fact]
+        public void ApplyHeaderValuesToQuery_CodeAndClientIdInHeadesr_ReturnsExpectedValue()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://test.com/api/test");
+            request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, TestKey);
+            request.Headers.Add(WebHookReceiverManager.FunctionsClientIdHeaderName, TestId);
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?code={TestKey}", request.RequestUri.ToString());
+        }
+
+        [Fact]
+        public void ApplyHeaderValuesToQuery_ValuesInHeadersAndQuery_ReturnsExpectedValue()
+        {
+            // query string value takes precedence
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://test.com/api/test?code=foo&clientid=bar");
+            request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, TestKey);
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?code=foo&clientid=bar", request.RequestUri.ToString());
+
+            // case insensitive query param lookups
+            request = new HttpRequestMessage(HttpMethod.Post, "http://test.com/api/test?CODE=foo&clientid=bar");
+            request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, TestKey);
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?CODE=foo&clientid=bar", request.RequestUri.ToString());
+
+            // code via query param, id via header
+            request = new HttpRequestMessage(HttpMethod.Post, $"http://test.com/api/test?code={TestKey}");
+            request.Headers.Add(WebHookReceiverManager.FunctionsClientIdHeaderName, TestId);
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?code={TestKey}", request.RequestUri.ToString());
+
+            // id via query param, code via header
+            request = new HttpRequestMessage(HttpMethod.Post, $"http://test.com/api/test?clientid={TestId}");
+            request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, TestKey);
+            WebHookReceiverManager.ApplyHeaderValuesToQuery(request);
+            Assert.Equal($"http://test.com/api/test?clientid={TestId}&code={TestKey}", request.RequestUri.ToString());
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -486,6 +486,7 @@
     <Compile Include="WebApiApplicationTests.cs" />
     <Compile Include="WebHooks\DynamicWebHookReceiverConfigTests.cs" />
     <Compile Include="Handlers\WebScriptHostHandlerTests.cs" />
+    <Compile Include="WebHooks\WebHookReceiverManagerTests.cs" />
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/1098

If a code/key value is specified via headers, we now promote that to the query string, which is what the underlying WebHooks library expects.