### PR TITLE
Adding Admin host log endpoint (#1519)

### DIFF
--- a/src/WebJobs.Script.WebHost/Models/HostLogEntry.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostLogEntry.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    public class HostLogEntry
+    {
+        /// <summary>
+        /// Gets or sets the log level.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TraceLevel Level { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the function the log entry is for.
+        /// </summary>
+        public string FunctionName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source of the log entry.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the log message.
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -506,6 +506,7 @@
     <Compile Include="Models\ApiErrorModel.cs" />
     <Compile Include="Models\ApiModel.cs" />
     <Compile Include="Models\ApiModelUtility.cs" />
+    <Compile Include="Models\HostLogEntry.cs" />
     <Compile Include="Models\Swagger\HttpOperationInfo.cs" />
     <Compile Include="Models\Swagger\HttpOperationParameterInfo.cs" />
     <Compile Include="Models\Link.cs" />

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
 using System.Linq;
@@ -12,6 +13,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -346,6 +348,23 @@ namespace Microsoft.Azure.WebJobs.Script
         internal static bool IsNullable(Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+        internal static LogLevel ToLogLevel(TraceLevel traceLevel)
+        {
+            switch (traceLevel)
+            {
+                case TraceLevel.Verbose:
+                    return LogLevel.Trace;
+                case TraceLevel.Info:
+                    return LogLevel.Information;
+                case TraceLevel.Warning:
+                    return LogLevel.Warning;
+                case TraceLevel.Error:
+                    return LogLevel.Error;
+                default:
+                    return LogLevel.None;
+            }
         }
 
         private class FilteredExpandoObjectConverter : ExpandoObjectConverter


### PR DESCRIPTION
Adding a new `admin/host/log` endpoint that accepts authenticated JSON POST requests of the form:

```javascript
[
	{ level: "Error", source: "ScaleController", message: "Kaboom!"}, 
	{ level: "Warning", source: "ScaleController", message: "Something isn't right..." }
]
```

And writes the logs to host logs.