### PR TITLE
Script functions' input binding not writing to file

### DIFF
--- a/src/WebJobs.Script/Description/ScriptFunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/ScriptFunctionInvokerBase.cs
@@ -79,6 +79,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                             Value = stream
                         };
                         await inputBinding.BindAsync(bindingContext);
+
+                        if (bindingContext.Value is string)
+                        {
+                            using (StreamWriter sw = new StreamWriter(stream))
+                            {
+                                await sw.WriteAsync((string)bindingContext.Value);
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Resolves #1718 

The input bindings of script functions, particularly Python functions, did not input anything to the function because the data from the binding wasn't getting written to the associated file.

This only adds a check for strings; might want to add a check for byte[] and Stream later.