### PR TITLE
Updated WebJobs.Script nuspec dependencies

### DIFF
--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -14,24 +14,39 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Script Node.js</tags>
     <dependencies>
-      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10811" />
-      <dependency id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10811" />
-      <dependency id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10811" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.1.0-beta1-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.1.0-beta1-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10450" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.0.0-beta1-10450" />
       <dependency id="Edge.js" version="6.5.1" />
-      <dependency id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.0.0" />
-      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
       <dependency id="FSharp.Compiler.Service" version="9.0.1" />
       <dependency id="FSharp.Core" version="4.0.0.1" />
+      <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.3.0" />
+      <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.1.0-beta1-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.0.0-beta1-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.1.0-beta1-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10450" />
+      <dependency id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" />
+      <dependency id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" />
+      <dependency id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" />
+      <dependency id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.0.0" />
+      <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" />
+      <dependency id="Microsoft.Extensions.Logging" version="1.1.1" />
+      <dependency id="NuGet.Frameworks" version="3.4.3" />
+      <dependency id="NuGet.LibraryModel" version="3.4.3" />
+      <dependency id="SendGrid.SmtpApi" version="1.3.1" />
+      <dependency id="System.ComponentModel" version="4.3.0" />
+      <dependency id="System.Diagnostics.FileVersionInfo" version="4.3.0" />
+      <dependency id="System.Dynamic.Runtime" version="4.3.0" />
+      <dependency id="System.IO.Abstractions" version="2.0.0.140" />
       <dependency id="System.Reactive" version="3.1.1" />
+      <dependency id="System.Text.Encoding.CodePages" version="4.3.0" />
+      <dependency id="System.Threading.Tasks.Parallel" version="4.3.0" />
+      <dependency id="System.Threading.Thread" version="4.3.0" />
+      <dependency id="System.ValueTuple" version="4.3.0" />
+      <dependency id="System.Xml.XmlDocument" version="4.3.0" />
+      <dependency id="System.Xml.XPath.XDocument" version="4.3.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
resolves #1276 

ran `nuget pack .\WebJobs.Script.csproj -Version 1.0.0-beta2` to generate a nuget package, pulled dependencies from the package nuspec.