### PR TITLE
Add null body handling for content headers

### DIFF
--- a/src/WebJobs.Script/Binding/HttpBinding.cs
+++ b/src/WebJobs.Script/Binding/HttpBinding.cs
@@ -289,21 +289,21 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                     // content header collection
                     case "content-type":
                         MediaTypeHeaderValue mediaType = null;
-                        if (MediaTypeHeaderValue.TryParse(header.Value.ToString(), out mediaType))
+                        if (response.Content != null && MediaTypeHeaderValue.TryParse(header.Value.ToString(), out mediaType))
                         {
                             response.Content.Headers.ContentType = mediaType;
                         }
                         break;
                     case "content-length":
                         long contentLength;
-                        if (long.TryParse(header.Value.ToString(), out contentLength))
+                        if (response.Content != null && long.TryParse(header.Value.ToString(), out contentLength))
                         {
                             response.Content.Headers.ContentLength = contentLength;
                         }
                         break;
                     case "content-disposition":
                         ContentDispositionHeaderValue contentDisposition = null;
-                        if (ContentDispositionHeaderValue.TryParse(header.Value.ToString(), out contentDisposition))
+                        if (response.Content != null && ContentDispositionHeaderValue.TryParse(header.Value.ToString(), out contentDisposition))
                         {
                             response.Content.Headers.ContentDisposition = contentDisposition;
                         }
@@ -311,35 +311,41 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                     case "content-encoding":
                     case "content-language":
                     case "content-range":
-                        response.Content.Headers.Add(header.Key, header.Value.ToString());
+                        if (response.Content != null)
+                        {
+                            response.Content.Headers.Add(header.Key, header.Value.ToString());
+                        }
                         break;
                     case "content-location":
                         Uri uri;
-                        if (Uri.TryCreate(header.Value.ToString(), UriKind.Absolute, out uri))
+                        if (response.Content != null && Uri.TryCreate(header.Value.ToString(), UriKind.Absolute, out uri))
                         {
                             response.Content.Headers.ContentLocation = uri;
                         }
                         break;
                     case "content-md5":
                         byte[] value;
-                        if (header.Value is string)
+                        if (response.Content != null)
                         {
-                            value = Convert.FromBase64String((string)header.Value);
+                            if (header.Value is string)
+                            {
+                                value = Convert.FromBase64String((string)header.Value);
+                            }
+                            else
+                            {
+                                value = header.Value as byte[];
+                            }
+                            response.Content.Headers.ContentMD5 = value;
                         }
-                        else
-                        {
-                            value = header.Value as byte[];
-                        }
-                        response.Content.Headers.ContentMD5 = value;
                         break;
                     case "expires":
-                        if (DateTimeOffset.TryParse(header.Value.ToString(), out dateTimeOffset))
+                        if (response.Content != null && DateTimeOffset.TryParse(header.Value.ToString(), out dateTimeOffset))
                         {
                             response.Content.Headers.Expires = dateTimeOffset;
                         }
                         break;
                     case "last-modified":
-                        if (DateTimeOffset.TryParse(header.Value.ToString(), out dateTimeOffset))
+                        if (response.Content != null && DateTimeOffset.TryParse(header.Value.ToString(), out dateTimeOffset))
                         {
                             response.Content.Headers.LastModified = dateTimeOffset;
                         }

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -606,6 +606,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task HttpTrigger_Scenarios_NullBody()
+        {
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(string.Format("http://localhost/api/httptrigger-scenarios")),
+                Method = HttpMethod.Post,
+            };
+            request.SetConfiguration(new HttpConfiguration());
+            request.Headers.Add("scenario", "nullbody");
+            Dictionary<string, object> arguments = new Dictionary<string, object>
+            {
+                { "req", request }
+            };
+            await Fixture.Host.CallAsync("HttpTrigger-Scenarios", arguments);
+
+            HttpResponseMessage response = (HttpResponseMessage)request.Properties[ScriptConstants.AzureFunctionsHttpResponseKey];
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Null(response.Content);
+        }
+
+        [Fact]
         public async Task HttpTrigger_Scenarios_ScalarReturn_InBody()
         {
             HttpRequestMessage request = new HttpRequestMessage

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
@@ -45,6 +45,10 @@ module.exports = function (context, req) {
             context.bindings.res = { status: 202, body: "test" };
             break;
 
+        case "nullbody":
+            context.res = { status: 204, body: null, headers: { 'content-type': 'application/json' } };
+            break;
+
         default:
             context.res = {
                 status: 400


### PR DESCRIPTION
resolves #1268 

I hate the way this code looks, but I don't know how to do it in a cleaner way barring reflection hackery (and that might not even be clean due to property vs key naming differences).  Could add another switch statement, but ugly as well.

HttpContentHeaders is a sealed class with no constructor so I can't assign to a dummy object, and as the assignments must happen to typed properties there's no generic `Add(string, object)` method :(