### PR TITLE
Implementation of system level keys

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Data/secrets/host.json
+++ b/src/WebJobs.Script.WebHost/App_Data/secrets/host.json
@@ -10,6 +10,12 @@
       "value": "zlnu496ve212kk1p84ncrtdvmtpembduqp25ajjc",
       "encrypted": false
     }
+  ],
+  "systemKeys": [
+    {
+      "name": "samplesystemkey",
+      "value": "bcnu496ve212kk1p84ncrtdvmtpembduqp25aghe",
+      "encrypted": false
+    }
   ]
-
 }

--- a/src/WebJobs.Script.WebHost/GlobalSuppressions.cs
+++ b/src/WebJobs.Script.WebHost/GlobalSuppressions.cs
@@ -89,3 +89,6 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.MetricsEventManager.#BeginEvent(System.String,System.String)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemMetricEvent.#DebugValue")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.WebHost.Controllers.AdminController.#Ping()")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.WebHost.HostSecretsInfo.#SystemKeys")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.WebHost.FunctionSecrets.#Keys")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.WebHost.HostSecrets.#SystemKeys")]

--- a/src/WebJobs.Script.WebHost/Security/FunctionSecrets.cs
+++ b/src/WebJobs.Script.WebHost/Security/FunctionSecrets.cs
@@ -27,10 +27,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public override bool HasStaleKeys => Keys?.Any(k => k.IsStale) ?? false;
 
         [JsonIgnore]
-        protected override ICollection<Key> InnerFunctionKeys => Keys;
-
-        [JsonIgnore]
         public override ScriptSecretsType SecretsType => ScriptSecretsType.Function;
+
+        protected override ICollection<Key> GetKeys(string keyScope) => Keys;
 
         public override ScriptSecrets Refresh(IKeyValueConverterFactory factory)
         {

--- a/src/WebJobs.Script.WebHost/Security/HostKeyScopes.cs
+++ b/src/WebJobs.Script.WebHost/Security/HostKeyScopes.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Web;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
-    public class HostSecretsInfo
+    public static class HostKeyScopes
     {
-        public string MasterKey { get; set; }
+        public const string FunctionKeys = "functionkeys";
 
-        public Dictionary<string, string> FunctionKeys { get; set; }
-
-        public Dictionary<string, string> SystemKeys { get; set; }
+        public const string SystemKeys = "systemkeys";
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/ISecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/ISecretManager.cs
@@ -13,9 +13,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// Deletes a function secret.
         /// </summary>
         /// <param name="secretName">The name of the secret to be deleted.</param>
-        /// <param name="functionName">The function name, in case of a function level secret; <see cref="null"/> if this is a host level function secret.</param>
+        /// <param name="keyScope">The target scope for the key. In case of a function level secrets, this will be the name of the function,
+        /// for host level secrets, this will identify the host secret type.</param>
+        /// <param name="secretsType">The target secrets type.</param>
         /// <returns>True if the secret was successfully deleted; otherwise, false.</returns>
-        Task<bool> DeleteSecretAsync(string secretName, string functionName = null);
+        Task<bool> DeleteSecretAsync(string secretName, string keyScope, ScriptSecretsType secretsType);
 
         /// <summary>
         /// Retrieves function secrets.
@@ -37,9 +39,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// </summary>
         /// <param name="secretName">The name of the secret to be created or updated.</param>
         /// <param name="secret">The secret value.</param>
-        /// <param name="functionName">The optional function name. If not provided, the function secret will be created at the host level.</param>
+        /// <param name="keyScope">The target scope for the key. For function level secrets, this will be the name of the function,
+        /// for host level secrets, this will identify the host secret type.</param>
+        /// <param name="secretsType">The target secrets type.</param>
         /// <returns>A <see cref="Task"/> that completes when the operation is finished.</returns>
-        Task<KeyOperationResult> AddOrUpdateFunctionSecretAsync(string secretName, string secret, string functionName = null);
+        Task<KeyOperationResult> AddOrUpdateFunctionSecretAsync(string secretName, string secret, string keyScope, ScriptSecretsType secretsType);
 
         /// <summary>
         /// Updates the host master key.

--- a/src/WebJobs.Script.WebHost/Security/ScriptSecrets.cs
+++ b/src/WebJobs.Script.WebHost/Security/ScriptSecrets.cs
@@ -21,19 +21,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public abstract bool HasStaleKeys { get; }
 
         [JsonIgnore]
-        protected abstract ICollection<Key> InnerFunctionKeys { get; }
-
-        [JsonIgnore]
         public abstract ScriptSecretsType SecretsType { get; }
+
+        protected abstract ICollection<Key> GetKeys(string keyScope);
 
         public abstract ScriptSecrets Refresh(IKeyValueConverterFactory factory);
 
         public abstract IEnumerator<Key> GetEnumerator();
 
-        public virtual void AddKey(Key item) => InnerFunctionKeys?.Add(item);
+        public virtual void AddKey(Key item, string keyScope) => GetKeys(keyScope)?.Add(item);
 
-        public virtual bool RemoveKey(Key item) => InnerFunctionKeys?.Remove(item) ?? false;
+        public virtual bool RemoveKey(Key item, string keyScope) => GetKeys(keyScope)?.Remove(item) ?? false;
 
-        public virtual Key GetFunctionKey(string name) => InnerFunctionKeys?.FirstOrDefault(k => string.Equals(k.Name, name, StringComparison.OrdinalIgnoreCase));
+        public virtual Key GetFunctionKey(string name, string keyScope) => GetKeys(keyScope)?.FirstOrDefault(k => string.Equals(k.Name, name, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -437,6 +437,7 @@
     <Compile Include="Security\FileSystemSecretsRepository.cs" />
     <Compile Include="Security\FunctionSecrets.cs" />
     <Compile Include="Security\DataProtectionKeyValueConverter.cs" />
+    <Compile Include="Security\HostKeyScopes.cs" />
     <Compile Include="Security\HostSecretsInfo.cs" />
     <Compile Include="Security\IKeyValueWriter.cs" />
     <Compile Include="Security\ISecretManager.cs" />

--- a/src/WebJobs.Script/AuthorizationLevel.cs
+++ b/src/WebJobs.Script/AuthorizationLevel.cs
@@ -16,9 +16,14 @@ namespace Microsoft.Azure.WebJobs.Script
         User,
 
         /// <summary>
-        /// Allow access to requests that include the function key
+        /// Allow access to requests that include a function key
         /// </summary>
         Function,
+
+        /// <summary>
+        /// Allows access to requests that include a system key
+        /// </summary>
+        System,
 
         /// <summary>
         /// Allow access to requests that include the master key

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteFunctionKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteFunctionKeyScenario.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
         }
 
         [Fact(DisplayName = "The secret manager key delete is invoked.")]
-        public void FunctionKeysAreRetrievedFromSecretManager()
+        public void SecretManagerKeyDeleteIsInvoked()
         {
-            _fixture.SecretManagerMock.Verify(s => s.DeleteSecretAsync("TestKey", _fixture.TestFunctionName));
+            _fixture.SecretManagerMock.Verify(s => s.DeleteSecretAsync("TestKey", _fixture.TestKeyScope, _fixture.SecretsType));
         }
 
         public class Fixture : KeyManagementFixture
@@ -48,14 +48,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
             public HttpResponseMessage HttpResponse { get; }
 
-            public string FormattedRequestUri => string.Format(RequestUriFormat, TestFunctionName);
+            public string FormattedRequestUri => string.Format(RequestUriFormat, TestKeyScope);
 
             protected virtual string RequestUriFormat => _requestUri;
 
             protected override Mock<TestSecretManager> BuildSecretManager()
             {
                 var manager = base.BuildSecretManager();
-                manager.Setup(s => s.DeleteSecretAsync("TestKey", TestFunctionName))
+                manager.Setup(s => s.DeleteSecretAsync("TestKey", TestKeyScope, SecretsType))
                     .ReturnsAsync(true);
 
                 return manager;

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostFunctionKeysScenario.cs
@@ -29,7 +29,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
             protected override string RequestUriFormat => _requestUri;
 
-            public override string TestFunctionName => null;
+            public override string TestKeyScope => HostKeyScopes.FunctionKeys;
+
+            public override ScriptSecretsType SecretsType => ScriptSecretsType.Host;
+        }
+    }
+
+    [Trait("A DELETE request is made against the host function key (functionKeys) resource endpoint", "")]
+    public class DeleteHostFunctionKeysNewEndpointScenario : DeleteFunctionKeysScenario, IClassFixture<DeleteHostFunctionKeysNewEndpointScenario.HostFixture>
+    {
+        private readonly Fixture _fixture;
+
+        public DeleteHostFunctionKeysNewEndpointScenario(HostFixture fixture)
+            : base(fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public class HostFixture : DeleteFunctionKeysScenario.Fixture
+        {
+            private readonly string _requestUri = "http://localhost/admin/host/functionkeys/TestKey";
+
+            protected override string RequestUriFormat => _requestUri;
+
+            public override string TestKeyScope => HostKeyScopes.FunctionKeys;
+
+            public override ScriptSecretsType SecretsType => ScriptSecretsType.Host;
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostSystemKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostSystemKeysScenario.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
+{
+    [Trait("A DELETE request is made against the host system keys resource endpoint", "")]
+    public class DeleteHostSystemKeysScenario : DeleteFunctionKeysScenario, IClassFixture<DeleteHostSystemKeysScenario.HostFixture>
+    {
+        private readonly Fixture _fixture;
+
+        public DeleteHostSystemKeysScenario(HostFixture fixture)
+            : base(fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public class HostFixture : DeleteFunctionKeysScenario.Fixture
+        {
+            private readonly string _requestUri = "http://localhost/admin/host/systemkeys/TestKey";
+
+            protected override string RequestUriFormat => _requestUri;
+
+            public override string TestKeyScope => HostKeyScopes.SystemKeys;
+
+            public override ScriptSecretsType SecretsType => ScriptSecretsType.Host;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetFunctionKeysScenario.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
         [Fact(DisplayName = "The function keys are retrieved from the secret manager.")]
         public void FunctionKeysAreRetrievedFromSecretManager()
         {
-            _fixture.SecretManagerMock.Verify(s => s.GetFunctionSecretsAsync(_fixture.TestFunctionName, false));
+            _fixture.SecretManagerMock.Verify(s => s.GetFunctionSecretsAsync(_fixture.TestKeyScope, false));
         }
 
         [Fact(DisplayName = "Response body is a valid list of keys.")]
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
             public HttpResponseMessage HttpResponse { get; }
 
-            public string FormattedRequestUri => string.Format(RequestUriFormat, TestFunctionName);
+            public string FormattedRequestUri => string.Format(RequestUriFormat, TestKeyScope);
 
             protected virtual string RequestUriFormat => _requestUri;
         }

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostSystemKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostSystemKeysScenario.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
+{
+    [Trait("A GET request is made against the host function system keys collection endpoint", "")]
+    public class GetHostSystemKeysScenario : GetFunctionKeysScenario, IClassFixture<GetHostSystemKeysScenario.HostFixture>
+    {
+        public GetHostSystemKeysScenario(GetKeysFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class HostFixture : GetKeysFixture
+        {
+            private readonly string _requestUri = "http://localhost/admin/host/systemkeys";
+
+            protected override string RequestUriFormat => _requestUri;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/KeyManagementFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/KeyManagementFixture.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
         public Mock<TestSecretManager> SecretManagerMock { get; set; }
 
-        public virtual string TestFunctionName => _testFunctionName;
+        public virtual string TestKeyScope => _testFunctionName;
+
+        public virtual ScriptSecretsType SecretsType => ScriptSecretsType.Function;
 
         protected override void RegisterDependencies(ContainerBuilder builder, WebHostSettings settings)
         {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostFunctionKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostFunctionKeyScenario.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
             public HttpResponseMessage HttpResponse { get; }
 
-            public string FormattedRequestUri => string.Format(RequestUriFormat, TestFunctionName);
+            public string FormattedRequestUri => string.Format(RequestUriFormat, TestKeyScope);
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostHostSystemKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostHostSystemKeyScenario.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
+{
+    [Trait("A POST request is made against the host system keys resource endpoint", "")]
+    public class PostHostSystemKeyScenario : PostFunctionKeysScenario, IClassFixture<PostHostSystemKeyScenario.HostFixture>
+    {
+        public PostHostSystemKeyScenario(HostFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class HostFixture : PostFunctionKeysScenario.Fixture
+        {
+            private readonly string _requestUri = "http://localhost/admin/host/systemkeys/TestKey";
+
+            protected override string RequestUriFormat => _requestUri;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutFunctionKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutFunctionKeyScenario.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
             public HttpResponseMessage HttpResponse { get; }
 
-            public string FormattedRequestUri => string.Format(RequestUriFormat, TestFunctionName);
+            public string FormattedRequestUri => string.Format(RequestUriFormat, TestKeyScope);
 
             protected virtual string RequestUriFormat => _requestUri;
         }

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutHostSystemKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutHostSystemKeyScenario.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
+{
+    [Trait("A PUT request is made against the host system keys resource endpoint", "")]
+    public class PutHostSystemKeyScenario : PutFunctionKeysScenario, IClassFixture<PutHostSystemKeyScenario.HostFixture>
+    {
+        public PutHostSystemKeyScenario(HostFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class HostFixture : Fixture
+        {
+            private readonly string _requestUri = "http://localhost/admin/host/systemkeys/TestKey";
+
+            protected override string RequestUriFormat => _requestUri;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -408,6 +408,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiHubTestHelper.cs" />
+    <Compile Include="Controllers\Keys\DeleteHostSystemKeysScenario.cs" />
+    <Compile Include="Controllers\Keys\GetHostSystemKeysScenario.cs" />
+    <Compile Include="Controllers\Keys\PostHostSystemKeyScenario.cs" />
+    <Compile Include="Controllers\Keys\PutHostSystemKeyScenario.cs" />
     <Compile Include="FakeTabularConnectorAdapter.cs" />
     <Compile Include="BashEndToEndTests.cs" />
     <Compile Include="BlobLeaseManagerTests.cs" />

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             throw new NotImplementedException();
         }
 
-        public virtual Task<bool> DeleteSecretAsync(string secretName, string functionName)
+        public virtual Task<bool> DeleteSecretAsync(string secretName, string keyScope, ScriptSecretsType secretsType)
         {
             return Task.FromResult(true);
         }
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
         }
 
-        public virtual Task<KeyOperationResult> AddOrUpdateFunctionSecretAsync(string secretName, string secret, string functionName)
+        public virtual Task<KeyOperationResult> AddOrUpdateFunctionSecretAsync(string secretName, string secret, string keyScope, ScriptSecretsType secretsType)
         {
             string resultSecret = secret ?? "generated";
             return Task.FromResult(new KeyOperationResult(resultSecret, OperationResult.Created));

--- a/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var key = new Key("key2", "secret2");
             var keyOperationResult = new KeyOperationResult(key.Value, OperationResult.Updated);
-            _secretsManagerMock.Setup(p => p.AddOrUpdateFunctionSecretAsync(key.Name, key.Value, "ErrorFunction")).ReturnsAsync(keyOperationResult);
+            _secretsManagerMock.Setup(p => p.AddOrUpdateFunctionSecretAsync(key.Name, key.Value, "ErrorFunction", ScriptSecretsType.Function)).ReturnsAsync(keyOperationResult);
             
             var result = (OkNegotiatedContentResult<ApiModel>)(await _testController.Put("ErrorFunction", key.Name, key));
             var content = (JObject)result.Content;
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             _testController.Request = new HttpRequestMessage(HttpMethod.Get, "https://local/admin/functions/keys/key2");
 
-            _secretsManagerMock.Setup(p => p.DeleteSecretAsync("key2", "ErrorFunction")).ReturnsAsync(true);
+            _secretsManagerMock.Setup(p => p.DeleteSecretAsync("key2", "ErrorFunction", ScriptSecretsType.Function)).ReturnsAsync(true);
 
             var result = (StatusCodeResult)(await _testController.Delete("ErrorFunction", "key2"));
             Assert.Equal(HttpStatusCode.NoContent, result.StatusCode);


### PR DESCRIPTION
The changes in this PR introduce the following:

- A new key type/scope at the host level for system components (e.g. the swagger endpoint)
- Updated APIs to manage those new secrets
- Updated the route for host level function keys to be more consistent with what was introduced for system keys. The resource collection is now `functionkeys`, as opposed to `keys`, but we're maintaining the previous route for back compat
- Updated the `AuthorizationLevelAttribute` to handle System level authorization requirements and named keys (e.g. an API can now not only specify that authorization must be of a certain level, but also require a specific key, by name)
- Some minor cleanup for clarity/consistency