### PR TITLE
Fix for proper script invocation by path

### DIFF
--- a/src/WebJobs.Script/Description/PowerShell/PowerShellFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/PowerShell/PowerShellFunctionInvoker.cs
@@ -96,8 +96,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                         LogLoadedModules();
                     }
 
-                    _script = GetScript(_scriptFilePath);
-                    powerShellInstance.AddScript(_script, true);
+                    if (File.Exists(_scriptFilePath))
+                    {
+                        powerShellInstance.AddScript(_scriptFilePath, false);
+                    }
 
                     PSDataCollection<PSObject> outputCollection = new PSDataCollection<PSObject>();
                     outputCollection.DataAdded += (sender, e) => OutputCollectionDataAdded(sender, e, traceWriter);
@@ -248,17 +250,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             return stackTrace;
-        }
-
-        internal static string GetScript(string scriptFilePath)
-        {
-            string script = null;
-            if (File.Exists(scriptFilePath))
-            {
-                script = File.ReadAllText(scriptFilePath);
-            }
-
-            return script;
         }
 
         internal static List<string> GetModuleFilePaths(string rootScriptPath, string functionName)

--- a/src/WebJobs.Script/Description/PowerShell/PowerShellFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/PowerShell/PowerShellFunctionInvoker.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly Collection<FunctionBinding> _inputBindings;
         private readonly Collection<FunctionBinding> _outputBindings;
 
-        private string _script;
         private List<string> _moduleFiles;
 
         internal PowerShellFunctionInvoker(ScriptHost host, FunctionMetadata functionMetadata,

--- a/test/WebJobs.Script.Tests/Description/PowerShell/PowerShellInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/PowerShell/PowerShellInvokerTests.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public void GetScript()
-        {
-            string result = PowerShellFunctionInvoker.GetScript(_fixture.TestScriptPath);
-            Assert.Equal(_fixture.TestScriptContent, result.Trim(), StringComparer.OrdinalIgnoreCase);
-        }
-
-        [Fact]
         public void GetModuleFilePaths()
         {
             List<string> modulesPath = PowerShellFunctionInvoker.GetModuleFilePaths(_fixture.TestRootScriptPath, _fixture.TestFunctionName);


### PR DESCRIPTION
It is much better to invoke scripts by path than by extracting their contents. This allows for PowerShell to set $PSScriptRoot to the folder containing the script (very important for scripts that want to reference something in the local folder), $MyInvocation gets set up properly with access to the script path under $MyInvocation.Command.Path, etc.
It is also much better to invoke the script file without creating an unnecessary child scope. There is no point in introducing additional overhead where it is not required. That is why the second argument was replaced with false.