### PR TITLE
if type is bool, return its value

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1472,9 +1472,9 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (isDisabledValue != null)
             {
-                if (isDisabledValue.Type == JTokenType.Boolean && (bool)isDisabledValue)
+                if (isDisabledValue.Type == JTokenType.Boolean)
                 {
-                    return true;
+                    return (bool)isDisabledValue;
                 }
                 else
                 {


### PR DESCRIPTION
working on duplicating this logic in kudu, and it looks like the code will try to expand `isDisabledValue` to an environment variable if we have `"disabled":false`

we can return its boolean value once we know its of `JTokenType.Boolean`