### PR TITLE
Tweaking Local mode HostId generation

### DIFF
--- a/src/WebJobs.Script.Host/Program.cs
+++ b/src/WebJobs.Script.Host/Program.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.WebJobs.Script.Host
                 rootPath = (string)args[0];
             }
 
-            ScriptHostConfiguration config = new ScriptHostConfiguration()
+            var config = new ScriptHostConfiguration()
             {
                 RootScriptPath = rootPath
             };
 
-            ScriptHostManager scriptHostManager = new ScriptHostManager(config);
+            var scriptHostManager = new ScriptHostManager(config);
             scriptHostManager.RunAndBlock();
         }
     }

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
@@ -33,22 +33,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         internal static WebHostSettings CreateDefault(ScriptSettingsManager settingsManager)
         {
-            WebHostSettings settings = new WebHostSettings();
+            WebHostSettings settings = new WebHostSettings
+            {
+                IsSelfHost = !settingsManager.IsAzureEnvironment
+            };
 
-            string home = settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath);
-            bool isLocal = string.IsNullOrEmpty(home);
-            if (isLocal)
+            if (settingsManager.IsAzureEnvironment)
+            {
+                string home = settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath);
+                settings.ScriptPath = Path.Combine(home, @"site\wwwroot");
+                settings.LogPath = Path.Combine(home, @"LogFiles\Application\Functions");
+                settings.SecretsPath = Path.Combine(home, @"data\Functions\secrets");
+            }
+            else
             {
                 settings.ScriptPath = settingsManager.GetSetting(EnvironmentSettingNames.AzureWebJobsScriptRoot);
                 settings.LogPath = Path.Combine(Path.GetTempPath(), @"Functions");
                 settings.SecretsPath = System.Web.HttpContext.Current.Server.MapPath("~/App_Data/Secrets");
-            }
-            else
-            {
-                // we're running in Azure
-                settings.ScriptPath = Path.Combine(home, @"site\wwwroot");
-                settings.LogPath = Path.Combine(home, @"LogFiles\Application\Functions");
-                settings.SecretsPath = Path.Combine(home, @"data\Functions\secrets");
             }
 
             if (string.IsNullOrEmpty(settings.ScriptPath))

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             set { _instance = value; }
         }
 
-        public bool IsAzureEnvironment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId));
+        public virtual bool IsAzureEnvironment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId));
 
         public bool IsRemoteDebuggingEnabled => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.RemoteDebuggingPort));
 


### PR DESCRIPTION
Rather than rely on an explicit setting IsSelfHost to determine whether we're running in Azure or locally, I instead use our existing IsAzureEnvironment setting.