### PR TITLE
Bump minimum VS Version for C#7

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15 (VS2017)
+VisualStudioVersion = 15.1.26403.7
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script", "src\WebJobs.Script\WebJobs.Script.csproj", "{1DC670CD-F42F-4D8F-97BD-0E1AA8221094}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}"


### PR DESCRIPTION
@brettsam @fabiocav @tohling 

This will open VS2017 by default and provide an obvious error message if opening with VS2015