### PR TITLE
adding a test for HttpTriggers and disposed hosts

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1123,6 +1123,10 @@ namespace Microsoft.Azure.WebJobs.Script
                     scriptConfig.Functions.Add((string)function);
                 }
             }
+            else
+            {
+                scriptConfig.Functions = null;
+            }
 
             // We may already have a host id, but the one from the JSON takes precedence
             JToken hostId = (JToken)config["id"];

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -31,9 +30,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly TempDirectory _secretsDirectory = new TempDirectory();
         private WebScriptHostManagerTests.Fixture _fixture;
 
-        // Some tests need their own manager that differs from the fixture.
-        private WebScriptHostManager _manager;
-
         public WebScriptHostManagerTests(WebScriptHostManagerTests.Fixture fixture)
         {
             _fixture = fixture;
@@ -53,11 +49,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
             await host.CallAsync("ManualTrigger", parameters);
 
+            // it's possible that the TimerTrigger fires during this so filter them out.
+
+            string[] events = _fixture.EventGenerator.Events.Where(e => !e.Contains("TimerTrigger")).ToArray();
+            Assert.True(events.Length == 4, $"Expected 4 events. Actual: {events.Length}. Actual events: {Environment.NewLine}{string.Join(Environment.NewLine, events)}");
             Assert.Equal(4, _fixture.EventGenerator.Events.Count);
-            Assert.True(_fixture.EventGenerator.Events[0].StartsWith("Info WebJobs.Execution Executing 'Functions.ManualTrigger' (Reason='This function was programmatically called via the host APIs.', Id="));
-            Assert.True(_fixture.EventGenerator.Events[1].StartsWith("Info ManualTrigger Function started (Id="));
-            Assert.True(_fixture.EventGenerator.Events[2].StartsWith("Info ManualTrigger Function completed (Success, Id="));
-            Assert.True(_fixture.EventGenerator.Events[3].StartsWith("Info WebJobs.Execution Executed 'Functions.ManualTrigger' (Succeeded, Id="));
+            Assert.StartsWith("Info WebJobs.Execution Executing 'Functions.ManualTrigger' (Reason='This function was programmatically called via the host APIs.', Id=", events[0]);
+            Assert.StartsWith("Info ManualTrigger Function started (Id=", events[1]);
+            Assert.StartsWith("Info ManualTrigger Function completed (Success, Id=", events[2]);
+            Assert.StartsWith("Info WebJobs.Execution Executed 'Functions.ManualTrigger' (Succeeded, Id=", events[3]);
 
             // make sure the user log wasn't traced
             Assert.False(_fixture.EventGenerator.Events.Any(p => p.Contains("ManualTrigger function invoked!")));
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             webHostSettings.SecretsPath = _secretsDirectory.Path;
             var mockEventManager = new Mock<IScriptEventManager>();
 
-            ScriptHostManager hostManager = new WebScriptHostManager(config, new TestSecretManagerFactory(secretManager), mockEventManager.Object,  _settingsManager, webHostSettings);
+            ScriptHostManager hostManager = new WebScriptHostManager(config, new TestSecretManagerFactory(secretManager), mockEventManager.Object, _settingsManager, webHostSettings);
 
             Task runTask = Task.Run(() => hostManager.RunAndBlock());
 
@@ -187,33 +187,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task OnTimeoutException_IgnoreToken_StopsManager()
-        {
-            var trace = new TestTraceWriter(TraceLevel.Info);
-
-            await RunTimeoutExceptionTest(trace, handleCancellation: false);
-
-            await TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running));
-            Assert.DoesNotContain(trace.Traces, t => t.Message.StartsWith("Done"));
-            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
-            Assert.Contains(trace.Traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
-        }
-
-        [Fact]
-        public async Task OnTimeoutException_UsesToken_ManagerKeepsRunning()
-        {
-            var trace = new TestTraceWriter(TraceLevel.Info);
-
-            await RunTimeoutExceptionTest(trace, handleCancellation: true);
-
-            // wait a few seconds to make sure the manager doesn't die
-            await Assert.ThrowsAsync<ApplicationException>(() => TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running), timeout: 3000));
-            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Done"));
-            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
-            Assert.DoesNotContain(trace.Traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
-        }
-
-        [Fact]
         public void AddRouteDataToRequest_DoesNotAddRequestProperty_WhenRouteDataNull()
         {
             var mockRouteData = new Mock<IHttpRouteData>(MockBehavior.Strict);
@@ -249,50 +222,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(result["p4"], null);
         }
 
-        private async Task RunTimeoutExceptionTest(TraceWriter trace, bool handleCancellation)
-        {
-            TimeSpan gracePeriod = TimeSpan.FromMilliseconds(5000);
-            _manager = await CreateAndStartWebScriptHostManager(trace);
-
-            string scenarioName = handleCancellation ? "useToken" : "ignoreToken";
-
-            var args = new Dictionary<string, object>
-            {
-                { "input", scenarioName }
-            };
-
-            await Assert.ThrowsAsync<FunctionTimeoutException>(() => _manager.Instance.CallAsync("TimeoutToken", args));
-        }
-
-        private async Task<WebScriptHostManager> CreateAndStartWebScriptHostManager(TraceWriter traceWriter)
-        {
-            var functions = new Collection<string> { "TimeoutToken" };
-
-            ScriptHostConfiguration config = new ScriptHostConfiguration()
-            {
-                RootScriptPath = $@"TestScripts\CSharp",
-                TraceWriter = traceWriter,
-                FileLoggingMode = FileLoggingMode.Always,
-                Functions = functions,
-                FunctionTimeout = TimeSpan.FromSeconds(3)
-            };
-
-            var mockEventManager = new Mock<IScriptEventManager>();
-            var manager = new WebScriptHostManager(config, new TestSecretManagerFactory(), mockEventManager.Object, _settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path });
-            Task task = Task.Run(() => { manager.RunAndBlock(); });
-            await TestHelpers.Await(() => manager.State == ScriptHostState.Running);
-
-            return manager;
-        }
-
         public void Dispose()
         {
-            if (_manager != null)
-            {
-                _manager.Stop();
-                _manager.Dispose();
-            }
-
             _secretsDirectory.Dispose();
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Moq;
+using WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Host
+{
+    public class WebScriptHostManagerTimeoutTests : IDisposable
+    {
+        private readonly TempDirectory _secretsDirectory = new TempDirectory();
+        private WebScriptHostManager _manager;
+
+        [Fact]
+        public async Task OnTimeoutException_IgnoreToken_StopsManager()
+        {
+            var trace = new TestTraceWriter(TraceLevel.Info);
+
+            await RunTimeoutExceptionTest(trace, handleCancellation: false);
+
+            await TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running));
+            Assert.DoesNotContain(trace.Traces, t => t.Message.StartsWith("Done"));
+            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
+            Assert.Contains(trace.Traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
+        }
+
+        [Fact]
+        public async Task OnTimeoutException_UsesToken_ManagerKeepsRunning()
+        {
+            var trace = new TestTraceWriter(TraceLevel.Info);
+
+            await RunTimeoutExceptionTest(trace, handleCancellation: true);
+
+            // wait a few seconds to make sure the manager doesn't die
+            await Assert.ThrowsAsync<ApplicationException>(() => TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running),
+                timeout: 3000, throwWhenDebugging: true));
+            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Done"));
+            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
+            Assert.DoesNotContain(trace.Traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
+        }
+
+        private async Task RunTimeoutExceptionTest(TraceWriter trace, bool handleCancellation)
+        {
+            TimeSpan gracePeriod = TimeSpan.FromMilliseconds(5000);
+            _manager = await CreateAndStartWebScriptHostManager(trace);
+
+            string scenarioName = handleCancellation ? "useToken" : "ignoreToken";
+
+            var args = new Dictionary<string, object>
+            {
+                { "input", scenarioName }
+            };
+
+            await Assert.ThrowsAsync<FunctionTimeoutException>(() => _manager.Instance.CallAsync("TimeoutToken", args));
+        }
+
+        private async Task<WebScriptHostManager> CreateAndStartWebScriptHostManager(TraceWriter traceWriter)
+        {
+            var functions = new Collection<string> { "TimeoutToken" };
+
+            ScriptHostConfiguration config = new ScriptHostConfiguration()
+            {
+                RootScriptPath = $@"TestScripts\CSharp",
+                TraceWriter = traceWriter,
+                FileLoggingMode = FileLoggingMode.Always,
+                Functions = functions,
+                FunctionTimeout = TimeSpan.FromSeconds(3)
+            };
+
+            var mockEventManager = new Mock<IScriptEventManager>();
+            var manager = new WebScriptHostManager(config, new TestSecretManagerFactory(), mockEventManager.Object, ScriptSettingsManager.Instance, new WebHostSettings { SecretsPath = _secretsDirectory.Path });
+            Task task = Task.Run(() => { manager.RunAndBlock(); });
+            await TestHelpers.Await(() => manager.State == ScriptHostState.Running);
+
+            return manager;
+        }
+
+        public void Dispose()
+        {
+            if (_manager != null)
+            {
+                _manager.Stop();
+                _manager.Dispose();
+            }
+
+            _secretsDirectory.Dispose();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/SamplesEndToEndRestartTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/SamplesEndToEndRestartTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    // Running these in their own class with private fixtures so they do not affect the timing of
+    // subsequent tests.
+    public class SamplesEndToEndRestartTests
+    {
+        [Fact(Skip = "Will not pass until https://github.com/Azure/azure-webjobs-sdk-script/issues/1537 is fixed")]
+        public async Task HttpTrigger_HostRestarts()
+        {
+            string uri = "api/httptrigger-csharp?name=brett";
+
+            bool stop = false;
+            bool failed = false;
+            HttpResponseMessage failedResponse = null;
+
+            // Use a private fixture to prevent timing restart issues with other tests
+            SamplesEndToEndTests.TestFixture fixture = new SamplesEndToEndTests.TestFixture();
+            string hostJsonPath = Path.Combine(fixture.HostSettings.ScriptPath, "host.json");
+            string originalHostJson = File.ReadAllText(hostJsonPath);
+            try
+            {
+                // setup just this function to keep things quicker
+                JObject hostJson = JObject.Parse(originalHostJson);
+                hostJson["functions"] = new JArray("HttpTrigger-CSharp");
+                File.WriteAllText(hostJsonPath, hostJson.ToString());
+
+                List<Task> requestTasks = new List<Task>();
+
+                for (int i = 0; i < 5; i++)
+                {
+                    requestTasks.Add(Task.Run(() =>
+                    {
+                        while (!failed && !stop)
+                        {
+                            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+                            request.Headers.Add("x-functions-key", "t8laajal0a1ajkgzoqlfv5gxr4ebhqozebw4qzdy");
+                            HttpResponseMessage response = fixture.HttpClient.SendAsync(request).Result;
+                            if (!response.IsSuccessStatusCode)
+                            {
+                                failed = true;
+                                failedResponse = response;
+                            }
+                        }
+                    }));
+                }
+
+                string functionJsonPath = Path.Combine(fixture.HostSettings.ScriptPath, "HttpTrigger-CSharp", "function.json");
+
+                // try for 2 minutes to force a host restart
+                for (int i = 0; i < 60 && !failed; i++)
+                {
+                    await Task.Delay(2000);
+                    File.SetLastWriteTimeUtc(functionJsonPath, DateTime.UtcNow);
+                }
+
+                stop = true;
+                await Task.WhenAll(requestTasks);
+
+                Assert.False(failed, $"Request failed. Response: {failedResponse?.StatusCode} {failedResponse?.Content.ReadAsStringAsync().Result}");
+            }
+            finally
+            {
+                File.WriteAllText(hostJsonPath, originalHostJson);
+                fixture.Dispose();
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -405,6 +405,7 @@
     <Compile Include="BashEndToEndTests.cs" />
     <Compile Include="BlobLeaseManagerTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Host\WebScriptHostManagerTimeoutTests.cs" />
     <Compile Include="NodeContentTests.cs" />
     <Compile Include="Controllers\ControllerScenarioTestFixture.cs" />
     <Compile Include="Controllers\Keys\DeleteHostFunctionKeysScenario.cs" />
@@ -430,6 +431,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="SamplesEndToEndRestartTests.cs" />
     <Compile Include="SamplesEndToEndTests.cs" />
     <Compile Include="Host\ScriptHostManagerTests.cs" />
     <Compile Include="Host\StandbyModeTests.cs" />

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -31,14 +31,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static async Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000)
+        public static async Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false)
         {
             DateTime start = DateTime.Now;
             while (!condition())
             {
                 await Task.Delay(pollingInterval);
 
-                if (!Debugger.IsAttached && (DateTime.Now - start).TotalMilliseconds > timeout)
+                bool shouldThrow = !Debugger.IsAttached || (Debugger.IsAttached && throwWhenDebugging);
+                if (shouldThrow && (DateTime.Now - start).TotalMilliseconds > timeout)
                 {
                     throw new ApplicationException("Condition not reached within timeout.");
                 }

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -682,6 +682,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void ApplyConfiguration_ClearsFunctionsFilter()
+        {
+            // A previous bug wouldn't properly clear the filter if you removed it.
+            JObject config = new JObject();
+            config["id"] = ID;
+
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            Assert.Null(scriptConfig.Functions);
+
+            config["functions"] = new JArray("Function1", "Function2");
+
+            ScriptHost.ApplyConfiguration(config, scriptConfig);
+            Assert.Equal(2, scriptConfig.Functions.Count);
+            Assert.Equal("Function1", scriptConfig.Functions.ElementAt(0));
+            Assert.Equal("Function2", scriptConfig.Functions.ElementAt(1));
+
+            config.Remove("functions");
+
+            ScriptHost.ApplyConfiguration(config, scriptConfig);
+
+            Assert.Null(scriptConfig.Functions);
+        }
+
+        [Fact]
         public void ApplyConfiguration_AppliesTimeout()
         {
             JObject config = new JObject();


### PR DESCRIPTION
By its nature, this test is flaky. I want to make sure it fails in AppVeyor before I issue a temporary fix.