### PR TITLE
logging to ILogger on config error

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestScripts/OutOfRange/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/OutOfRange/host.json
@@ -1,0 +1,7 @@
+﻿{    
+    "logger": {
+        "aggregator": {            
+            "flushTimeout": "00:30:00"
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -973,6 +973,9 @@
     <None Include="TestScripts\Node\WebHookTrigger\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\OutOfRange\host.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\Php\BlobTriggerToBlob\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Should help address https://github.com/Azure/azure-webjobs-sdk/issues/1126 by making sure we're logging to both TraceWriter and (a default) ILogger if we have an error while building the configuration.