### PR TITLE
Fixing Host ID initialization (ensuring it is set when FastLogger is created)

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        private static ScriptHostConfiguration CreateScriptHostConfiguration(WebHostSettings settings)
+        internal static ScriptHostConfiguration CreateScriptHostConfiguration(WebHostSettings settings)
         {
             InitializeFileSystem(settings.ScriptPath);
 
@@ -157,8 +157,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 RootScriptPath = settings.ScriptPath,
                 RootLogPath = settings.LogPath,
                 FileLoggingMode = FileLoggingMode.DebugOnly,
-                TraceWriter = settings.TraceWriter
+                TraceWriter = settings.TraceWriter,
+                IsSelfHost = settings.IsSelfHost
             };
+
+            scriptHostConfig.HostConfig.HostId = Utility.GetDefaultHostId(_settingsManager, scriptHostConfig);
 
             return scriptHostConfig;
         }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 if (string.IsNullOrEmpty(ScriptConfig.HostConfig.HostId))
                 {
-                    ScriptConfig.HostConfig.HostId = GetDefaultHostId(_settingsManager, ScriptConfig);
+                    ScriptConfig.HostConfig.HostId = Utility.GetDefaultHostId(_settingsManager, ScriptConfig);
                 }
                 if (string.IsNullOrEmpty(ScriptConfig.HostConfig.HostId))
                 {
@@ -1302,44 +1302,6 @@ namespace Microsoft.Azure.WebJobs.Script
                     }
                 }
             }
-        }
-
-        internal static string GetDefaultHostId(ScriptSettingsManager settingsManager, ScriptHostConfiguration scriptConfig)
-        {
-            // We're setting the default here on the newly created configuration
-            // If the user has explicitly set the HostID via host.json, it will overwrite
-            // what we set here
-            string hostId = null;
-            if (scriptConfig.IsSelfHost)
-            {
-                // When running locally, derive a stable host ID from machine name
-                // and root path. We use a hash rather than the path itself to ensure
-                // IDs differ (due to truncation) between folders that may share the same
-                // root path prefix.
-                // Note that such an ID won't work in distributed scenarios, so should
-                // only be used for local/CLI scenarios.
-                string sanitizedMachineName = Environment.MachineName
-                    .Where(char.IsLetterOrDigit)
-                    .Aggregate(new StringBuilder(), (b, c) => b.Append(c)).ToString();
-                hostId = $"{sanitizedMachineName}-{Math.Abs(scriptConfig.RootScriptPath.GetHashCode())}";
-            }
-            else if (!string.IsNullOrEmpty(settingsManager.AzureWebsiteUniqueSlotName))
-            {
-                // If running on Azure Web App, derive the host ID from unique site slot name
-                hostId = settingsManager.AzureWebsiteUniqueSlotName;
-            }
-
-            if (!string.IsNullOrEmpty(hostId))
-            {
-                if (hostId.Length > ScriptConstants.MaximumHostIdLength)
-                {
-                    // Truncate to the max host name length if needed
-                    hostId = hostId.Substring(0, ScriptConstants.MaximumHostIdLength);
-                }
-            }
-
-            // Lowercase and trim any trailing '-' as they can cause problems with queue names
-            return hostId?.ToLowerInvariant().TrimEnd('-');
         }
 
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -140,6 +140,44 @@ namespace Microsoft.Azure.WebJobs.Script
             return functionName;
         }
 
+        internal static string GetDefaultHostId(ScriptSettingsManager settingsManager, ScriptHostConfiguration scriptConfig)
+        {
+            // We're setting the default here on the newly created configuration
+            // If the user has explicitly set the HostID via host.json, it will overwrite
+            // what we set here
+            string hostId = null;
+            if (scriptConfig.IsSelfHost)
+            {
+                // When running locally, derive a stable host ID from machine name
+                // and root path. We use a hash rather than the path itself to ensure
+                // IDs differ (due to truncation) between folders that may share the same
+                // root path prefix.
+                // Note that such an ID won't work in distributed scenarios, so should
+                // only be used for local/CLI scenarios.
+                string sanitizedMachineName = Environment.MachineName
+                    .Where(char.IsLetterOrDigit)
+                    .Aggregate(new StringBuilder(), (b, c) => b.Append(c)).ToString();
+                hostId = $"{sanitizedMachineName}-{Math.Abs(scriptConfig.RootScriptPath.GetHashCode())}";
+            }
+            else if (!string.IsNullOrEmpty(settingsManager.AzureWebsiteUniqueSlotName))
+            {
+                // If running on Azure Web App, derive the host ID from unique site slot name
+                hostId = settingsManager.AzureWebsiteUniqueSlotName;
+            }
+
+            if (!string.IsNullOrEmpty(hostId))
+            {
+                if (hostId.Length > ScriptConstants.MaximumHostIdLength)
+                {
+                    // Truncate to the max host name length if needed
+                    hostId = hostId.Substring(0, ScriptConstants.MaximumHostIdLength);
+                }
+            }
+
+            // Lowercase and trim any trailing '-' as they can cause problems with queue names
+            return hostId?.ToLowerInvariant().TrimEnd('-');
+        }
+
         public static string FlattenException(Exception ex, Func<string, string> sourceFormatter = null, bool includeSource = true)
         {
             StringBuilder flattenedErrorsBuilder = new StringBuilder();

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1214,38 +1214,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.False(host.IsFunction(null));
         }
 
-        [Fact]
-        public void GetDefaultHostId_SelfHost_ReturnsExpectedResult()
-        {
-            var config = new ScriptHostConfiguration
-            {
-                IsSelfHost = true,
-                RootScriptPath = @"c:\testing\FUNCTIONS-TEST\test$#"
-            };
-            var scriptSettingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict);
-
-            string hostId = ScriptHost.GetDefaultHostId(scriptSettingsManagerMock.Object, config);
-            string sanitizedMachineName = Environment.MachineName
-                    .Where(char.IsLetterOrDigit)
-                    .Aggregate(new StringBuilder(), (b, c) => b.Append(c)).ToString().ToLowerInvariant();
-            Assert.Equal($"{sanitizedMachineName}-789851553", hostId);
-        }
-
-        [Theory]
-        [InlineData("TEST-FUNCTIONS--", "test-functions")]
-        [InlineData("TEST-FUNCTIONS-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "test-functions-xxxxxxxxxxxxxxxxx")]
-        [InlineData("TEST-FUNCTIONS-XXXXXXXXXXXXXXXX-XXXX", "test-functions-xxxxxxxxxxxxxxxx")] /* 32nd character is a '-' */
-        [InlineData(null, null)]
-        public void GetDefaultHostId_AzureHost_ReturnsExpectedResult(string input, string expected)
-        {
-            var config = new ScriptHostConfiguration();
-            var scriptSettingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict);
-            scriptSettingsManagerMock.SetupGet(p => p.AzureWebsiteUniqueSlotName).Returns(() => input);
-
-            string hostId = ScriptHost.GetDefaultHostId(scriptSettingsManagerMock.Object, config);
-            Assert.Equal(expected, hostId);
-        }
-
         public class AssemblyMock : Assembly
         {
             public override object[] GetCustomAttributes(Type attributeType, bool inherit)

--- a/test/WebJobs.Script.Tests/WebHostResolverTests.cs
+++ b/test/WebJobs.Script.Tests/WebHostResolverTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class WebHostResolverTests
+    {
+        [Fact]
+        public void GetScriptHostConfiguration_SetsHostId()
+        {
+            var environmentSettings = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteName, "testsite" },
+                { EnvironmentSettingNames.AzureWebsiteSlotName, "production" },
+            };
+
+            using (var environment = new TestScopedEnvironmentVariable(environmentSettings))
+            {
+                var settingsManager = new ScriptSettingsManager();
+                var secretManagerFactoryMock = new Mock<ISecretManagerFactory>();
+                var resolver = new WebHostResolver(settingsManager, secretManagerFactoryMock.Object);
+
+                var settings = new WebHostSettings
+                {
+                    ScriptPath = @"c:\some\path",
+                    LogPath = @"c:\log\path",
+                    SecretsPath = @"c:\secrets\path"
+                };
+
+                ScriptHostConfiguration configuration = resolver.GetScriptHostConfiguration(settings);
+
+                Assert.Equal("testsite", configuration.HostConfig.HostId);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -541,6 +541,7 @@
     <Compile Include="WebHooks\DynamicWebHookReceiverConfigTests.cs" />
     <Compile Include="Handlers\WebScriptHostHandlerTests.cs" />
     <Compile Include="WebHooks\WebHookReceiverManagerTests.cs" />
+    <Compile Include="WebHostResolverTests.cs" />
     <Compile Include="WebScriptHostRequestManagerTests.cs" />
     <AdditionalFiles Include="..\..\stylecop.json">
       <Link>stylecop.json</Link>


### PR DESCRIPTION
Resolves #1393

This is a very tactical fix to address a production impacting issue (described in #1393). I'm working on a larger fix as this still doesn't address some configuration related issues, but wanted to make sure this was out.