### PR TITLE
Updating data protection package

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -223,7 +223,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha47\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -49,7 +49,7 @@
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.0-beta2-10515" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10726" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-beta2-10515" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha47" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -157,7 +157,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha47\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -33,7 +33,7 @@
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.0-beta2-10515" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10726" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-beta2-10515" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha47" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -157,7 +157,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha47\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -33,7 +33,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.0-beta2-10399" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10726" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.0-beta2-10515" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha47" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />


### PR DESCRIPTION
Resolves #1194 

This package update fixes the following:

 - Uses the `WEBSITE_IIS_SITE_NAME` to resolve the site name used to lookup the machine key
 - Uses `%systemdrive%` for the path where secrets are stored