### PR TITLE
Improve Mono portability

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -157,12 +157,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     {
                         if (!_webHostSettings.IsSelfHost)
                         {
-                            // FIXME: Mono does not yet support HostingEnvironment.QueueBackgroundWorkItem
-#if MONO
-                            Task.Run(() => WarmUp(_webHostSettings));
-#else
                             HostingEnvironment.QueueBackgroundWorkItem((ct) => WarmUp(_webHostSettings));
-#endif
                         }
                         else
                         {
@@ -176,12 +171,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     if (!_webHostSettings.IsSelfHost)
                     {
-                        // FIXME: This behaves a little differently on Mono as it does not handle cancellation
-#if MONO
-                        Task.Run(() => RunAndBlock());
-#else
                         HostingEnvironment.QueueBackgroundWorkItem((ct) => RunAndBlock(ct));
-#endif
                     }
                     else
                     {

--- a/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/CSharp/CSharpCompilation.cs
@@ -97,11 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     var compilationWithAnalyzers = _compilation.WithAnalyzers(GetAnalyzers());
                     var diagnostics = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
                     var emitOptions = new EmitOptions().WithDebugInformationFormat(
-#if WINDOWS
-                        DebugInformationFormat.Pdb
-#else
-                        DebugInformationFormat.PortablePdb
-#endif
+			PlatformHelper.IsMono? DebugInformationFormat.PortablePdb : DebugInformationFormat.Pdb
                     );
                     var emitResult = compilationWithAnalyzers.Compilation.Emit(assemblyStream, pdbStream, options: emitOptions, cancellationToken: cancellationToken);
 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -263,9 +263,6 @@
       <HintPath>..\..\packages\Twilio.4.7.2\lib\3.5\Twilio.Api.dll</HintPath>
       <Private>True</Private>
     </Reference>
-  </ItemGroup>
-  <!-- Mono doesn't need these .NET Standard facades/shims, it ships its own -->
-  <ItemGroup Condition="'$(OS)'!='Unix'">
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.1.0\lib\net46\System.AppContext.dll</HintPath>
       <Private>True</Private>

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -341,9 +341,6 @@
       <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-  </ItemGroup>
-  <!-- Mono doesn't need these NetStandard shims/facades, it ships its own -->
-  <ItemGroup Condition="'$(OS)'!='Unix'">
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.1.0\lib\net46\System.AppContext.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Remove workarounds that are no longer needed on Mono master and make the remaining compile-time check a runtime check so the assembly is portable.