### PR TITLE
Use new JobHost.CallAsync(string) overload.

### DIFF
--- a/src/WebJobs.Script.Extensibility/WebJobs.Script.Extensibility.csproj
+++ b/src/WebJobs.Script.Extensibility/WebJobs.Script.Extensibility.csproj
@@ -43,10 +43,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Script.Extensibility/packages.config
+++ b/src/WebJobs.Script.Extensibility/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.1" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.1" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.1" targetFramework="net45" />

--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -104,7 +104,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1-10452\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -131,16 +131,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta1-10452\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -16,8 +16,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -26,9 +26,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10452" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -17,7 +17,7 @@
       <dependency id="Edge.js" version="6.5.1" />
       <dependency id="FSharp.Compiler.Service" version="9.0.1" />
       <dependency id="FSharp.Core" version="4.0.0.1" />
-      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" />
       <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.3.0" />
       <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10452" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -184,7 +184,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1-10453\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -214,19 +214,19 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta1-10452\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.79-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -42,8 +42,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1-10453" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -53,10 +53,10 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10452" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.79-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -246,13 +246,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public virtual async Task CallAsync(string method, Dictionary<string, object> arguments, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // TODO: Validate inputs
-            // TODO: Cache this lookup result
-            method = method.ToLowerInvariant();
-            Type type = ScriptConfig.HostConfig.TypeLocator.GetTypes().SingleOrDefault(p => p.Name == ScriptHost.GeneratedTypeName);
-            var methodInfo = type.GetMethods().SingleOrDefault(p => p.Name.ToLowerInvariant() == method);
-
-            await CallAsync(methodInfo, arguments, cancellationToken);
+            await base.CallAsync(method, arguments, cancellationToken);
         }
 
         protected virtual void Initialize()

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -94,7 +94,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1-10453\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -124,16 +124,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta1-10452\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -17,8 +17,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1-10453" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -28,9 +28,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10452" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -110,7 +110,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1-10453\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -140,19 +140,19 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta1-10452\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.79-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -26,8 +26,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1-10453" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -37,10 +37,10 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10452" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.79-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -123,7 +123,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1-10453\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -153,16 +153,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta1-10452\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10938\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-10947\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.79-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -27,8 +27,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10938" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10947" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1-10453" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta4-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -38,9 +38,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta1-10452" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10452" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10938" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-10947" targetFramework="net46" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.79-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />


### PR DESCRIPTION
This also lets script ignore the ITypeLocator to lookup method Infos.