### PR TITLE
Removing F# from warmup path

### DIFF
--- a/src/WebJobs.Script.WebHost/Resources/Functions/Test-FSharp/function.json
+++ b/src/WebJobs.Script.WebHost/Resources/Functions/Test-FSharp/function.json
@@ -1,9 +1,0 @@
-﻿{
-    "bindings": [
-        {
-            "type": "manualTrigger",
-            "name": "input",
-            "direction": "in"
-        }
-    ]
-}

--- a/src/WebJobs.Script.WebHost/Resources/Functions/Test-FSharp/run.fsx
+++ b/src/WebJobs.Script.WebHost/Resources/Functions/Test-FSharp/run.fsx
@@ -1,4 +1,0 @@
-open System
-
-let Run(input: string, log: TraceWriter) =   
-    log.Info(sprintf "Input=%s" input)

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -470,7 +470,6 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Functions\Test-FSharp\run.fsx" />
     <EmbeddedResource Include="Home.html" />
     <Content Include="Web.config" />
   </ItemGroup>
@@ -591,7 +590,6 @@
     <EmbeddedResource Include="Resources\Functions\host.json" />
     <EmbeddedResource Include="Resources\Functions\Test-CSharp\function.json" />
     <EmbeddedResource Include="Resources\Functions\Test-CSharp\run.csx" />
-    <EmbeddedResource Include="Resources\Functions\Test-FSharp\function.json" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        public static void WarmUp(WebHostSettings settings, IScriptEventManager eventManager)
+        public static async Task WarmUp(WebHostSettings settings, IScriptEventManager eventManager)
         {
             var traceWriter = new FileTraceWriter(Path.Combine(settings.LogPath, "Host"), TraceLevel.Info);
             ScriptHost host = null;
@@ -265,14 +265,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 content = ReadResourceString("Functions.Test_CSharp.run.csx");
                 File.WriteAllText(Path.Combine(functionPath, "run.csx"), content);
 
-                // read in the F# function
-                functionPath = Path.Combine(rootPath, "Test-FSharp");
-                Directory.CreateDirectory(functionPath);
-                content = ReadResourceString("Functions.Test_FSharp.function.json");
-                File.WriteAllText(Path.Combine(functionPath, "function.json"), content);
-                content = ReadResourceString("Functions.Test_FSharp.run.fsx");
-                File.WriteAllText(Path.Combine(functionPath, "run.fsx"), content);
-
                 traceWriter.Info("Warm up functions deployed");
 
                 ScriptHostConfiguration config = new ScriptHostConfiguration
@@ -296,8 +288,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     { "input", "{}" }
                 };
                 host.CallAsync("Test-CSharp", arguments).Wait();
-                host.CallAsync("Test-FSharp", arguments).Wait();
                 host.Stop();
+
+                await NodeFunctionInvoker.InitializeAsync();
 
                 traceWriter.Info("Warm up succeeded");
             }

--- a/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Node/NodeFunctionInvoker.cs
@@ -705,7 +705,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         /// <summary>
         /// Performs required static initialization in the Edge context.
         /// </summary>
-        private static async Task InitializeAsync()
+        internal static async Task InitializeAsync()
         {
             var handle = (ScriptFunc)(err =>
             {

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -121,13 +122,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public void Warmup_Succeeds()
+        public async Task Warmup_Succeeds()
         {
             using (new TestEnvironment())
             {
                 var settings = GetWebHostSettings();
                 var eventManagerMock = new Mock<IScriptEventManager>();
-                WebScriptHostManager.WarmUp(settings, eventManagerMock.Object);
+                await WebScriptHostManager.WarmUp(settings, eventManagerMock.Object);
 
                 var hostLogPath = Path.Combine(settings.LogPath, @"host");
                 var hostLogFile = Directory.GetFiles(hostLogPath).First();
@@ -135,7 +136,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 Assert.Contains("Warm up started", content);
                 Assert.Contains("Executed 'Functions.Test-CSharp' (Succeeded, Id=", content);
-                Assert.Contains("Executed 'Functions.Test-FSharp' (Succeeded, Id=", content);
                 Assert.Contains("Warm up succeeded", content);
             }
         }


### PR DESCRIPTION
To optimize our warmup path, we'll remove F# for now. Relatively low usage, so we don't want to penalize the mainline case for this.