### PR TITLE
Enable Key APIs for functions in error (#1253)

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [Route("admin/functions/{name}/keys")]
         public async Task<IHttpActionResult> Get(string name)
         {
-            if (!_scriptHostManager.Instance.Functions.Any(f => string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase)))
+            if (!_scriptHostManager.Instance.IsFunction(name))
             {
                 return NotFound();
             }
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         private async Task<IHttpActionResult> AddOrUpdateFunctionSecretAsync(string keyName, string value, string functionName = null)
         {
             if (functionName != null &&
-                !_scriptHostManager.Instance.Functions.Any(f => string.Equals(f.Name, functionName, StringComparison.OrdinalIgnoreCase)))
+                !_scriptHostManager.Instance.IsFunction(functionName))
             {
                 return NotFound();
             }
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return BadRequest("Invalid key name.");
             }
 
-            if ((functionName != null && !_scriptHostManager.Instance.Functions.Any(f => string.Equals(f.Name, functionName, StringComparison.OrdinalIgnoreCase))) ||
+            if ((functionName != null && !_scriptHostManager.Instance.IsFunction(functionName)) ||
                 !await _secretManager.DeleteSecretAsync(keyName, functionName))
             {
                 // Either the function or the key were not found

--- a/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http.Results;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Moq;
+using Newtonsoft.Json.Linq;
+using WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class KeysControllerTests : IDisposable
+    {
+        private readonly ScriptSettingsManager _settingsManager;
+        private readonly TempDirectory _secretsDirectory = new TempDirectory();
+        private Mock<ScriptHost> _hostMock;
+        private Mock<WebScriptHostManager> _managerMock;
+        private Collection<FunctionDescriptor> _testFunctions;
+        private Dictionary<string, Collection<string>> _testFunctionErrors;
+        private KeysController _testController;
+        private Mock<ISecretManager> _secretsManagerMock;
+
+        public KeysControllerTests()
+        {
+            _settingsManager = ScriptSettingsManager.Instance;
+            _testFunctions = new Collection<FunctionDescriptor>();
+            _testFunctionErrors = new Dictionary<string, Collection<string>>();
+
+            var config = new ScriptHostConfiguration();
+            var environment = new NullScriptHostEnvironment();
+            _hostMock = new Mock<ScriptHost>(MockBehavior.Strict, new object[] { environment, config, null });
+            _hostMock.Setup(p => p.Functions).Returns(_testFunctions);
+            _hostMock.Setup(p => p.FunctionErrors).Returns(_testFunctionErrors);
+
+            WebHostSettings settings = new WebHostSettings();
+            settings.SecretsPath = _secretsDirectory.Path;
+            _secretsManagerMock = new Mock<ISecretManager>(MockBehavior.Strict);
+            _managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new object[] { config, new TestSecretManagerFactory(_secretsManagerMock.Object), _settingsManager, settings });
+            _managerMock.SetupGet(p => p.Instance).Returns(_hostMock.Object);
+
+            var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+            
+            _testController = new KeysController(_managerMock.Object, _secretsManagerMock.Object, traceWriter);
+
+            // setup some test functions
+            string errorFunction = "ErrorFunction";
+            var errors = new Collection<string>();
+            errors.Add("A really really bad error!");
+            _testFunctionErrors.Add(errorFunction, errors);
+
+            var keys = new Dictionary<string, string>
+            {
+                { "key1", "secret1" }
+            };
+            _secretsManagerMock.Setup(p => p.GetFunctionSecretsAsync(errorFunction, false)).ReturnsAsync(keys);
+        }
+
+        [Fact]
+        public async Task GetKeys_FunctionInError_ReturnsKeys()
+        {
+            _testController.Request = new HttpRequestMessage(HttpMethod.Get, "https://local/admin/functions/keys");
+            var result = (OkNegotiatedContentResult<ApiModel>)(await _testController.Get("ErrorFunction"));
+
+            var content = (JObject)result.Content;
+            var keys = content["keys"];
+            Assert.Equal("key1", keys[0]["name"]);
+            Assert.Equal("secret1", keys[0]["value"]);
+        }
+
+        [Fact]
+        public async Task PutKey_FunctionInError_Succeeds()
+        {
+            _testController.Request = new HttpRequestMessage(HttpMethod.Get, "https://local/admin/functions/keys/key2");
+
+            var key = new Key("key2", "secret2");
+            var keyOperationResult = new KeyOperationResult(key.Value, OperationResult.Updated);
+            _secretsManagerMock.Setup(p => p.AddOrUpdateFunctionSecretAsync(key.Name, key.Value, "ErrorFunction")).ReturnsAsync(keyOperationResult);
+            
+            var result = (OkNegotiatedContentResult<ApiModel>)(await _testController.Put("ErrorFunction", key.Name, key));
+            var content = (JObject)result.Content;
+            Assert.Equal("key2", content["name"]);
+            Assert.Equal("secret2", content["value"]);
+        }
+
+        [Fact]
+        public async Task DeleteKey_FunctionInError_Succeeds()
+        {
+            _testController.Request = new HttpRequestMessage(HttpMethod.Get, "https://local/admin/functions/keys/key2");
+
+            _secretsManagerMock.Setup(p => p.DeleteSecretAsync("key2", "ErrorFunction")).ReturnsAsync(true);
+
+            var result = (StatusCodeResult)(await _testController.Delete("ErrorFunction", "key2"));
+            Assert.Equal(HttpStatusCode.NoContent, result.StatusCode);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _secretsDirectory.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -934,6 +934,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("The specified route conflicts with one or more built in routes.", functionError);
         }
 
+        [Fact]
+        public void IsFunction_ReturnsExpectedResult()
+        {
+            Mock<IScriptHostEnvironment> mockEnvironment = new Mock<IScriptHostEnvironment>(MockBehavior.Strict);
+            var config = new ScriptHostConfiguration();
+
+            var mockHost = new Mock<ScriptHost>(MockBehavior.Strict, new object[] { mockEnvironment.Object, config, null });
+
+            var functions = new Collection<FunctionDescriptor>();
+            var functionErrors = new Dictionary<string, Collection<string>>();
+            mockHost.Setup(p => p.Functions).Returns(functions);
+            mockHost.Setup(p => p.FunctionErrors).Returns(functionErrors);
+
+            var parameters = new Collection<ParameterDescriptor>();
+            parameters.Add(new ParameterDescriptor("param1", typeof(string)));
+            var metadata = new FunctionMetadata();
+            var invoker = new TestInvoker();
+            var function = new FunctionDescriptor("TestFunction", invoker, metadata, parameters);
+            functions.Add(function);
+
+            var errors = new Collection<string>();
+            errors.Add("A really really bad error!");
+            functionErrors.Add("ErrorFunction", errors);
+
+            var host = mockHost.Object;
+            Assert.True(host.IsFunction("TestFunction"));
+            Assert.True(host.IsFunction("ErrorFunction"));
+            Assert.False(host.IsFunction("DoesNotExist"));
+            Assert.False(host.IsFunction(""));
+            Assert.False(host.IsFunction(null));
+        }
+
         public class AssemblyMock : Assembly
         {
             public override object[] GetCustomAttributes(Type attributeType, bool inherit)

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -446,6 +446,7 @@
     <Compile Include="Binding\SendGridScriptBindingProviderTests.cs" />
     <Compile Include="Binding\TwilioScriptBindingProviderTests.cs" />
     <Compile Include="Controllers\Admin\AdminControllerTests.cs" />
+    <Compile Include="Controllers\Admin\KeysControllerTests.cs" />
     <Compile Include="Description\DotNet\CSharp\CSharpCompilationServiceTests.cs" />
     <Compile Include="Description\Script\ScriptFunctionInvokerBaseTests.cs" />
     <Compile Include="Filters\AuthorizationLevelAttributeTests.cs" />


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk-script/issues/1253. Previously we would only return results from the function keys APIs for functions not in error.