### PR TITLE
Updating data protection package

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -216,7 +216,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha43\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -48,7 +48,7 @@
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.0-beta1-10456" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta1-10476" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-beta1-10456" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha43" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -148,7 +148,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha43\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -32,7 +32,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.0-beta1-10383" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta1-10476" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-beta1-10456" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha43" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />


### PR DESCRIPTION
This package update fixes the following:

 - Uses the `WEBSITE_IIS_SITE_NAME` to resolve the site name used to lookup the machine key
 - Uses `%systemdrive%` for the path where secrets are stored