### PR TITLE
Removing ping endpoint and expanding host/status endpoint

### DIFF
--- a/src/WebJobs.Script.WebHost/Models/HostStatus.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostStatus.cs
@@ -9,16 +9,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {
     public class HostStatus
     {
-        public HostStatus()
-        {
-            Version = ScriptHost.Version;
-        }
-
         /// <summary>
         /// Gets or sets the host id.
         /// </summary>
         [JsonProperty(PropertyName = "id", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current status of the host.
+        /// </summary>
+        [JsonProperty(PropertyName = "state", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string State { get; set; }
 
         /// <summary>
         /// Gets or sets the host version.

--- a/src/WebJobs.Script/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestMessageExtensions.cs
@@ -10,6 +10,21 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public static class HttpRequestMessageExtensions
     {
+        public static AuthorizationLevel GetAuthorizationLevel(this HttpRequestMessage request)
+        {
+            return request.GetRequestPropertyOrDefault<AuthorizationLevel>(ScriptConstants.AzureFunctionsHttpRequestAuthorizationLevel);
+        }
+
+        public static TValue GetRequestPropertyOrDefault<TValue>(this HttpRequestMessage request, string key)
+        {
+            object value = null;
+            if (request.Properties.TryGetValue(key, out value))
+            {
+                return (TValue)value;
+            }
+            return default(TValue);
+        }
+
         public static IDictionary<string, string> GetQueryParameterDictionary(this HttpRequestMessage request)
         {
             var keyValuePairs = request.GetQueryNameValuePairs();

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureFunctionsWebHookDataKey = "MS_AzureFunctionsWebHookData";
         public const string AzureFunctionsHttpResponseKey = "MS_AzureFunctionsHttpResponse";
         public const string AzureFunctionsHttpRouteDataKey = "MS_AzureFunctionsHttpRouteData";
+        public const string AzureFunctionsHttpRequestAuthorizationLevel = "MS_AzureFunctionsAuthorizationLevel";
 
         public const string TracePropertyPrimaryHostKey = "MS_PrimaryHost";
         public const string TracePropertyFunctionNameKey = "MS_FunctionName";

--- a/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
@@ -907,16 +907,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task HostPing_Succeeds()
-        {
-            string uri = "admin/host/ping";
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-            HttpResponseMessage response = await this._fixture.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task HostStatus_Succeeds()
+        public async Task HostStatus_AdminLevel_Succeeds()
         {
             string uri = "admin/host/status";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -948,28 +939,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(expectedVersion, node.Value);
             node = doc.Descendants(XName.Get("Id", ns)).Single();
             Assert.Equal(expectedId, node.Value);
+            node = doc.Descendants(XName.Get("State", ns)).Single();
+            Assert.True(node.Value == "Running" || node.Value == "Created");
 
             node = doc.Descendants(XName.Get("Errors", ns)).Single();
             Assert.True(node.IsEmpty);
         }
 
         [Fact]
-        public async Task HostStatus_FunctionLevelRequest_Fails()
+        public async Task HostStatus_FunctionLevelRequest_Succeeds()
         {
             string uri = "admin/host/status";
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             request.Headers.Add("x-functions-key", "zlnu496ve212kk1p84ncrtdvmtpembduqp25ajjc");
             var response = await this._fixture.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string json = await response.Content.ReadAsStringAsync();
+            JObject obj = JObject.Parse(json);
+            Assert.Equal(0, obj.Properties().Count());
         }
 
         [Fact]
-        public async Task HostStatus_AnonymousLevelRequest_Fails()
+        public async Task HostStatus_AnonymousLevelRequest_Succeeds()
         {
             string uri = "admin/host/status";
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await this._fixture.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string json = await response.Content.ReadAsStringAsync();
+            JObject obj = JObject.Parse(json);
+            Assert.Equal(0, obj.Properties().Count());
         }
 
         private async Task<HttpResponseMessage> GetHostStatusAsync()


### PR DESCRIPTION
The host status endpoint now accepts different authorization levels, so it can be used for simple ping, as well as detailed status (admin authorization).