### PR TITLE
Give error on deleted Function.json

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -71,6 +71,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     string shortName = Utility.GetFunctionShortName(item.FunctionName);
 
                     FunctionDescriptor descr = _funcLookup(shortName);
+                    if (descr == null)
+                    {
+                        // This exception will cause the function to not get executed.
+                        throw new InvalidOperationException($"Missing function.json for '{shortName}'.");
+                    }
                     FunctionLogger logInfo = descr.Invoker.LogInfo;
                     state = new FunctionInstanceMonitor(descr.Metadata, _metrics, item.FunctionInstanceId, logInfo);
 


### PR DESCRIPTION
For VS tooling case, give an error if user has a method in their code (with attributes), but deletes the generated Function.json.

See https://github.com/Azure/azure-webjobs-sdk-script/issues/1732