### PR TITLE
Implementing Http throttle support (#1261)

### DIFF
--- a/sample/Bot-CSharp/run.csx
+++ b/sample/Bot-CSharp/run.csx
@@ -1,4 +1,6 @@
-﻿public class BotMessage
+﻿using System.Net;
+
+public class BotMessage
 {
     public string Source { get; set; }
     public string Message { get; set; }

--- a/sample/host.json
+++ b/sample/host.json
@@ -4,7 +4,9 @@
         "from": "Azure Functions <samples@functions.com>"
     },
     "http": {
-        "routePrefix": "api"
+        "routePrefix": "api",
+        "maxDegreeOfParallelism": 5,
+        "maxQueueLength": 30
     },
     "tracing": {
         "fileLoggingMode": "always"

--- a/schemas/json/host.json
+++ b/schemas/json/host.json
@@ -44,6 +44,21 @@
                     "description": "Defines the default route prefix that applies to all routes. Use an empty string to remove the prefix.",
                     "type": "string",
                     "default": "api"
+                },
+                "maxDegreeOfParallelism": {
+                    "description": "Defines the the maximum number of http functions that will execute in parallel.",
+                    "type": "integer",
+                    "default": -1
+                },
+                "maxQueueLength": {
+                    "description": "Defines the maximum number of pending requests that will be queued for processing.",
+                    "type": "integer",
+                    "default": -1
+                },
+                "dynamicThrottlesEnabled": {
+                    "description": "Indicates whether dynamic host counter checks should be enabled.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },

--- a/src/WebJobs.Script.WebHost/App_Data/secrets/httptrigger-csharp.json
+++ b/src/WebJobs.Script.WebHost/App_Data/secrets/httptrigger-csharp.json
@@ -1,3 +1,9 @@
 {
-  "key": null
+    "keys": [
+        {
+            "name": "default",
+            "value": "9884kkdlkkdf83ksld8589kflss90sll5kjjsyfjskqv",
+            "encrypted": false
+        }
+    ]
 }

--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using System.Web.Http.Dependencies;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.WebHooks;
@@ -32,25 +33,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         public override async Task<HttpResponseMessage> ExecuteAsync(HttpControllerContext controllerContext, CancellationToken cancellationToken)
         {
-            HttpRequestMessage request = controllerContext.Request;
-
-            // First see if the request maps to an HTTP function
-            FunctionDescriptor function = _scriptHostManager.GetHttpFunctionOrNull(request);
+            var request = controllerContext.Request;
+            var function = _scriptHostManager.GetHttpFunctionOrNull(request);
             if (function == null)
             {
+                // request does not map to an HTTP function
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
             }
+            request.SetProperty(ScriptConstants.AzureFunctionsHttpFunctionKey, function);
 
-            // Determine the authorization level of the request
-            ISecretManager secretManager = controllerContext.Configuration.DependencyResolver.GetService<ISecretManager>();
-            var settings = controllerContext.Configuration.DependencyResolver.GetService<WebHostSettings>();
-            var authorizationLevel = settings.IsAuthDisabled
-                ? AuthorizationLevel.Admin
-                : await AuthorizationLevelAttribute.GetAuthorizationLevelAsync(request, secretManager, functionName: function.Name);
-            request.SetAuthorizationLevel(authorizationLevel);
-
+            var authorizationLevel = await DetermineAuthorizationLevelAsync(request, function, controllerContext.Configuration.DependencyResolver);
             if (function.Metadata.IsExcluded ||
-                (function.Metadata.IsDisabled && authorizationLevel != AuthorizationLevel.Admin))
+               (function.Metadata.IsDisabled && authorizationLevel != AuthorizationLevel.Admin))
             {
                 // disabled functions are not publicly addressable w/o Admin level auth,
                 // and excluded functions are also ignored here (though the check above will
@@ -58,10 +52,33 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
             }
 
-            // Dispatch the request
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> processRequestHandler = async (req, ct) =>
+            {
+                return await ProcessRequestAsync(req, function, ct);
+            };
+            return await _scriptHostManager.HttpRequestManager.ProcessRequestAsync(request, processRequestHandler, cancellationToken);
+        }
+
+        public static async Task<AuthorizationLevel> DetermineAuthorizationLevelAsync(HttpRequestMessage request, FunctionDescriptor function, IDependencyResolver resolver)
+        {
+            var secretManager = resolver.GetService<ISecretManager>();
+            var settings = resolver.GetService<WebHostSettings>();
+
+            var authorizationLevel = settings.IsAuthDisabled
+                ? AuthorizationLevel.Admin
+                : await AuthorizationLevelAttribute.GetAuthorizationLevelAsync(request, secretManager, functionName: function.Name);
+            request.SetAuthorizationLevel(authorizationLevel);
+
+            return authorizationLevel;
+        }
+
+        private async Task<HttpResponseMessage> ProcessRequestAsync(HttpRequestMessage request, FunctionDescriptor function, CancellationToken cancellationToken)
+        {
             HttpTriggerBindingMetadata httpFunctionMetadata = (HttpTriggerBindingMetadata)function.Metadata.InputBindings.FirstOrDefault(p => string.Compare("HttpTrigger", p.Type, StringComparison.OrdinalIgnoreCase) == 0);
             bool isWebHook = !string.IsNullOrEmpty(httpFunctionMetadata.WebHookType);
+            var authorizationLevel = request.GetAuthorizationLevel();
             HttpResponseMessage response = null;
+
             if (isWebHook)
             {
                 if (authorizationLevel == AuthorizationLevel.Admin)

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -475,6 +475,7 @@
     <Compile Include="WebHooks\WebHookReceiverManager.cs" />
     <Compile Include="WebScriptHostExceptionHandler.cs" />
     <Compile Include="WebScriptHostManager.cs" />
+    <Compile Include="WebScriptHostRequestManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config">
@@ -492,6 +493,7 @@
     <Content Include="App_Data\secrets\httptrigger-csharp-customroute.json" />
     <Content Include="App_Data\secrets\httptrigger-customroute-get.json" />
     <Content Include="App_Data\secrets\httptrigger-customroute-post.json" />
+    <Content Include="App_Data\secrets\httptrigger-csharp.json" />
     <None Include="App_Data\secrets\HttpTrigger.json" />
     <Content Include="App_Data\secrets\webhook-azure-csharp.json" />
     <None Include="App_Data\secrets\WebHook-Generic-CSharp.json" />

--- a/src/WebJobs.Script.WebHost/WebScriptHostRequestManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostRequestManager.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Net.Http;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Binding.Http;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    public class WebScriptHostRequestManager : HttpRequestManager
+    {
+        private readonly HostPerformanceManager _performanceManager;
+        private readonly IMetricsLogger _metricsLogger;
+        private readonly int _performanceCheckPeriodSeconds;
+        private DateTime _lastPerformanceCheck;
+        private bool _rejectAllRequests;
+
+        public WebScriptHostRequestManager(HttpConfiguration config, HostPerformanceManager performanceManager, IMetricsLogger metricsLogger, TraceWriter traceWriter, int performanceCheckPeriodSeconds = 15) : base(config, traceWriter)
+        {
+            _performanceManager = performanceManager;
+            _metricsLogger = metricsLogger;
+            _performanceCheckPeriodSeconds = performanceCheckPeriodSeconds;
+        }
+
+        protected override bool RejectAllRequests()
+        {
+            if (base.RejectAllRequests())
+            {
+                return true;
+            }
+
+            if (Config.DynamicThrottlesEnabled &&
+               ((DateTime.UtcNow - _lastPerformanceCheck) > TimeSpan.FromSeconds(_performanceCheckPeriodSeconds)))
+            {
+                // only check host status periodically
+                Collection<string> exceededCounters = new Collection<string>();
+                _rejectAllRequests = _performanceManager.IsUnderHighLoad(exceededCounters);
+                _lastPerformanceCheck = DateTime.UtcNow;
+                if (_rejectAllRequests)
+                {
+                    TraceWriter.Info($"Thresholds for the following counters have been exceeded: {string.Join(", ", exceededCounters)}");
+                }
+            }
+
+            return _rejectAllRequests;
+        }
+
+        protected override HttpResponseMessage RejectRequest(HttpRequestMessage request)
+        {
+            var function = request.GetPropertyOrDefault<FunctionDescriptor>(ScriptConstants.AzureFunctionsHttpFunctionKey);
+            _metricsLogger.LogEvent(MetricEventNames.FunctionInvokeThrottled, function.Name);
+
+            return base.RejectRequest(request);
+        }
+    }
+}

--- a/src/WebJobs.Script/Binding/Http/HttpConfiguration.cs
+++ b/src/WebJobs.Script/Binding/Http/HttpConfiguration.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.Azure.WebJobs.Script.Binding.Http
+{
+    public class HttpConfiguration
+    {
+        public HttpConfiguration()
+        {
+            MaxQueueLength = DataflowBlockOptions.Unbounded;
+            MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded;
+            RoutePrefix = ScriptConstants.DefaultHttpRoutePrefix;
+        }
+
+        /// <summary>
+        /// Gets or sets the default route prefix that will be applied to
+        /// function routes.
+        /// </summary>
+        public string RoutePrefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of pending requests that
+        /// will be queued for processing. If this limit is exceeded,
+        /// new requests will be rejected with a 429 status code.
+        /// </summary>
+        public int MaxQueueLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of http functions that will execute
+        /// in parallel.
+        /// </summary>
+        public int MaxDegreeOfParallelism { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether dynamic host counter
+        /// checks should be enabled.
+        /// </summary>
+        public bool DynamicThrottlesEnabled { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Binding/Http/HttpRequestManager.cs
+++ b/src/WebJobs.Script/Binding/Http/HttpRequestManager.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.Azure.WebJobs.Host;
+
+namespace Microsoft.Azure.WebJobs.Script.Binding.Http
+{
+    /// <summary>
+    /// Provides http request buffering/throttling capabilities.
+    /// </summary>
+    public class HttpRequestManager
+    {
+        private ActionBlock<HttpRequestItem> _requestQueue;
+
+        public HttpRequestManager(HttpConfiguration httpConfiguration, TraceWriter traceWriter)
+        {
+            Config = httpConfiguration;
+            TraceWriter = traceWriter;
+
+            if (Config.MaxQueueLength != DataflowBlockOptions.Unbounded ||
+                Config.MaxDegreeOfParallelism != DataflowBlockOptions.Unbounded)
+            {
+                InitializeRequestQueue();
+            }
+        }
+
+        protected HttpConfiguration Config { get; }
+
+        protected TraceWriter TraceWriter { get; }
+
+        public async Task<HttpResponseMessage> ProcessRequestAsync(HttpRequestMessage request, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> processRequestHandler, CancellationToken cancellationToken)
+        {
+            if (RejectAllRequests())
+            {
+                // request cannot be queued or processed at this time,
+                return RejectRequest(request);
+            }
+
+            if (_requestQueue != null)
+            {
+                // enqueue the workitem
+                var item = new HttpRequestItem
+                {
+                    Request = request,
+                    ProcessRequestHandler = processRequestHandler,
+                    CancellationToken = cancellationToken,
+                    CompletionSource = new TaskCompletionSource<HttpResponseMessage>()
+                };
+                if (_requestQueue.Post(item))
+                {
+                    return await item.CompletionSource.Task;
+                }
+                else
+                {
+                    TraceWriter.Info($"Http request queue limit of {Config.MaxQueueLength} has been exceeded.");
+                    return RejectRequest(request);
+                }
+            }
+            else
+            {
+                // queue is not enabled, so just dispatch the request directly
+                return await processRequestHandler(request, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// For a request that will be rejected due to load, max queue length
+        /// exceeded, etc. this method will be called, allowing the
+        /// status code, headers, etc. for the request to be configured.
+        /// </summary>
+        /// <param name="request">The request to reject.</param>
+        /// <returns>The response to return.</returns>
+        protected virtual HttpResponseMessage RejectRequest(HttpRequestMessage request)
+        {
+            return new HttpResponseMessage((HttpStatusCode)429);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether all incoming requests
+        /// should be rejected, for example due to host overload, etc.
+        /// </summary>
+        /// <returns>True if requests shoudl be rejected.</returns>
+        protected virtual bool RejectAllRequests()
+        {
+            return false;
+        }
+
+        private void InitializeRequestQueue()
+        {
+            var options = new ExecutionDataflowBlockOptions
+            {
+                MaxDegreeOfParallelism = Config.MaxDegreeOfParallelism,
+                BoundedCapacity = Config.MaxQueueLength
+            };
+
+            _requestQueue = new ActionBlock<HttpRequestItem>(async item =>
+            {
+                try
+                {
+                    var response = await item.ProcessRequestHandler(item.Request, item.CancellationToken);
+                    item.CompletionSource.SetResult(response);
+                }
+                catch (Exception ex)
+                {
+                    item.CompletionSource.SetException(ex);
+                }
+            }, options);
+        }
+
+        private class HttpRequestItem
+        {
+            /// <summary>
+            /// Gets or sets the request to process.
+            /// </summary>
+            public HttpRequestMessage Request { get; set; }
+
+            /// <summary>
+            /// Gets or sets the process method for the request.
+            /// </summary>
+            public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> ProcessRequestHandler { get; set; }
+
+            /// <summary>
+            /// Gets or sets the cancellation token.
+            /// </summary>
+            public CancellationToken CancellationToken { get; set; }
+
+            /// <summary>
+            /// Gets or sets the completion source to use.
+            /// </summary>
+            public TaskCompletionSource<HttpResponseMessage> CompletionSource { get; set; }
+        }
+    }
+}

--- a/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
+++ b/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Binding.Http;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 
 namespace Microsoft.Azure.WebJobs.Script
@@ -64,10 +65,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public FileLoggingMode FileLoggingMode { get; set; }
 
         /// <summary>
-        /// Gets or sets the default route prefix that will be applied to
-        /// function routes.
+        /// Gets or sets the <see cref="HttpConfiguration"/>
         /// </summary>
-        public string HttpRoutePrefix { get; set; }
+        public HttpConfiguration HttpConfiguration { get; set; }
 
         /// <summary>
         /// Gets or sets the list of functions that should be run. This list can be used to filter

--- a/src/WebJobs.Script/Diagnostics/ApplicationPerformanceCounters.cs
+++ b/src/WebJobs.Script/Diagnostics/ApplicationPerformanceCounters.cs
@@ -5,50 +5,50 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
 {
     public class ApplicationPerformanceCounters
     {
-        public int UserTime { get; set; }
+        public long UserTime { get; set; }
 
-        public int KernelTime { get; set; }
+        public long KernelTime { get; set; }
 
-        public int PageFaults { get; set; }
+        public long PageFaults { get; set; }
 
-        public int Processes { get; set; }
+        public long Processes { get; set; }
 
-        public int ProcessLimit { get; set; }
+        public long ProcessLimit { get; set; }
 
-        public int Threads { get; set; }
+        public long Threads { get; set; }
 
-        public int ThreadLimit { get; set; }
+        public long ThreadLimit { get; set; }
 
-        public int Connections { get; set; }
+        public long Connections { get; set; }
 
-        public int ConnectionLimit { get; set; }
+        public long ConnectionLimit { get; set; }
 
-        public int Sections { get; set; }
+        public long Sections { get; set; }
 
-        public int SectionLimit { get; set; }
+        public long SectionLimit { get; set; }
 
-        public int NamedPipes { get; set; }
+        public long NamedPipes { get; set; }
 
-        public int NamedPipeLimit { get; set; }
+        public long NamedPipeLimit { get; set; }
 
-        public int ReadIoOperations { get; set; }
+        public long ReadIoOperations { get; set; }
 
-        public int WriteIoOperations { get; set; }
+        public long WriteIoOperations { get; set; }
 
-        public int OtherIoOperations { get; set; }
+        public long OtherIoOperations { get; set; }
 
-        public int ReadIoBytes { get; set; }
+        public long ReadIoBytes { get; set; }
 
-        public int WriteIoBytes { get; set; }
+        public long WriteIoBytes { get; set; }
 
-        public int OtherIoBytes { get; set; }
+        public long OtherIoBytes { get; set; }
 
-        public int PrivateBytes { get; set; }
+        public long PrivateBytes { get; set; }
 
-        public int Handles { get; set; }
+        public long Handles { get; set; }
 
-        public int ContextSwitches { get; set; }
+        public long ContextSwitches { get; set; }
 
-        public int RemoteOpens { get; set; }
+        public long RemoteOpens { get; set; }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
         public const string FunctionBindingTypeDirectionFormat = "function.binding.{0}.{1}";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
+        public const string FunctionInvokeThrottled = "function.invoke.throttled";
     }
 }

--- a/src/WebJobs.Script/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestMessageExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -24,6 +25,16 @@ namespace Microsoft.Azure.WebJobs.Script
         public static void SetAuthorizationLevel(this HttpRequestMessage request, AuthorizationLevel authorizationLevel)
         {
             request.Properties[ScriptConstants.AzureFunctionsHttpRequestAuthorizationLevelKey] = authorizationLevel;
+        }
+
+        public static void SetProperty(this HttpRequestMessage request, string propertyName, object value)
+        {
+            request.Properties[propertyName] = value;
+        }
+
+        public static T GetPropertyOrDefault<T>(this HttpRequestMessage request, string propertyName)
+        {
+            return request.GetRequestPropertyOrDefault<T>(propertyName);
         }
 
         public static bool IsAntaresInternalRequest(this HttpRequestMessage request)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -23,6 +23,7 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Script.Binding.Http;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -1030,15 +1031,12 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // apply http configuration configuration
             configSection = (JObject)config["http"];
-            string routePrefix = ScriptConstants.DefaultHttpRoutePrefix;
+            HttpConfiguration httpConfig = null;
             if (configSection != null)
             {
-                if (configSection.TryGetValue("routePrefix", out value))
-                {
-                    routePrefix = (string)value;
-                }
+                httpConfig = configSection.ToObject<HttpConfiguration>();
             }
-            scriptConfig.HttpRoutePrefix = routePrefix;
+            scriptConfig.HttpConfiguration = httpConfig ?? new HttpConfiguration();
 
             if (config.TryGetValue("functionTimeout", out value))
             {

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureFunctionsHttpResponseKey = "MS_AzureFunctionsHttpResponse";
         public const string AzureFunctionsHttpRouteDataKey = "MS_AzureFunctionsHttpRouteData";
         public const string AzureFunctionsHttpRequestAuthorizationLevelKey = "MS_AzureFunctionsAuthorizationLevel";
+        public const string AzureFunctionsHttpFunctionKey = "MS_AzureFunctionsHttpFunction";
         public const string AzureFunctionsRequestIdKey = "MS_AzureFunctionsRequestID";
 
         public const string TracePropertyPrimaryHostKey = "MS_PrimaryHost";

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -341,6 +341,8 @@
     <Compile Include="Binding\ExtensionBinding.cs" />
     <Compile Include="Binding\FunctionBinding.cs" />
     <Compile Include="Binding\HttpBinding.cs" />
+    <Compile Include="Binding\Http\HttpConfiguration.cs" />
+    <Compile Include="Binding\Http\HttpRequestManager.cs" />
     <Compile Include="Binding\Http\HttpTriggerAttribute.cs" />
     <Compile Include="Binding\Http\HttpTriggerAttributeBindingProvider.cs" />
     <Compile Include="Binding\Http\HttpRouteFactory.cs" />

--- a/test/WebJobs.Script.Tests/Binding/HttpRequestManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/HttpRequestManagerTests.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Binding.Http;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Binding
+{
+    public class HttpRequestManagerTests
+    {
+        private TestTraceWriter _traceWriter;
+
+        public HttpRequestManagerTests()
+        {
+            _traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+        }
+
+        [Fact]
+        public async Task ProcessRequest_PropigatesExceptions()
+        {
+            var ex = new Exception("Kaboom!");
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> process = (req, ct) =>
+            {
+                throw ex;
+            };
+            var config = new HttpConfiguration
+            {
+                MaxQueueLength = 10,
+                MaxDegreeOfParallelism = 5
+            };
+            var manager = new HttpRequestManager(config, _traceWriter);
+
+            var resultEx = await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                var request = new HttpRequestMessage();
+                await manager.ProcessRequestAsync(request, process, CancellationToken.None);
+            });
+            Assert.Same(ex, resultEx);
+        }
+
+        [Fact]
+        public async Task ProcessRequest_NoThrottle_DispatchesDirectly()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> process = (req, ct) =>
+            {
+                return Task.FromResult(response);
+            };
+            var config = new HttpConfiguration();
+            var manager = new HttpRequestManager(config, _traceWriter);
+
+            var request = new HttpRequestMessage();
+            var result = await manager.ProcessRequestAsync(request, process, CancellationToken.None);
+            Assert.Same(response, result);
+        }
+
+        [Fact]
+        public async Task ProcessRequest_MaxParallelism_RequestsAreThrottled()
+        {
+            int maxParallelism = 3;
+            int count = 0;
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> process = async (req, ct) =>
+            {
+                if (Interlocked.Increment(ref count) > maxParallelism)
+                {
+                    throw new Exception("Kaboom!");
+                }
+
+                await Task.Delay(100);
+
+                Interlocked.Decrement(ref count);
+
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            };
+            var config = new HttpConfiguration
+            {
+                MaxDegreeOfParallelism = maxParallelism
+            };
+            var manager = new HttpRequestManager(config, _traceWriter);
+
+            // expect all requests to succeed
+            var tasks = new List<Task<HttpResponseMessage>>();
+            for (int i = 0; i < 20; i++)
+            {
+                var request = new HttpRequestMessage();
+                tasks.Add(manager.ProcessRequestAsync(request, process, CancellationToken.None));
+            }
+            await Task.WhenAll(tasks);
+            Assert.True(tasks.All(p => p.Result.StatusCode == HttpStatusCode.OK));
+        }
+
+        [Fact]
+        public async Task ProcessRequest_MaxQueueLength_RequestsAreRejected()
+        {
+            int maxQueueLength = 10;
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> process = async (req, ct) =>
+            {
+                await Task.Delay(100);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            };
+            var config = new HttpConfiguration
+            {
+                MaxQueueLength = maxQueueLength,
+                MaxDegreeOfParallelism = 1
+            };
+            var manager = new HttpRequestManager(config, _traceWriter);
+
+            // expect requests past the threshold to be rejected
+            var tasks = new List<Task<HttpResponseMessage>>();
+            for (int i = 0; i < 25; i++)
+            {
+                var request = new HttpRequestMessage();
+                tasks.Add(manager.ProcessRequestAsync(request, process, CancellationToken.None));
+            }
+            await Task.WhenAll(tasks);
+            int countSuccess = tasks.Count(p => p.Result.StatusCode == HttpStatusCode.OK);
+            Assert.Equal(maxQueueLength, countSuccess);
+            int rejectCount = 25 - countSuccess;
+            Assert.Equal(rejectCount, tasks.Count(p => p.Result.StatusCode == (HttpStatusCode)429));
+
+            Assert.Equal(rejectCount, _traceWriter.Traces.Count);
+            Assert.True(_traceWriter.Traces.All(p => string.Compare("Http request queue limit of 10 has been exceeded.", p.Message) == 0));
+
+            // send a number of requests not exceeding the limit
+            // expect all to succeed
+            tasks = new List<Task<HttpResponseMessage>>();
+            for (int i = 0; i < maxQueueLength; i++)
+            {
+                var request = new HttpRequestMessage();
+                tasks.Add(manager.ProcessRequestAsync(request, process, CancellationToken.None));
+            }
+            await Task.WhenAll(tasks);
+            Assert.True(tasks.All(p => p.Result.StatusCode == HttpStatusCode.OK));
+        }
+
+        [Fact]
+        public async Task ProcessRequest_HostIsOverloaded_RequestsAreRejected()
+        {
+            bool rejectRequests = false;
+            var config = new HttpConfiguration();
+            Func<bool> rejectAllRequests = () =>
+            {
+                return rejectRequests;
+            };
+
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> process = async (req, ct) =>
+            {
+                await Task.Delay(100);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            };
+            var manager = new TestHttpRequestManager(config, _traceWriter, rejectAllRequests);
+
+            var tasks = new List<Task<HttpResponseMessage>>();
+            for (int i = 0; i < 10; i++)
+            {
+                if (i == 7)
+                {
+                    rejectRequests = true;
+                }
+                var request = new HttpRequestMessage();
+                tasks.Add(manager.ProcessRequestAsync(request, process, CancellationToken.None));
+            }
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(7, tasks.Count(p => p.Result.StatusCode == HttpStatusCode.OK));
+            Assert.Equal(3, tasks.Count(p => p.Result.StatusCode == (HttpStatusCode)429));
+        }
+
+        [Fact]
+        public async Task ProcessRequest_HostIsOverloaded_CustomRejectAction()
+        {
+            bool rejectOverrideCalled = false;
+            var config = new HttpConfiguration();
+            Func<bool> rejectAllRequests = () =>
+            {
+                return true;
+            };
+            Func<HttpRequestMessage, HttpResponseMessage> rejectRequest = (req) =>
+            {
+                rejectOverrideCalled = true;
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            };
+
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> process = (req, ct) =>
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            };
+            var manager = new TestHttpRequestManager(config, _traceWriter, rejectAllRequests, rejectRequest);
+
+            var request = new HttpRequestMessage();
+            var response = await manager.ProcessRequestAsync(request, process, CancellationToken.None);
+
+            Assert.True(rejectOverrideCalled);
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        }
+
+        private class TestHttpRequestManager : HttpRequestManager
+        {
+            private readonly Func<bool> _rejectAllRequests;
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _rejectRequest;
+
+            public TestHttpRequestManager(HttpConfiguration config, TraceWriter traceWriter, Func<bool> rejectAllRequests = null, Func<HttpRequestMessage, HttpResponseMessage> rejectRequest = null) : base(config, traceWriter)
+            {
+                _rejectAllRequests = rejectAllRequests;
+                _rejectRequest = rejectRequest;
+            }
+
+            protected override bool RejectAllRequests()
+            {
+                if (_rejectAllRequests != null)
+                {
+                    return _rejectAllRequests();
+                }
+                return base.RejectAllRequests();
+            }
+
+            protected override HttpResponseMessage RejectRequest(HttpRequestMessage request)
+            {
+                if (_rejectRequest != null)
+                {
+                    return _rejectRequest(request);
+                }
+                return base.RejectRequest(request);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -536,13 +537,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             ScriptHost.ApplyConfiguration(config, scriptConfig);
 
-            Assert.Equal(ScriptConstants.DefaultHttpRoutePrefix, scriptConfig.HttpRoutePrefix);
+            Assert.Equal(ScriptConstants.DefaultHttpRoutePrefix, scriptConfig.HttpConfiguration.RoutePrefix);
+            Assert.Equal(false, scriptConfig.HttpConfiguration.DynamicThrottlesEnabled);
+            Assert.Equal(scriptConfig.HttpConfiguration.MaxDegreeOfParallelism, DataflowBlockOptions.Unbounded);
+            Assert.Equal(scriptConfig.HttpConfiguration.MaxQueueLength, DataflowBlockOptions.Unbounded);
 
             http["routePrefix"] = "myprefix";
+            http["dynamicThrottlesEnabled"] = true;
+            http["maxDegreeOfParallelism"] = 5;
+            http["maxQueueLength"] = 10;
 
             ScriptHost.ApplyConfiguration(config, scriptConfig);
 
-            Assert.Equal("myprefix", scriptConfig.HttpRoutePrefix);
+            Assert.Equal("myprefix", scriptConfig.HttpConfiguration.RoutePrefix);
+            Assert.Equal(true, scriptConfig.HttpConfiguration.DynamicThrottlesEnabled);
+            Assert.Equal(scriptConfig.HttpConfiguration.MaxDegreeOfParallelism, 5);
+            Assert.Equal(scriptConfig.HttpConfiguration.MaxQueueLength, 10);
         }
 
         // with swagger with setting name with value

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -426,6 +426,7 @@
   <ItemGroup>
     <Compile Include="Binding\CoreExtensionsScriptBindingProviderTests.cs" />
     <Compile Include="Binding\HttpBindingTests.cs" />
+    <Compile Include="Binding\HttpRequestManagerTests.cs" />
     <Compile Include="Binding\SendGridScriptBindingProviderTests.cs" />
     <Compile Include="Binding\ServiceBusScriptBindingProviderTests.cs" />
     <Compile Include="Binding\TwilioScriptBindingProviderTests.cs" />
@@ -489,6 +490,7 @@
     <Compile Include="WebHooks\DynamicWebHookReceiverConfigTests.cs" />
     <Compile Include="Handlers\WebScriptHostHandlerTests.cs" />
     <Compile Include="WebHooks\WebHookReceiverManagerTests.cs" />
+    <Compile Include="WebScriptHostRequestManagerTests.cs" />
     <AdditionalFiles Include="..\..\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>

--- a/test/WebJobs.Script.Tests/WebScriptHostRequestManagerTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostRequestManagerTests.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Binding.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class WebScriptHostRequestManagerTests
+    {
+        private readonly WebScriptHostRequestManager _requestManager;
+        private readonly Mock<IMetricsLogger> _metricsLogger;
+        private readonly Mock<HostPerformanceManager> _performanceManager;
+        private readonly FunctionDescriptor _functionDescriptor;
+        private readonly HttpConfiguration _httpConfig;
+        private readonly TestTraceWriter _traceWriter;
+
+        public WebScriptHostRequestManagerTests()
+        {
+            _metricsLogger = new Mock<IMetricsLogger>(MockBehavior.Strict);
+            _performanceManager = new Mock<HostPerformanceManager>(MockBehavior.Strict, new object[] { new ScriptSettingsManager(), _traceWriter });
+            _httpConfig = new HttpConfiguration();
+            _traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+            _requestManager = new WebScriptHostRequestManager(_httpConfig, _performanceManager.Object, _metricsLogger.Object, _traceWriter, 1);
+            _functionDescriptor = new FunctionDescriptor("Test", null, null, new Collection<ParameterDescriptor>());
+        }
+
+        [Fact]
+        public async Task ProcessRequestAsync_PerformanceThrottle_ReturnsExpectedResult()
+        {
+            _httpConfig.DynamicThrottlesEnabled = true;
+
+            bool highLoad = false;
+            int highLoadQueryCount = 0;
+            _performanceManager.Setup(p => p.IsUnderHighLoad(It.IsAny<Collection<string>>()))
+                .Callback<Collection<string>>((exceededCounters) =>
+                {
+                    if (highLoad)
+                    {
+                        exceededCounters.Add("Threads");
+                        exceededCounters.Add("Processes");
+                    }
+                }).Returns(() =>
+                {
+                    highLoadQueryCount++;
+                    return highLoad;
+                });
+            int throttleMetricCount = 0;
+            _metricsLogger.Setup(p => p.LogEvent(MetricEventNames.FunctionInvokeThrottled, "Test")).Callback(() =>
+            {
+                throttleMetricCount++;
+            });
+
+            // issue some requests while not under high load
+            var request = new HttpRequestMessage();
+            HttpResponseMessage response = null;
+            for (int i = 0; i < 3; i++)
+            {
+                response = await _requestManager.ProcessRequestAsync(request, ProcessRequest, CancellationToken.None);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                await Task.Delay(100);
+            }
+            Assert.Equal(1, highLoadQueryCount);
+            Assert.Equal(0, throttleMetricCount);
+
+            // signal high load and verify requests are rejected
+            await Task.Delay(1000);
+            highLoad = true;
+            for (int i = 0; i < 3; i++)
+            {
+                response = await _requestManager.ProcessRequestAsync(request, ProcessRequest, CancellationToken.None);
+                Assert.Equal((HttpStatusCode)429, response.StatusCode);
+                await Task.Delay(100);
+            }
+            Assert.Equal(2, highLoadQueryCount);
+            Assert.Equal(3, throttleMetricCount);
+            var trace = _traceWriter.Traces.Last();
+            Assert.Equal("Thresholds for the following counters have been exceeded: Threads, Processes", trace.Message);
+
+            await Task.Delay(1000);
+            highLoad = false;
+            for (int i = 0; i < 3; i++)
+            {
+                response = await _requestManager.ProcessRequestAsync(request, ProcessRequest, CancellationToken.None);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                await Task.Delay(100);
+            }
+            Assert.Equal(3, highLoadQueryCount);
+            Assert.Equal(3, throttleMetricCount);
+        }
+
+        private Task<HttpResponseMessage> ProcessRequest(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.SetProperty(ScriptConstants.AzureFunctionsHttpFunctionKey, _functionDescriptor);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue https://github.com/Azure/azure-webjobs-sdk-script/issues/1261. The goal here is to provide some user configurable knobs similar to the throttling knobs on our other triggers (e.g. queues batch size, etc.). This new capability is completely opt in - if none of the http config knobs are set, things work as they did before.

We now provide the following http throttle behavior:

- optional/configurable maximum http request queue length. When exceeded, additional requests will be rejected
- optional/configurable maximum concurrency level for http requests. E.g. when set to N, only N requests will ever be processed concurrently. All others will sit in the request queue
- configurable performance counter throttling - if any of the existing host level performance counters are above 80% (e.g. Connections, Threads, Processes, etc., to be expanded to CPU/Memory in the future).