### PR TITLE
Increasing maximum function timeout from 5 to 20 minutes

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -23,7 +23,6 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
-using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script.Binding;
@@ -55,7 +54,8 @@ namespace Microsoft.Azure.WebJobs.Script
         private ImmutableArray<string> _directorySnapshot;
         private BlobLeaseManager _blobLeaseManager;
         private static readonly TimeSpan MinTimeout = TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan MaxTimeout = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan MaxTimeout = TimeSpan.FromMinutes(20);
         private static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static readonly string Version = GetAssemblyFileVersion(typeof(ScriptHost).Assembly);
         private ScriptSettingsManager _settingsManager;
@@ -1214,7 +1214,7 @@ namespace Microsoft.Azure.WebJobs.Script
             else if (ScriptSettingsManager.Instance.IsDynamicSku)
             {
                 // Apply a default if this is running on Dynamic.
-                scriptConfig.FunctionTimeout = MaxTimeout;
+                scriptConfig.FunctionTimeout = DefaultTimeout;
             }
 
             // apply swagger configuration

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -757,7 +757,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteSku, "Dynamic");
 
-                config["functionTimeout"] = "00:05:01";
+                config["functionTimeout"] = "00:20:01";
                 Assert.Throws<ArgumentException>(() => ScriptHost.ApplyConfiguration(config, scriptConfig));
 
                 config["functionTimeout"] = "00:00:00.9";


### PR DESCRIPTION
Recent infrastructure changes in Dynamic allow us to increase our maximum timeout. This addresses issue https://github.com/Azure/Azure-Functions/issues/75.

I've also updated our host.json wiki doc here: https://github.com/Azure/azure-webjobs-sdk-script/wiki/host.json. I also added a note to https://github.com/Azure/azure-webjobs-sdk-script/issues/18.



