### PR TITLE
Fix function.json schema for VS

### DIFF
--- a/schemas/json/function.json
+++ b/schemas/json/function.json
@@ -3,173 +3,90 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "disabled": {
-      "type": "boolean",
-      "description": "If set to true, marks the function as disabled (it cannot be triggered)."
-    },
-    "excluded": {
-      "type": "boolean",
-      "description": "If set to true, the function will not be loaded, compiled, or triggered."
-    },
-    "scriptFile": {
-      "type": "string",
-      "description": "Optional path to function script file."
-    },
-    "entryPoint": {
-      "type": "string",
-      "description": "Optional named entry point."
-    },
     "bindings": {
       "type": "array",
       "description": "A list of function bindings.",
       "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "oneOf": [
-              {
-                "$ref": "#/definitions/bindingNames"
-              },
-              {
-                "not": {
-                  "$ref": "#/definitions/bindingNames"
-                }
-              }
-            ]
-          }
-        },
+        "oneOf": [
+          { "$ref": "#/definitions/dynamicBinding" },
+          { "$ref": "#/definitions/serviceBusBinding" },
+          { "$ref": "#/definitions/blobBinding" },
+          { "$ref": "#/definitions/manualTriggerBinding" },
+          { "$ref": "#/definitions/eventHubBinding" },
+          { "$ref": "#/definitions/timerTriggerBinding" },
+          { "$ref": "#/definitions/queueBinding" },
+          { "$ref": "#/definitions/httpBinding" },
+          { "$ref": "#/definitions/mobileBinding" },
+          { "$ref": "#/definitions/documentDBBinding" },
+          { "$ref": "#/definitions/tableBinding" },
+          { "$ref": "#/definitions/notificationHubBinding" },
+          { "$ref": "#/definitions/twilioSmsBinding" },
+          { "$ref": "#/definitions/sendGridBinding" }
+        ],
         "allOf": [
-          {
-            "$ref": "#/definitions/binding"
-          }
-        ],
-        "required": [
-          "type"
-        ],
-        "dependencies": {
-          "type": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/timerTrigger"
-              },
-              {
-                "$ref": "#/definitions/queueTrigger"
-              },
-              {
-                "$ref": "#/definitions/queue"
-              },
-              {
-                "$ref": "#/definitions/httpTrigger"
-              },
-              {
-                "$ref": "#/definitions/http"
-              },
-              {
-                "$ref": "#/definitions/eventHubTrigger"
-              },
-              {
-                "$ref": "#/definitions/eventHub"
-              },
-              {
-                "$ref": "#/definitions/serviceBusTrigger"
-              },
-              {
-                "$ref": "#/definitions/serviceBus"
-              },
-              {
-                "$ref": "#/definitions/blobTrigger"
-              },
-              {
-                "$ref": "#/definitions/blob"
-              },
-              {
-                "$ref": "#/definitions/manualTrigger"
-              },
-              {
-                "$ref": "#/definitions/table"
-              },
-              {
-                "$ref": "#/definitions/dynamic"
-              },
-              {
-                "$ref": "#/definitions/notificationHub"
-              },
-              {
-                "$ref": "#/definitions/twilioSms"
-              },
-              {
-                "$ref": "#/definitions/sendGrid"
-              },
-              {
-                "$ref": "#/definitions/mobileTable"
-              },
-              {
-                "$ref": "#/definitions/documentDB"
-              }
-            ]
-          }
-        }
+          { "$ref": "#/definitions/bindingBase" }
+        ]
+      },
+      "disabled": {
+        "type": "boolean",
+        "description": "If set to true, marks the function as disabled (it cannot be triggered)."
+      },
+      "excluded": {
+        "type": "boolean",
+        "description": "If set to true, the function will not be loaded, compiled, or triggered."
+      },
+      "scriptFile": {
+        "type": "string",
+        "description": "Optional path to function script file."
+      },
+      "entryPoint": {
+        "type": "string",
+        "description": "Optional named entry point."
       }
     }
   },
   "definitions": {
-    "bindingNames": {
-      "type": "string",
-      "enum": [
-        "timerTrigger",
-        "queueTrigger",
-        "queue",
-        "httpTrigger",
-        "http",
-        "eventHubTrigger",
-        "eventHub",
-        "manualTrigger",
-        "blobTrigger",
-        "blob",
-        "serviceBusTrigger",
-        "serviceBus",
-        "table",
-        "notificationHub",
-        "twilioSms",
-        "sendGrid",
-        "mobileTable",
-        "documentDB"
-      ]
-    },
-    "serviceBusTrigger": {
+    "bindingBase": {
       "properties": {
-        "type": {
+        "name": { "type": "string" },
+        "type": { "type": "string" },
+        "direction": {
           "type": "string",
-          "pattern": "^serviceBusTrigger$"
+          "enum": [ "in", "out", "inout" ]
         }
       },
-      "allOf": [
-        {
-          "$ref": "#/definitions/trigger"
-        },
-        {
-          "$ref": "#/definitions/serviceBusBase"
-        }
-      ]
+      "required": [ "name", "type", "direction" ]
     },
-    "serviceBus": {
+    "dynamicBinding": {
       "properties": {
         "type": {
-          "type": "string",
-          "pattern": "^serviceBus$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
+          "not": {
+            "enum": [
+              "serviceBusTrigger",
+              "serviceBus",
+              "blobTrigger",
+              "blob",
+              "manualTrigger",
+              "eventHubTrigger",
+              "eventHub",
+              "timerTrigger",
+              "queueTrigger",
+              "queue",
+              "httpTrigger",
+              "http",
+              "mobileTable",
+              "documentDB",
+              "table",
+              "notificationHub",
+              "twilioSms",
+              "sendGrid"
+            ]
+          }
         },
-        {
-          "$ref": "#/definitions/serviceBusBase"
-        }
-      ]
+        "direction": { "enum": [ "in", "out", "inout" ] }
+      }
     },
-    "serviceBusBase": {
+    "serviceBusBinding": {
       "properties": {
         "queueName": {
           "type": "string",
@@ -195,102 +112,54 @@
             "listen"
           ]
         }
-      }
-    },
-    "blobTrigger": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^blobTrigger$"
-        }
       },
-      "allOf": [
+      "oneOf": [
         {
-          "$ref": "#/definitions/trigger"
+          "properties": {
+            "type": { "enum": [ "serviceBusTrigger" ] },
+            "direction": { "enum": [ "in" ] }
+          }
         },
         {
-          "$ref": "#/definitions/blobBindingBase"
+          "properties": {
+            "type": { "enum": [ "serviceBus" ] },
+            "direction": { "enum": [ "out" ] }
+          }
         }
       ]
     },
-    "blob": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^blob$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/blobBindingBase"
-        },
-        {
-          "$ref": "#/definitions/binding"
-        }
-      ]
-    },
-    "blobBindingBase": {
+    "blobBinding": {
       "properties": {
         "path": {
           "type": "string",
-          "description": "The path to the blob contaiter"
+          "description": "The path to the blob container"
         },
         "connection": {
           "type": "string",
           "description": "An app setting (or environment variable) with the storage connection string to be used by this binding."
         }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "type": { "enum": [ "blobTrigger" ] },
+            "direction": { "enum": [ "in" ] }
+          }
+        },
+        {
+          "properties": {
+            "type": { "enum": [ "blob" ] }
+          }
+        }
+      ]
+    },
+    "manualTriggerBinding": {
+      "properties": {
+        "type": { "enum": [ "manualTrigger" ] },
+        "direction": { "enum": [ "in" ] }
       }
     },
-    "manualTrigger": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^manualTrigger$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/trigger"
-        }
-      ]
-    },
-    "eventHubTrigger": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^eventHubTrigger$"
-        },
-        "consumerGroup": {
-          "type": "string",
-          "description": "The event hub consumer group."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/trigger"
-        },
-        {
-          "$ref": "#/definitions/eventHubBase"
-        }
-      ]
-    },
-    "eventHub": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^eventHub$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        },
-        {
-          "$ref": "#/definitions/eventHubBase"
-        }
-      ]
-    },
-    "eventHubBase": {
+    "eventHubBinding": {
       "properties": {
         "path": {
           "type": "string",
@@ -300,59 +169,38 @@
           "type": "string",
           "description": "The event hub connection string setting."
         }
-      }
-    },
-    "timerTrigger": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^timerTrigger$"
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "type": { "enum": [ "eventHubTrigger" ] },
+            "direction": { "enum": [ "in" ] },
+            "consumerGroup": {
+              "type": "string",
+              "description": "The event hub consumer group."
+            }
+          }
         },
+        {
+          "properties": {
+            "type": { "enum": [ "eventHub" ] },
+            "direction": { "enum": [ "out" ] }
+          }
+        }
+      ]
+    },
+    "timerTriggerBinding": {
+      "properties": {
+        "type": { "enum": [ "timerTrigger" ] },
+        "direction": { "enum": [ "in" ] },
         "schedule": {
           "type": "string",
           "description": "A CRON expression representing the timer schedule.",
-          "pattern": "^^(\\*|((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?)(,((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?)(,((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|(((1\\d)|(2[0-3])|\\d)(\\-((1\\d)|(2[0-3])|\\d)(\\/\\d+)?)?)(,(((1\\d)|(2[0-3])|\\d)(\\-((1\\d)|(2[0-3])|\\d)(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|((([1-2]\\d)|(3[0-1])|[1-9])(\\-(([1-2]\\d)|(3[0-1])|[1-9])(\\/\\d+)?)?)(,((([1-2]\\d)|(3[0-1])|[1-9])(\\-(([1-2]\\d)|(3[0-1])|[1-9])(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|(([A-Za-z]+|(1[0-2])|[1-9])(\\-([A-Za-z]+|(1[0-2])|[1-9])(\\/\\d+)?)?)(,(([A-Za-z]+|(1[0-2])|[1-9])(\\-([A-Za-z]+|(1[0-2])|[1-9])(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|(([A-Za-z]+|[0-6])(\\-([A-Za-z]+|[0-6])(\\/\\d+)?)?)(,(([A-Za-z]+|[0-6])(\\-([A-Za-z]+|[0-6])(\\/\\d+)?)?))*)(\\/\\d+)?$$"
+          "pattern": "^(\\*|((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?)(,((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?)(,((([1-5]\\d)|\\d)(\\-(([1-5]\\d)|\\d)(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|(((1\\d)|(2[0-3])|\\d)(\\-((1\\d)|(2[0-3])|\\d)(\\/\\d+)?)?)(,(((1\\d)|(2[0-3])|\\d)(\\-((1\\d)|(2[0-3])|\\d)(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|((([1-2]\\d)|(3[0-1])|[1-9])(\\-(([1-2]\\d)|(3[0-1])|[1-9])(\\/\\d+)?)?)(,((([1-2]\\d)|(3[0-1])|[1-9])(\\-(([1-2]\\d)|(3[0-1])|[1-9])(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|(([A-Za-z]+|(1[0-2])|[1-9])(\\-([A-Za-z]+|(1[0-2])|[1-9])(\\/\\d+)?)?)(,(([A-Za-z]+|(1[0-2])|[1-9])(\\-([A-Za-z]+|(1[0-2])|[1-9])(\\/\\d+)?)?))*)(\\/\\d+)? (\\*|(([A-Za-z]+|[0-6])(\\-([A-Za-z]+|[0-6])(\\/\\d+)?)?)(,(([A-Za-z]+|[0-6])(\\-([A-Za-z]+|[0-6])(\\/\\d+)?)?))*)(\\/\\d+)?$"
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/trigger"
-        }
-      ]
+      }
     },
-    "queueTrigger": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^queueTrigger$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/trigger"
-        },
-        {
-          "$ref": "#/definitions/queueBase"
-        }
-      ]
-    },
-    "queue": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^queue$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        },
-        {
-          "$ref": "#/definitions/queueBase"
-        }
-      ]
-    },
-    "queueBase": {
+    "queueBinding": {
       "properties": {
         "queueName": {
           "type": "string",
@@ -362,76 +210,76 @@
           "type": "string",
           "description": "An app setting (or environment variable) with the storage connection string to be used by this binding."
         }
-      }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "type": { "enum": [ "queueTrigger" ] },
+            "direction": { "enum": [ "in" ] }
+          }
+        },
+        {
+          "properties": {
+            "type": { "enum": [ "queue" ] },
+            "direction": { "enum": [ "out" ] }
+          }
+        }
+      ]
     },
     "httpTrigger": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^httpTrigger$"
-        },
-        "route": {
-          "type": "string",
-          "description": "The function HTTP route template."
-        },
-        "webHookType": {
-          "type": "string",
-          "description": "The type of WebHook handled by the trigger (if handling a pre-defined WebHook)."
-        },
-        "authLevel": {
-          "type": "string",
-          "default": "function",
-          "enum": [
-            "anonymous",
-            "function",
-            "admin"
-          ],
-          "description": "The function HTTP authorization level."
-        },
-        "methods": {
-          "type": "array",
-          "items": [
-            {
+
+    },
+    "httpBinding": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": { "enum": [ "httpTrigger" ] },
+            "direction": { "enum": [ "in" ] },
+            "route": {
               "type": "string",
-              "enum": [
-                "get",
-                "post",
-                "delete",
-                "head",
-                "patch",
-                "put",
-                "options",
-                "trace"
+              "description": "The function HTTP route template."
+            },
+            "webHookType": {
+              "type": "string",
+              "description": "The type of WebHook handled by the trigger (if handling a pre-defined WebHook)."
+            },
+            "authLevel": {
+              "type": "string",
+              "default": "function",
+              "enum": [ "anonymous", "function", "admin" ],
+              "description": "The function HTTP authorization level."
+            },
+            "methods": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "get",
+                    "post",
+                    "delete",
+                    "head",
+                    "patch",
+                    "put",
+                    "options",
+                    "trace"
+                  ]
+                }
               ]
             }
-          ]
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/trigger"
-        }
-      ]
-    },
-    "http": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^http$"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
-    },
-    "mobileTable": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^mobileTable$"
+          }
         },
+        {
+          "properties": {
+            "type": { "enum": [ "http" ] },
+            "direction": { "enum": [ "out" ] }
+          }
+        }
+      ]
+    },
+    "mobileBinding": {
+      "properties": {
+        "type": { "enum": [ "mobileTable" ] },
         "tableName": {
           "type": "string",
           "description": "This is the name of the table within your Mobile App to which data will be written."
@@ -447,39 +295,24 @@
       },
       "oneOf": [
         {
-          "$ref": "#/definitions/mobileTableInputBinding"
+          "properties": {
+            "direction": { "enum": [ "in" ] },
+            "id": {
+              "type": "string",
+              "description": "This is the id for the record to retrieve."
+            }
+          }
         },
         {
-          "$ref": "#/definitions/mobileTableOutputBinding"
+          "properties": {
+            "direction": { "enum": [ "out" ] }
+          }
         }
       ]
     },
-    "mobileTableInputBinding": {
+    "documentDBBinding": {
       "properties": {
-        "id": {
-          "type": "string",
-          "description": "This is the id for the record to retrieve."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/inputBinding"
-        }
-      ]
-    },
-    "mobileTableOutputBinding": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
-    },
-    "documentDB": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^documentDB$"
-        },
+        "type": { "enum": [ "documentDB" ] },
         "connection": {
           "type": "string",
           "description": "This is the connection string for your DocumentDB account."
@@ -495,39 +328,28 @@
       },
       "oneOf": [
         {
-          "$ref": "#/definitions/documentDBInputBinding"
+          "properties": {
+            "direction": { "enum": [ "in" ] },
+            "id": {
+              "type": "string",
+              "description": "This is the id for the record to retrieve."
+            }
+          }
         },
         {
-          "$ref": "#/definitions/documentDBOutputBinding"
+          "properties": {
+            "direction": { "enum": [ "out" ] },
+            "createIfNotExists": {
+              "type": "boolean",
+              "description": "When true, your database and collection will be created automatically."
+            }
+          }
         }
       ]
     },
-    "documentDBInputBinding": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/inputBinding"
-        }
-      ]
-    },
-    "documentDBOutputBinding": {
+    "tableBinding": {
       "properties": {
-        "createIfNotExists": {
-          "type": "boolean",
-          "description": "When true, your database and collection will be created automatically."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
-    },
-    "table": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^table$"
-        },
+        "type": { "enum": [ "table" ] },
         "tableName": {
           "type": "string",
           "description": "The name of the storage table."
@@ -547,43 +369,29 @@
       },
       "oneOf": [
         {
-          "$ref": "#/definitions/tableInputBinding"
+          "properties": {
+            "direction": { "enum": [ "in" ] },
+            "take": {
+              "type": "string",
+              "description": "The number or records to retrieve."
+            },
+            "filter": {
+              "type": "string",
+              "description": "A filter expression to be applied when retrieving rows."
+            }
+          }
         },
         {
-          "$ref": "#/definitions/tableOutputBinding"
+          "properties": {
+            "direction": { "enum": [ "out" ] }
+          }
         }
       ]
     },
-    "tableInputBinding": {
+    "notificationHubBinding": {
       "properties": {
-        "take": {
-          "type": "string",
-          "description": "The number or records to retrieve."
-        },
-        "filter": {
-          "type": "string",
-          "description": "A filter expression to be applied when retrieving rows."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/inputBinding"
-        }
-      ]
-    },
-    "tableOutputBinding": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
-    },
-    "notificationHub": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^notificationHub$"
-        },
+        "type": { "enum": [ "notificationHub" ] },
+        "direction": { "enum": [ "out" ] },
         "tagExpression": {
           "type": "string",
           "description": "The tag to send the notification to."
@@ -608,19 +416,12 @@
             "mpns"
           ]
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
+      }
     },
-    "twilioSms": {
+    "twilioSmsBinding": {
       "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^twilioSms$"
-        },
+        "type": { "enum": [ "twilioSms" ] },
+        "direction": { "enum": [ "out" ] },
         "accountSid": {
           "type": "string",
           "description": "The name of the app setting which contains your Twilio Account Sid."
@@ -641,19 +442,12 @@
           "type": "string",
           "description": "Optional body of SMS text message."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
+      }
     },
-    "sendGrid": {
+    "sendGridBinding": {
       "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^sendGrid$"
-        },
+        "type": { "enum": [ "sendGrid" ] },
+        "direction": { "enum": [ "out" ] },
         "apiKey": {
           "type": "string",
           "description": "The name of the app setting which contains your SendGrid api key."
@@ -673,91 +467,6 @@
         "text": {
           "type": "string",
           "description": "The text of the email."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/outputBinding"
-        }
-      ]
-    },
-    "binding": {
-      "properties": {
-        "direction": {
-          "type": "string",
-          "enum": [
-            "in",
-            "out",
-            "inout"
-          ]
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "direction",
-        "name"
-      ]
-    },
-    "trigger": {
-      "properties": {
-        "direction": {
-          "type": "string",
-          "enum": [
-            "in"
-          ]
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "direction",
-        "name"
-      ]
-    },
-    "inputBinding": {
-      "properties": {
-        "direction": {
-          "type": "string",
-          "enum": [
-            "in"
-          ]
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "direction",
-        "name"
-      ]
-    },
-    "outputBinding": {
-      "properties": {
-        "direction": {
-          "type": "string",
-          "enum": [
-            "out"
-          ]
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "direction",
-        "name"
-      ]
-    },
-    "dynamic": {
-      "properties": {
-        "type": {
-          "type": "string",
-          "not": {
-            "$ref": "#/definitions/bindingNames"
-          }
         }
       }
     }

--- a/schemas/json/function.json
+++ b/schemas/json/function.json
@@ -9,19 +9,23 @@
       "items": {
         "oneOf": [
           { "$ref": "#/definitions/dynamicBinding" },
-          { "$ref": "#/definitions/serviceBusBinding" },
-          { "$ref": "#/definitions/blobBinding" },
-          { "$ref": "#/definitions/manualTriggerBinding" },
-          { "$ref": "#/definitions/eventHubBinding" },
-          { "$ref": "#/definitions/timerTriggerBinding" },
-          { "$ref": "#/definitions/queueBinding" },
-          { "$ref": "#/definitions/httpBinding" },
-          { "$ref": "#/definitions/mobileBinding" },
-          { "$ref": "#/definitions/documentDBBinding" },
-          { "$ref": "#/definitions/tableBinding" },
-          { "$ref": "#/definitions/notificationHubBinding" },
-          { "$ref": "#/definitions/twilioSmsBinding" },
-          { "$ref": "#/definitions/sendGridBinding" }
+          { 
+            "oneOf": [
+              { "$ref": "#/definitions/serviceBusBinding" },
+              { "$ref": "#/definitions/blobBinding" },
+              { "$ref": "#/definitions/manualTriggerBinding" },
+              { "$ref": "#/definitions/eventHubBinding" },
+              { "$ref": "#/definitions/timerTriggerBinding" },
+              { "$ref": "#/definitions/queueBinding" },
+              { "$ref": "#/definitions/httpBinding" },
+              { "$ref": "#/definitions/mobileBinding" },
+              { "$ref": "#/definitions/documentDBBinding" },
+              { "$ref": "#/definitions/tableBinding" },
+              { "$ref": "#/definitions/notificationHubBinding" },
+              { "$ref": "#/definitions/twilioSmsBinding" },
+              { "$ref": "#/definitions/sendGridBinding" }
+            ]
+          }
         ],
         "allOf": [
           { "$ref": "#/definitions/bindingBase" }


### PR DESCRIPTION
resolves #1188 

Changed binding type matching so that it's handled correctly by VS.

I made binding definitions consistent:
```
someResourceBinding: {
  properties: { ... }, // common binding properties
  oneOf: [ // differences between triggers, input, output
  { 
    properties: {
      type: { enum: [ "someTrigger"] },  // match if type == 'someTrigger'
      direction: { enum: [ "in" ]}       // and direction == 'in'
    }
  },
  { 
    properties: {
      type: { enum: [ "someOutput"] },  // match if type == 'someOutput'
      direction: { enum: [ "out" ]}       // and direction == 'out'
    }
  }]
}
```

For a new binding:
 - `type` names should be added to the `not oneOf` section of `dynamicBinding`.
 - Bindings should be added to the `oneOf` section of the `bindings` array.