### PR TITLE
Improvements to Node binding data handling

### DIFF
--- a/src/WebJobs.Script.Extensibility.NuGet/WebJobs.Script.Extensibility.nuspec
+++ b/src/WebJobs.Script.Extensibility.NuGet/WebJobs.Script.Extensibility.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Script Extensibility</tags>
     <dependencies>
-      <dependency id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" />
     </dependencies>
   </metadata>
 </package>

--- a/src/WebJobs.Script.Extensibility/WebJobs.Script.Extensibility.csproj
+++ b/src/WebJobs.Script.Extensibility/WebJobs.Script.Extensibility.csproj
@@ -43,10 +43,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Script.Extensibility/packages.config
+++ b/src/WebJobs.Script.Extensibility/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.1" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.1" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.1" targetFramework="net45" />

--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -83,7 +83,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -110,14 +110,14 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta2-10774\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -10,8 +10,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta3-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.12-beta" targetFramework="net46" />
@@ -21,7 +21,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10774" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -14,8 +14,8 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Script Node.js</tags>
     <dependencies>
-      <dependency id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" />
-      <dependency id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10543" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" />
+      <dependency id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10544" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10423" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.1-alpha1-10423" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.1-alpha1-10423" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -171,7 +171,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -198,17 +198,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta2-10774\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -36,8 +36,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta3-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.12-beta" targetFramework="net46" />
@@ -46,9 +46,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.1-alpha1-10423" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10774" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -310,5 +310,10 @@ namespace Microsoft.Azure.WebJobs.Script
 
             return false;
         }
+
+        internal static bool IsNullable(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -76,7 +76,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -103,14 +103,14 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta2-10774\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -11,8 +11,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta3-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.12-beta" targetFramework="net46" />
@@ -22,7 +22,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10774" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/BlobTriggerToBlob/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/BlobTriggerToBlob/index.js
@@ -1,9 +1,14 @@
 ﻿module.exports = function (context, input) {
+    var bindingData = context.bindingData;
     var result = {
         isBuffer: Buffer.isBuffer(input),
         length: input.length,
-        path: context.bindingData.blobTrigger,
-        invocationId: context.bindingData.invocationId
+        invocationId: bindingData.invocationId,
+        blobMetadata: {
+            path: bindingData.blobTrigger,
+            properties: bindingData.properties,
+            metadata: bindingData.metadata
+        }
     };
 
     context.log("TestResult:", JSON.stringify(result));

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -105,7 +105,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -132,17 +132,17 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta2-10774\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -20,8 +20,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta3-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.12-beta" targetFramework="net46" />
@@ -30,9 +30,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.1-alpha1-10423" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10774" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -294,5 +294,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var json = Utility.ToJson(val as ExpandoObject, Newtonsoft.Json.Formatting.None);
             Assert.Equal("{\"nested\":{},\"array\":[{}],\"value\":\"value\"}", json);
         }
+
+        [Theory]
+        [InlineData(typeof(ExpandoObject), false)]
+        [InlineData(typeof(string), false)]
+        [InlineData(typeof(int), false)]
+        [InlineData(typeof(int?), true)]
+        public void IsNullable_ReturnsExpectedResult(Type type, bool expected)
+        {
+            Assert.Equal(expected, Utility.IsNullable(type));
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -109,7 +109,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -136,14 +136,14 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.0.1-alpha1-10423\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta2-10774\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10543\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10544\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -21,8 +21,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10543" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10544" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta3-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.12-beta" targetFramework="net46" />
@@ -32,7 +32,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.0.1-alpha1-10423" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta2-10774" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10543" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10544" targetFramework="net46" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />


### PR DESCRIPTION
Pulling in the latest SDK version to get the changes made in https://github.com/Azure/azure-webjobs-sdk/pull/1087. At this point all the binding data types described in https://github.com/Azure/azure-webjobs-sdk/wiki/Trigger-Binding-Data are handled.