### PR TITLE
Script directory fix

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionInvoker.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _metricsLogger = Host.ScriptConfig.HostConfig.GetService<IMetricsLogger>();
             _functionEntryPointResolver = functionEntryPointResolver;
             _assemblyLoader = assemblyLoader;
-            _metadataResolver = metadataResolver ?? new FunctionMetadataResolver(functionMetadata, host.ScriptConfig.BindingProviders, TraceWriter, host.ScriptConfig.HostConfig.LoggerFactory);
+            _metadataResolver = metadataResolver ?? CreateMetadataResolver(host, functionMetadata, TraceWriter);
             _compilationService = compilationServiceFactory.CreateService(functionMetadata.ScriptType, _metadataResolver);
             _inputBindings = inputBindings;
             _outputBindings = outputBindings;
@@ -75,6 +75,13 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             _restorePackages = RestorePackages;
             _restorePackages = _restorePackages.Debounce();
+        }
+
+        private static IFunctionMetadataResolver CreateMetadataResolver(ScriptHost host, FunctionMetadata functionMetadata, TraceWriter traceWriter)
+        {
+            string functionScriptDirectory = Path.GetDirectoryName(functionMetadata.ScriptFile);
+            return new FunctionMetadataResolver(functionScriptDirectory, host.ScriptConfig.BindingProviders,
+                traceWriter, host.ScriptConfig.HostConfig.LoggerFactory);
         }
 
         private void InitializeFileWatcher()

--- a/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     public sealed class FunctionMetadataResolver : MetadataReferenceResolver, IFunctionMetadataResolver
     {
         private readonly string _privateAssembliesPath;
+        private readonly string _scriptFileDirectory;
         private readonly string[] _assemblyExtensions = new[] { ".exe", ".dll" };
         private readonly string _id = Guid.NewGuid().ToString();
-        private readonly FunctionMetadata _functionMetadata;
         private readonly TraceWriter _traceWriter;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ConcurrentDictionary<string, string> _externalReferences = new ConcurrentDictionary<string, string>();
@@ -75,12 +75,12 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 "Microsoft.Extensions.Logging"
             };
 
-        public FunctionMetadataResolver(FunctionMetadata metadata, ICollection<ScriptBindingProvider> bindingProviders, TraceWriter traceWriter, ILoggerFactory loggerFactory)
+        public FunctionMetadataResolver(string scriptFileDirectory, ICollection<ScriptBindingProvider> bindingProviders, TraceWriter traceWriter, ILoggerFactory loggerFactory)
         {
-            _functionMetadata = metadata;
+            _scriptFileDirectory = scriptFileDirectory;
             _traceWriter = traceWriter;
-            _packageAssemblyResolver = new PackageAssemblyResolver(metadata);
-            _privateAssembliesPath = GetBinDirectory(metadata);
+            _packageAssemblyResolver = new PackageAssemblyResolver(scriptFileDirectory);
+            _privateAssembliesPath = GetBinDirectory(scriptFileDirectory);
             _scriptResolver = ScriptMetadataResolver.Default.WithSearchPaths(_privateAssembliesPath);
             _extensionSharedAssemblyProvider = new ExtensionSharedAssemblyProvider(bindingProviders);
             _loggerFactory = loggerFactory;
@@ -94,18 +94,17 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     .WithMetadataResolver(this)
                     .WithReferences(GetCompilationReferences())
                     .WithImports(DefaultNamespaceImports)
-                    .WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, Path.GetDirectoryName(_functionMetadata.ScriptFile)));
+                    .WithSourceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, _scriptFileDirectory));
         }
 
         /// <summary>
         /// Gets the private 'bin' path for a given script.
         /// </summary>
-        /// <param name="metadata">The function metadata.</param>
+        /// <param name="baseDirectory">The path to the base directory.</param>
         /// <returns>The path to the function's private assembly folder</returns>
-        private static string GetBinDirectory(FunctionMetadata metadata)
+        private static string GetBinDirectory(string baseDirectory)
         {
-            string functionDirectory = Path.GetDirectoryName(metadata.ScriptFile);
-            return Path.Combine(Path.GetFullPath(functionDirectory), DotNetConstants.PrivateAssembliesFolderName);
+            return Path.Combine(Path.GetFullPath(baseDirectory), DotNetConstants.PrivateAssembliesFolderName);
         }
 
         public override bool Equals(object other)
@@ -192,10 +191,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 bool externalReference = false;
                 string basePath = _privateAssembliesPath;
 
-                // If this is a relative assembly reference, use the function directory as the base probing path
+                // If this is a relative assembly reference, use the function script directory as the base probing path
                 if (reference.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }) > -1)
                 {
-                    basePath = Path.GetDirectoryName(_functionMetadata.ScriptFile);
+                    basePath = _scriptFileDirectory;
                     externalReference = true;
                 }
 
@@ -264,11 +263,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public async Task<PackageRestoreResult> RestorePackagesAsync()
         {
-            var packageManager = new PackageManager(_functionMetadata, _traceWriter, _loggerFactory);
+            var packageManager = new PackageManager(_scriptFileDirectory, _traceWriter, _loggerFactory);
             PackageRestoreResult result = await packageManager.RestorePackagesAsync();
 
             // Reload the resolver
-            _packageAssemblyResolver = new PackageAssemblyResolver(_functionMetadata);
+            _packageAssemblyResolver = new PackageAssemblyResolver(_scriptFileDirectory);
 
             return result;
         }

--- a/src/WebJobs.Script/Description/DotNet/PackageAssemblyResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/PackageAssemblyResolver.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private readonly ImmutableArray<PackageReference> _packages;
 
-        public PackageAssemblyResolver(FunctionMetadata metadata)
+        public PackageAssemblyResolver(string workingDirectory)
         {
-            _packages = InitializeAssemblyRegistry(metadata);
+            _packages = InitializeAssemblyRegistry(workingDirectory);
         }
 
         public ImmutableArray<PackageReference> Packages
@@ -48,10 +48,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        private static ImmutableArray<PackageReference> InitializeAssemblyRegistry(FunctionMetadata metadata)
+        private static ImmutableArray<PackageReference> InitializeAssemblyRegistry(string functionDirectory)
         {
             var builder = ImmutableArray<PackageReference>.Empty.ToBuilder();
-            string fileName = Path.Combine(Path.GetDirectoryName(metadata.ScriptFile), DotNetConstants.ProjectLockFileName);
+            string fileName = Path.Combine(functionDirectory, DotNetConstants.ProjectLockFileName);
 
             if (File.Exists(fileName))
             {

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (Host.ScriptConfig.FileWatchingEnabled)
             {
-                string functionDirectory = Path.GetDirectoryName(Metadata.ScriptFile);
-                _fileWatcher = new AutoRecoveringFileSystemWatcher(functionDirectory);
+                string functionScriptDirectory = Path.GetDirectoryName(Metadata.ScriptFile);
+                _fileWatcher = new AutoRecoveringFileSystemWatcher(functionScriptDirectory);
                 _fileWatcher.Changed += OnScriptFileChanged;
 
                 return true;

--- a/src/WebJobs.Script/Description/FunctionMetadata.cs
+++ b/src/WebJobs.Script/Description/FunctionMetadata.cs
@@ -17,10 +17,15 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public string Name { get; set; }
 
         /// <summary>
-        /// The primary entry point for the function (to disambiguate if there are multiple
+        /// Gets or sets the primary entry point for the function (to disambiguate if there are multiple
         /// scripts in the function directory).
         /// </summary>
         public string ScriptFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function root directory.
+        /// </summary>
+        public string FunctionDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the optional named entry point for a function.

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -735,11 +735,12 @@ namespace Microsoft.Azure.WebJobs.Script
             return bindingProviders;
         }
 
-        private static FunctionMetadata ParseFunctionMetadata(string functionName, JObject configMetadata, ScriptSettingsManager settingsManager)
+        private static FunctionMetadata ParseFunctionMetadata(string functionName, JObject configMetadata, string scriptDirectory, ScriptSettingsManager settingsManager)
         {
             FunctionMetadata functionMetadata = new FunctionMetadata
             {
-                Name = functionName
+                Name = functionName,
+                FunctionDirectory = scriptDirectory
             };
 
             JValue triggerDisabledValue = null;
@@ -848,7 +849,7 @@ namespace Microsoft.Azure.WebJobs.Script
             fileSystem = fileSystem ?? new FileSystem();
 
             error = null;
-            functionMetadata = ParseFunctionMetadata(functionName, functionConfig, settingsManager);
+            functionMetadata = ParseFunctionMetadata(functionName, functionConfig, scriptDirectory, settingsManager);
 
             if (functionMetadata.IsExcluded)
             {

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var metadata = new FunctionMetadata
             {
                 ScriptFile = filePath,
+                FunctionDirectory = Path.GetDirectoryName(filePath),
                 Name = Guid.NewGuid().ToString(),
                 ScriptType = ScriptType.CSharp
             };
@@ -96,6 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var metadata = new FunctionMetadata
             {
                 ScriptFile = filePath,
+                FunctionDirectory = Path.GetDirectoryName(filePath),
                 Name = Guid.NewGuid().ToString(),
                 ScriptType = ScriptType.CSharp
             };
@@ -134,6 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var metadata = new FunctionMetadata
             {
                 ScriptFile = filePath,
+                FunctionDirectory = Path.GetDirectoryName(filePath),
                 Name = Guid.NewGuid().ToString(),
                 ScriptType = ScriptType.CSharp
             };

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoaderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoaderTests.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var resolver = new FunctionAssemblyLoader("c:\\");
 
-            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = @"c:\testroot\test1\test.tst" };
+            var metadata1Directory = @"c:\testroot\test1";
+            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = $@"{metadata1Directory}\test.tst" };
             var metadata2 = new FunctionMetadata { Name = "Test2", ScriptFile = @"c:\testroot\test2\test.tst" };
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
 
@@ -27,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             mockResolver.Setup(m => m.ResolveAssembly("MyTestAssembly.dll"))
               .Returns(new TestAssembly(new AssemblyName("MyTestAssembly")));
 
-            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, new FunctionMetadataResolver(metadata1, new Collection<ScriptBindingProvider>(), traceWriter, null), traceWriter, null);
+            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, new FunctionMetadataResolver(metadata1Directory, new Collection<ScriptBindingProvider>(), traceWriter, null), traceWriter, null);
             resolver.CreateOrUpdateContext(metadata2, this.GetType().Assembly, mockResolver.Object, traceWriter, null);
 
             Assembly result = resolver.ResolveAssembly(null, new System.ResolveEventArgs("MyTestAssembly.dll",
@@ -41,7 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var resolver = new FunctionAssemblyLoader("c:\\");
 
-            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = @"c:\testroot\test1\test.tst" };
+            var metadata1Directory = @"c:\testroot\test1";
+            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = $@"{metadata1Directory}\test.tst" };
             var metadata2 = new FunctionMetadata { Name = "Test2", ScriptFile = @"c:\testroot\test2\test.tst" };
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
 
@@ -49,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             mockResolver.Setup(m => m.ResolveAssembly("MyTestAssembly.dll"))
               .Returns<Assembly>(null);
 
-            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, new FunctionMetadataResolver(metadata1, new Collection<ScriptBindingProvider>(), traceWriter, null), traceWriter, null);
+            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, new FunctionMetadataResolver(metadata1Directory, new Collection<ScriptBindingProvider>(), traceWriter, null), traceWriter, null);
             resolver.CreateOrUpdateContext(metadata2, this.GetType().Assembly, mockResolver.Object, traceWriter, null);
 
             Assembly result = resolver.ResolveAssembly(AppDomain.CurrentDomain, new System.ResolveEventArgs("MyTestAssembly.dll",

--- a/test/WebJobs.Script.Tests/Description/DotNet/PackageAssemblyResolverTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/PackageAssemblyResolverTests.cs
@@ -52,14 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void GivenLockFile_PackageReferencesAreResolved()
         {
-            var functionMetadata = new FunctionMetadata()
-            {
-                Name = "TestFunction",
-                ScriptFile = _lockFilePath, /*We just need the path from this*/
-                ScriptType = ScriptType.CSharp
-            };
-
-            var assemblyResolver = new PackageAssemblyResolver(functionMetadata);
+            PackageAssemblyResolver assemblyResolver = CreateResolver();
 
             PackageReference package = assemblyResolver.Packages.Single();
 
@@ -72,14 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void GivenPackagesWithAssemblyReferences_AssemblyReferencesAreResolved()
         {
-            var functionMetadata = new FunctionMetadata()
-            {
-                Name = "TestFunction",
-                ScriptFile = _lockFilePath, /*We just need the path from this*/
-                ScriptType = ScriptType.CSharp
-            };
-
-            var assemblyResolver = new PackageAssemblyResolver(functionMetadata);
+            PackageAssemblyResolver assemblyResolver = CreateResolver();
 
             string nugetHome = PackageManager.GetNugetPackagesPath();
 
@@ -89,14 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void GivenPackagesWithFrameworkReferences_FrameworkReferencesAreResolved()
         {
-            var functionMetadata = new FunctionMetadata()
-            {
-                Name = "TestFunction",
-                ScriptFile = _lockFilePath, /*We just need the path from this*/
-                ScriptType = ScriptType.CSharp
-            };
-
-            var assemblyResolver = new PackageAssemblyResolver(functionMetadata);
+            PackageAssemblyResolver assemblyResolver = CreateResolver();
 
             Assert.Contains<string>("System.Net.Http", assemblyResolver.AssemblyReferences);
             Assert.Contains<string>("System.Net.Http.WebRequest", assemblyResolver.AssemblyReferences);
@@ -105,17 +84,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void TryResolveAssembly_WithReferencedAssemblyName_ResolvesAssemblyPathAndReturnsTrue()
         {
-            var functionMetadata = new FunctionMetadata()
-            {
-                Name = "TestFunction",
-                ScriptFile = _lockFilePath, /*We just need the path from this*/
-                ScriptType = ScriptType.CSharp
-            };
+            PackageAssemblyResolver assemblyResolver = CreateResolver();
 
-            var assemblyResolver = new PackageAssemblyResolver(functionMetadata);
-
-            string assemblyPath;
-            bool result = assemblyResolver.TryResolveAssembly(this.GetType().Assembly.FullName, out assemblyPath);
+            bool result = assemblyResolver.TryResolveAssembly(this.GetType().Assembly.FullName, out string assemblyPath);
 
             Assert.True(result);
             Assert.Equal(_targetAssemblyFilePath, assemblyPath);
@@ -124,6 +95,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void TryResolveAssembly_WithReferencedFrameworkAssemblyName_ResolvesAssemblyAndReturnsTrue()
         {
+            PackageAssemblyResolver assemblyResolver = CreateResolver();
+
+            bool result = assemblyResolver.TryResolveAssembly("System.Net.Http", out string assemblyPath);
+
+            Assert.True(result);
+            Assert.Equal("System.Net.Http", assemblyPath);
+        }
+
+        private PackageAssemblyResolver CreateResolver()
+        {
             var functionMetadata = new FunctionMetadata()
             {
                 Name = "TestFunction",
@@ -131,13 +112,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 ScriptType = ScriptType.CSharp
             };
 
-            var assemblyResolver = new PackageAssemblyResolver(functionMetadata);
-
-            string assemblyPath;
-            bool result = assemblyResolver.TryResolveAssembly("System.Net.Http", out assemblyPath);
-
-            Assert.True(result);
-            Assert.Equal("System.Net.Http", assemblyPath);
+            string functionDirectory = Path.GetDirectoryName(functionMetadata.ScriptFile);
+            return new PackageAssemblyResolver(functionDirectory);
         }
     }
 }


### PR DESCRIPTION
Updating code where the script directory is incorrectly derived from the script file path. Introducing a new property on `ScriptMetadata` so resolution is centralized.