### PR TITLE
Using alternate setting for blob key storage location

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/BlobStorageSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/BlobStorageSecretsRepository.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly string _accountConnectionString;
         private bool _disposed = false;
 
-        public BlobStorageSecretsRepository(string secretSentinelDirectoryPath, string accountConnectionString, string siteHostName)
+        public BlobStorageSecretsRepository(string secretSentinelDirectoryPath, string accountConnectionString, string siteSlotName)
         {
             if (secretSentinelDirectoryPath == null)
             {
@@ -38,6 +38,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (accountConnectionString == null)
             {
                 throw new ArgumentNullException(nameof(accountConnectionString));
+            }
+            if (siteSlotName == null)
+            {
+                throw new ArgumentNullException(nameof(siteSlotName));
             }
 
             _secretsSentinelFilePath = secretSentinelDirectoryPath;
@@ -48,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _sentinelFileWatcher = new AutoRecoveringFileSystemWatcher(_secretsSentinelFilePath, "*.json");
             _sentinelFileWatcher.Changed += OnChanged;
 
-            _secretsBlobPath = siteHostName.ToLowerInvariant();
+            _secretsBlobPath = siteSlotName.ToLowerInvariant();
             _hostSecretsBlobPath = string.Format("{0}/{1}", _secretsBlobPath, ScriptConstants.HostMetadataFileName);
 
             _accountConnectionString = accountConnectionString;

--- a/src/WebJobs.Script.WebHost/Security/DefaultSecretsRepositoryFactory.cs
+++ b/src/WebJobs.Script.WebHost/Security/DefaultSecretsRepositoryFactory.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             string storageString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Storage);
             if (secretStorageType != null && secretStorageType.Equals("Blob", StringComparison.OrdinalIgnoreCase) && storageString != null)
             {
-                string siteHostId = settingsManager.AzureWebsiteDefaultSubdomain ?? config.HostConfig.HostId;
-                return new BlobStorageSecretsRepository(Path.Combine(webHostSettings.SecretsPath, "Sentinels"), storageString, siteHostId);
+                string siteSlotName = settingsManager.AzureWebsiteUniqueSlotName ?? config.HostConfig.HostId;
+                return new BlobStorageSecretsRepository(Path.Combine(webHostSettings.SecretsPath, "Sentinels"), storageString, siteSlotName);
             }
             else
             {


### PR DESCRIPTION
Swap behavior using current HOSTNAME environment setting is not ideal - switching to alternate SLOT_NAME setting to make the operation more seamless 