### PR TITLE
rename to bindingMetadatas to avoid confusion

### DIFF
--- a/src/WebJobs.Script/Binding/FunctionBinding.cs
+++ b/src/WebJobs.Script/Binding/FunctionBinding.cs
@@ -37,15 +37,15 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         public abstract Collection<CustomAttributeBuilder> GetCustomAttributes(Type parameterType);
 
-        internal static Collection<FunctionBinding> GetBindings(ScriptHostConfiguration config, IEnumerable<BindingMetadata> functions, FileAccess fileAccess)
+        internal static Collection<FunctionBinding> GetBindings(ScriptHostConfiguration config, IEnumerable<BindingMetadata> bindingMetadatas, FileAccess fileAccess)
         {
             Collection<FunctionBinding> bindings = new Collection<FunctionBinding>();
 
             if (bindings != null)
             {
-                foreach (var function in functions)
+                foreach (var bindingMetadata in bindingMetadatas)
                 {
-                    string type = function.Type.ToLowerInvariant();
+                    string type = bindingMetadata.Type.ToLowerInvariant();
                     switch (type)
                     {
                         case "http":
@@ -53,11 +53,11 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                             {
                                 throw new InvalidOperationException("Http binding can only be used for output.");
                             }
-                            bindings.Add(new HttpBinding(config, function, FileAccess.Write));
+                            bindings.Add(new HttpBinding(config, bindingMetadata, FileAccess.Write));
                             break;
                         default:
                             FunctionBinding binding = null;
-                            if (TryParseFunctionBinding(config, function.Raw, out binding))
+                            if (TryParseFunctionBinding(config, bindingMetadata.Raw, out binding))
                             {
                                 bindings.Add(binding);
                             }


### PR DESCRIPTION
`GetBindings()` is called per [function](https://github.com/watashiSHUN/azure-webjobs-sdk-script/blob/dev/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs#L44-L45):
```
Collection<FunctionBinding> inputBindings = FunctionBinding.GetBindings(Config, functionMetadata.InputBindings, FileAccess.Read);
Collection<FunctionBinding> outputBindings = FunctionBinding.GetBindings(Config, functionMetadata.OutputBindings, FileAccess.Write);
```

 the `<BindingMetaData>` refers to the `binding` Jarray in function.json

naming it to `functions` is confusing, especially **we do in fact iterate through actual functions**:

![capture](https://user-images.githubusercontent.com/6531400/28486385-2a16312e-6e36-11e7-82b6-c584574cf9c0.JPG)
