### PR TITLE
EasyAuth Support

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -453,6 +453,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Scaling", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Scaling.Tests", "test\WebJobs.Script.Scaling.Tests\WebJobs.Script.Scaling.Tests.csproj", "{8088DC08-4BB1-442D-8CD4-571FC9330D54}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger-CSharp-UserAuth", "HttpTrigger-CSharp-UserAuth", "{FCC5D488-9ACD-4400-8FC8-83F60A8B2C77}"
+	ProjectSection(SolutionItems) = preProject
+		sample\HttpTrigger-CSharp-UserAuth\function.json = sample\HttpTrigger-CSharp-UserAuth\function.json
+		sample\HttpTrigger-CSharp-UserAuth\run.csx = sample\HttpTrigger-CSharp-UserAuth\run.csx
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger-UserAuth", "HttpTrigger-UserAuth", "{D88F4A3F-65F5-4A08-A5E4-A9C6CA0ACCF9}"
+	ProjectSection(SolutionItems) = preProject
+		sample\HttpTrigger-UserAuth\function.json = sample\HttpTrigger-UserAuth\function.json
+		sample\HttpTrigger-UserAuth\index.js = sample\HttpTrigger-UserAuth\index.js
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35a2025d-f68a-4b57-83a2-ed4eb9c3894d}*SharedItemsImports = 4
@@ -579,5 +591,7 @@ Global
 		{62489417-341D-42AD-9E84-E97EB8236979} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{292A9038-5807-4095-B37F-9A77170D7402} = {16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}
 		{8088DC08-4BB1-442D-8CD4-571FC9330D54} = {FD93A1ED-5AC4-4F9B-9087-E1C24320F36E}
+		{FCC5D488-9ACD-4400-8FC8-83F60A8B2C77} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{D88F4A3F-65F5-4A08-A5E4-A9C6CA0ACCF9} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 	EndGlobalSection
 EndGlobal

--- a/sample/HttpTrigger-Batch/run.bat
+++ b/sample/HttpTrigger-Batch/run.bat
@@ -2,8 +2,10 @@ echo OFF
 
 echo Batch HTTP function invoked!
 
+echo Identity: (%IDENTITY_AUTHENTICATION_TYPE%, %IDENTITY_CLAIMS_AUTHLEVEL%, %IDENTITY_CLAIMS_KEYID%)
+
 IF DEFINED req_query_name (
-	echo Hello %req_query_name%! > %res%
+	echo Hello %REQ_QUERY_NAME%! > %res%
 ) ELSE (
 	echo Please pass a name on the query string > %res%
 )

--- a/sample/HttpTrigger-CSharp-UserAuth/function.json
+++ b/sample/HttpTrigger-CSharp-UserAuth/function.json
@@ -1,0 +1,16 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "authLevel": "user",
+            "methods": [ "get" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/HttpTrigger-CSharp-UserAuth/run.csx
+++ b/sample/HttpTrigger-CSharp-UserAuth/run.csx
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using System.Net;
+using System.Security.Claims;
+
+public static Task<HttpResponseMessage> Run(HttpRequestMessage req, ClaimsIdentity identity, TraceWriter log)
+{
+    log.Info(string.Format("C# HTTP trigger function processed a request. {0}", req.RequestUri));
+
+    string responseContent = null;
+    var userIdClaim = identity.FindFirst(ClaimTypes.NameIdentifier);
+    if (userIdClaim != null)
+    {
+        // user identity
+        var userNameClaim = identity.FindFirst(ClaimTypes.Name);
+        responseContent = $"Identity: ({identity.AuthenticationType}, {userNameClaim.Value}, {userIdClaim.Value})";
+    }
+    else
+    {
+        // key based identity
+        var authLevelClaim = identity.FindFirst("urn:functions:authLevel");
+        var keyIdClaim = identity.FindFirst("urn:functions:keyId");
+        responseContent = $"Identity: ({identity.AuthenticationType}, {authLevelClaim.Value}, {keyIdClaim.Value})";
+    }
+    
+    var res = new HttpResponseMessage(HttpStatusCode.OK)
+    {
+        Content = new StringContent(responseContent)
+    };
+    
+    return Task.FromResult(res);
+}

--- a/sample/HttpTrigger-CSharp/run.csx
+++ b/sample/HttpTrigger-CSharp/run.csx
@@ -1,12 +1,17 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
+using System.Security.Claims;
 
-public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
+public static Task<HttpResponseMessage> Run(HttpRequestMessage req, ClaimsIdentity identity, TraceWriter log)
 {
-    var queryParams = req.GetQueryNameValuePairs()
-        .ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
-
     log.Info(string.Format("C# HTTP trigger function processed a request. {0}", req.RequestUri));
 
+    var authLevelClaim = identity.FindFirst("urn:functions:authLevel");
+    var keyIdClaim = identity.FindFirst("urn:functions:keyId");
+    log.Info($"Identity: ({identity.AuthenticationType}, {authLevelClaim.Value}, {keyIdClaim.Value})");
+
+    var queryParams = req.GetQueryNameValuePairs()
+        .ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
     HttpResponseMessage res = null;
     if (queryParams.TryGetValue("name", out string name))
     {

--- a/sample/HttpTrigger-UserAuth/function.json
+++ b/sample/HttpTrigger-UserAuth/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "authLevel": "user",
+            "methods": [ "get" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/HttpTrigger-UserAuth/index.js
+++ b/sample/HttpTrigger-UserAuth/index.js
@@ -1,0 +1,29 @@
+﻿const util = require('util');
+
+const claimTypes = {
+    nameIdentifier: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier',
+    name: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'
+}
+
+module.exports = function (context, req) {
+    var body,
+        identity = context.identity,
+        userIdClaim = identity.claims[claimTypes.nameIdentifier];
+
+    if (userIdClaim) {
+        var userNameClaim = identity.claims[claimTypes.name];
+        body = util.format('Identity: (%s, %s, %s)', identity.authenticationType, userNameClaim.value, userIdClaim.value); 
+    }
+    else {
+        var authLevelClaim = identity.claims['urn:functions:authLevel'],
+            keyIdClaim = identity.claims['urn:functions:keyId'];
+        body = util.format('Identity: (%s, %s, %s)', identity.authenticationType, authLevelClaim.value, keyIdClaim.value);
+    }
+
+    var res = {
+        status: 200,
+        body: body
+    };
+
+    context.done(null, res);
+};

--- a/sample/WebHook-Generic-CSharp/run.csx
+++ b/sample/WebHook-Generic-CSharp/run.csx
@@ -2,9 +2,14 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Security.Claims;
 
-public static JObject Run(Payload payload, string action)
+public static JObject Run(Payload payload, string action, ClaimsIdentity identity, TraceWriter log)
 {
+    var authLevelClaim = identity.FindFirst("urn:functions:authLevel");
+    var keyIdClaim = identity.FindFirst("urn:functions:keyId");
+    log.Info($"Identity: ({identity.AuthenticationType}, {authLevelClaim.Value}, {keyIdClaim.Value})");
+
     JObject body = new JObject()
     {
         { "result", $"Value: {payload.Value} Action: {action}" }

--- a/schemas/json/function.json
+++ b/schemas/json/function.json
@@ -266,7 +266,7 @@
             "authLevel": {
               "type": "string",
               "default": "function",
-              "enum": [ "anonymous", "function", "admin" ],
+              "enum": [ "anonymous", "user", "function", "admin" ],
               "description": "The function HTTP authorization level."
             },
             "methods": {

--- a/src/WebJobs.Script.WebHost/App_Data/secrets/WebHook-Generic-CSharp.json
+++ b/src/WebJobs.Script.WebHost/App_Data/secrets/WebHook-Generic-CSharp.json
@@ -1,9 +1,14 @@
 ﻿{
-  "keys": [
-    {
-      "name": "default",
-      "value": "827bdzxhqy3xc62cxa2hmfsh6gxzhg30s5pi64tu",
-      "encrypted": false
-    }
-  ]
+    "keys": [
+        {
+            "name": "default",
+            "value": "827bdzxhqy3xc62cxa2hmfsh6gxzhg30s5pi64tu",
+            "encrypted": false
+        },
+        {
+            "name": "c1",
+            "value": "19023kkfmnvu37fk58fkkkc88282874jdmxwx2w5",
+            "encrypted": false
+        }
+    ]
 }

--- a/src/WebJobs.Script.WebHost/App_Data/secrets/httptrigger-csharp-userauth.json
+++ b/src/WebJobs.Script.WebHost/App_Data/secrets/httptrigger-csharp-userauth.json
@@ -1,0 +1,9 @@
+{
+    "keys": [
+        {
+            "name": "default",
+            "value": "09785444kkmmfjfue638i2id888425wrif85kd63jjkv",
+            "encrypted": false
+        }
+    ]
+}

--- a/src/WebJobs.Script.WebHost/App_Data/secrets/httptrigger-csharp.json
+++ b/src/WebJobs.Script.WebHost/App_Data/secrets/httptrigger-csharp.json
@@ -4,6 +4,11 @@
             "name": "default",
             "value": "9884kkdlkkdf83ksld8589kflss90sll5kjjsyfjskqv",
             "encrypted": false
+        },
+        {
+            "name": "secondary",
+            "value": "8883jkdjs661734orlls8990skkdiij62jqtg66wiwiwu",
+            "encrypted": false
         }
     ]
 }

--- a/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
-using System.Web;
 using System.Web.Http;
 using System.Web.Http.ExceptionHandling;
 using Autofac;
 using Autofac.Integration.WebApi;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Handlers;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -152,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private static void InitializeFileSystem(string scriptPath)
         {
-            if (ScriptSettingsManager.Instance.IsAzureEnvironment)
+            if (ScriptSettingsManager.Instance.IsAppServiceEnvironment)
             {
                 // When running on Azure, we kick this off on the background
                 Task.Run(() =>

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
@@ -35,10 +35,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             WebHostSettings settings = new WebHostSettings
             {
-                IsSelfHost = !settingsManager.IsAzureEnvironment
+                IsSelfHost = !settingsManager.IsAppServiceEnvironment
             };
 
-            if (settingsManager.IsAzureEnvironment)
+            if (settingsManager.IsAppServiceEnvironment)
             {
                 string home = settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath);
                 settings.ScriptPath = Path.Combine(home, @"site\wwwroot");

--- a/src/WebJobs.Script.WebHost/Filters/AuthorizationLevelAttribute.cs
+++ b/src/WebJobs.Script.WebHost/Filters/AuthorizationLevelAttribute.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Filters
                 var result = await GetAuthorizationResultAsync(request, secretManager, EvaluateKeyMatch, KeyName);
                 requestAuthorizationLevel = result.AuthorizationLevel;
                 request.SetAuthorizationLevel(result.AuthorizationLevel);
-                request.SetProperty(ScriptConstants.AzureFunctionsHttpRequestKeyNameKey, result.KeyName);
+                request.SetProperty(ScriptConstants.AzureFunctionsHttpRequestKeyIdKey, result.KeyId);
             }
 
             if (request.IsAuthDisabled() ||

--- a/src/WebJobs.Script.WebHost/Security/DefaultKeyValueConverterFactory.cs
+++ b/src/WebJobs.Script.WebHost/Security/DefaultKeyValueConverterFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _encryptionSupported = IsEncryptionSupported();
         }
 
-        private static bool IsEncryptionSupported() => _settingsManager.IsAzureEnvironment || _settingsManager.GetSetting(AzureWebsiteLocalEncryptionKey) != null;
+        private static bool IsEncryptionSupported() => _settingsManager.IsAppServiceEnvironment || _settingsManager.GetSetting(AzureWebsiteLocalEncryptionKey) != null;
 
         public IKeyValueReader GetValueReader(Key key)
         {

--- a/src/WebJobs.Script.WebHost/Security/KeyAuthorizationResult.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyAuthorizationResult.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
     {
         public KeyAuthorizationResult(string keyId, AuthorizationLevel level)
         {
-            KeyName = keyId;
+            KeyId = keyId;
             AuthorizationLevel = level;
         }
 
-        public string KeyName { get; }
+        public string KeyId { get; }
 
         public AuthorizationLevel AuthorizationLevel { get; }
     }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -189,7 +189,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10950\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>C:\code\Git\Azure\azure-webjobs-sdk-extensions\test\WebJobs.Extensions.Tests\bin\Debug\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-beta4-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
@@ -204,7 +204,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta1-10002\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Http.1.0.0-beta1-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
+      <HintPath>C:\code\Git\Azure\azure-webjobs-sdk-extensions\test\WebJobs.Extensions.Tests\bin\Debug\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.MobileApps, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.1.0-beta1-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>
@@ -586,6 +586,7 @@
     <Content Include="App_Data\secrets\httptrigger-customroute-get.json" />
     <Content Include="App_Data\secrets\httptrigger-customroute-post.json" />
     <Content Include="App_Data\secrets\httptrigger-csharp.json" />
+    <Content Include="App_Data\secrets\httptrigger-csharp-userauth.json" />
     <None Include="App_Data\secrets\HttpTrigger.json" />
     <Content Include="App_Data\secrets\webhook-azure-csharp.json" />
     <None Include="App_Data\secrets\WebHook-Generic-CSharp.json" />

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             set { _instance = value; }
         }
 
-        public virtual bool IsAzureEnvironment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId));
+        public virtual bool IsAppServiceEnvironment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId));
 
         public bool IsRemoteDebuggingEnabled => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.RemoteDebuggingPort));
 

--- a/src/WebJobs.Script/Description/DotNet/Compilation/DotNetCompilationServiceFactory.cs
+++ b/src/WebJobs.Script/Description/DotNet/Compilation/DotNetCompilationServiceFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     string releaseModeSetting = ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.CompilationReleaseMode);
                     bool releaseMode;
                     if (!bool.TryParse(releaseModeSetting, out releaseMode) &&
-                        ScriptSettingsManager.Instance.IsAzureEnvironment &&
+                        ScriptSettingsManager.Instance.IsAppServiceEnvironment &&
                         !ScriptSettingsManager.Instance.IsRemoteDebuggingEnabled)
                     {
                         // If the release mode setting is not set, we're running in Azure

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Security.Claims;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Binding;
@@ -106,6 +107,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             // Add ExecutionContext to provide access to InvocationId, etc.
             parameters.Add(new ParameterDescriptor(ScriptConstants.SystemExecutionContextParameterName, typeof(ExecutionContext)));
+
+            // Add ClaimsIdentity to provide access to identity
+            parameters.Add(new ParameterDescriptor(ScriptConstants.SystemClaimsIdentityParameterName, typeof(ClaimsIdentity)));
 
             parameters.Add(new ParameterDescriptor(ScriptConstants.SystemLoggerParameterName, typeof(ILogger)));
 

--- a/src/WebJobs.Script/Description/FunctionInvocationContext.cs
+++ b/src/WebJobs.Script/Description/FunctionInvocationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Claims;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
 
@@ -9,6 +10,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 {
     public class FunctionInvocationContext
     {
+        public ClaimsIdentity Identity { get; set; }
+
         public ExecutionContext ExecutionContext { get; set; }
 
         public Binder Binder { get; set; }

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -101,9 +102,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             TraceWriter functionTraceWriter = parameters.OfType<TraceWriter>().FirstOrDefault();
             Binder binder = parameters.OfType<Binder>().FirstOrDefault();
             ILogger logger = parameters.OfType<ILogger>().FirstOrDefault();
+            ClaimsIdentity identity = parameters.OfType<ClaimsIdentity>().FirstOrDefault();
 
             FunctionInvocationContext context = new FunctionInvocationContext
             {
+                Identity = identity,
                 ExecutionContext = functionExecutionContext,
                 Binder = binder,
                 TraceWriter = functionTraceWriter,

--- a/src/WebJobs.Script/Description/Node/Compilation/ConditionalJavaScriptCompilationService.cs
+++ b/src/WebJobs.Script/Description/Node/Compilation/ConditionalJavaScriptCompilationService.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private string GetSentinelFilePath(string functionName)
         {
             string home = null;
-            if (_settingsManager.IsAzureEnvironment)
+            if (_settingsManager.IsAppServiceEnvironment)
             {
                 home = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath);
             }

--- a/src/WebJobs.Script/Description/PowerShell/PowerShellFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/PowerShell/PowerShellFunctionInvoker.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             SetExecutionContextVariables(context.ExecutionContext, environmentVariables);
 
-            InitializeEnvironmentVariables(environmentVariables, functionInstanceOutputPath, input, _outputBindings, context.ExecutionContext);
+            InitializeEnvironmentVariables(environmentVariables, functionInstanceOutputPath, input, _outputBindings, context);
 
             var userTraceWriter = context.TraceWriter;
             PSDataCollection<ErrorRecord> errors = await InvokePowerShellScript(environmentVariables, userTraceWriter);

--- a/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             string functionInstanceOutputPath = Path.Combine(Path.GetTempPath(), "Functions", "Binding", invocationId);
 
             Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
-            InitializeEnvironmentVariables(environmentVariables, functionInstanceOutputPath, input, _outputBindings, context.ExecutionContext);
+            InitializeEnvironmentVariables(environmentVariables, functionInstanceOutputPath, input, _outputBindings, context);
 
             object convertedInput = ConvertInput(input);
             Utility.ApplyBindingData(convertedInput, context.Binder.BindingData);

--- a/src/WebJobs.Script/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestMessageExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsAntaresInternalRequest(this HttpRequestMessage request)
         {
-            if (!ScriptSettingsManager.Instance.IsAzureEnvironment)
+            if (!ScriptSettingsManager.Instance.IsAppServiceEnvironment)
             {
                 return false;
             }
@@ -61,10 +61,10 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         /// <param name="request">The request.</param>
         /// <param name="level">The level to check.</param>
-        /// <param name="keyName">Optional key name if key based auth is being used</param>
+        /// <param name="keyId">Optional key ID if key based auth is being used</param>
         /// <returns>True if the request is authorized at the specified level,
         /// false otherwise.</returns>
-        public static bool HasAuthorizationLevel(this HttpRequestMessage request, AuthorizationLevel level, string keyName = null)
+        public static bool HasAuthorizationLevel(this HttpRequestMessage request, AuthorizationLevel level, string keyId = null)
         {
             if (request.IsAuthDisabled())
             {
@@ -78,11 +78,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 return true;
             }
 
-            if (keyName != null)
+            if (keyId != null)
             {
                 // if a key name is specified, make sure we have a match
-                string requestKeyName = request.GetPropertyOrDefault<string>(ScriptConstants.AzureFunctionsHttpRequestKeyNameKey);
-                if (string.Compare(keyName, requestKeyName) != 0)
+                string requestKeyId = request.GetPropertyOrDefault<string>(ScriptConstants.AzureFunctionsHttpRequestKeyIdKey);
+                if (string.Compare(keyId, requestKeyId) != 0)
                 {
                     return false;
                 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureFunctionsWebHookContextKey = "MS_AzureFunctionsWebHookContext";
         public const string AzureFunctionsHttpResponseKey = "MS_AzureFunctionsHttpResponse";
         public const string AzureFunctionsHttpRequestAuthorizationLevelKey = "MS_AzureFunctionsAuthorizationLevel";
-        public const string AzureFunctionsHttpRequestKeyNameKey = "MS_AzureFunctionsKeyId";
+        public const string AzureFunctionsHttpRequestKeyIdKey = "MS_AzureFunctionsKeyId";
         public const string AzureFunctionsHttpRequestAuthorizationDisabledKey = "MS_AzureFunctionsAuthorizationDisabled";
         public const string AzureFunctionsHttpFunctionKey = "MS_AzureFunctionsHttpFunction";
         public const string AzureFunctionsRequestIdKey = "MS_AzureFunctionsRequestID";
@@ -21,6 +21,10 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string TracePropertyEventDetailsKey = "MS_EventDetails";
         public const string TracePropertyIsUserTraceKey = "MS_IsUserTrace";
         public const string TracePropertyIsSystemTraceKey = "MS_IsSystemTrace";
+
+        public const string AzureFunctionsKeyAuthenticationType = "key";
+        public const string AzureFunctionsAuthLevelClaimName = "urn:functions:authLevel";
+        public const string AzureFunctionsKeyIdClaimName = "urn:functions:keyId";
 
         public const string TraceSourceSecretManagement = "SecretManagement";
         public const string TraceSourceHostAdmin = "HostAdmin";
@@ -40,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script
         // with user parameters
         public const string SystemTriggerParameterName = "_triggerValue";
         public const string SystemExecutionContextParameterName = "_context";
+        public const string SystemClaimsIdentityParameterName = "_identity";
         public const string SystemLogParameterName = "_log";
         public const string SystemBinderParameterName = "_binder";
         public const string SystemReturnParameterBindingName = "$return";
@@ -52,6 +57,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string DefaultMasterKeyName = "master";
         public const string DefaultFunctionKeyName = "default";
 
+        public const string AntaresEasyAuthProviderHeaderName = "X-MS-CLIENT-PRINCIPAL-IDP";
+        public const string AntaresEasyAuthProviderIdHeaderName = "X-MS-CLIENT-PRINCIPAL-ID";
         public const string AntaresLogIdHeaderName = "X-ARR-LOG-ID";
         public const string CheckLoadQueryParameterName = "checkLoad";
         public const string DynamicSku = "Dynamic";

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostMasterKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostMasterKeyScenario.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Net.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Moq;
 using Xunit;
 

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -128,7 +128,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.1.0-beta1-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Http.1.0.0-beta1-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
+      <HintPath>C:\code\Git\Azure\azure-webjobs-sdk-extensions\test\WebJobs.Extensions.Tests\bin\Debug\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.MobileApps, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.MobileApps.1.1.0-beta1-10467\lib\net45\Microsoft.Azure.WebJobs.Extensions.MobileApps.dll</HintPath>

--- a/test/WebJobs.Script.Tests/Description/Node/NodeFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Node/NodeFunctionGenerationTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -187,10 +188,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             Assert.Equal("Test", method.Name);
             ParameterInfo[] parameters = method.GetParameters();
-            Assert.Equal(5, parameters.Length);
+            Assert.Equal(6, parameters.Length);
             Assert.Equal(typeof(Task), method.ReturnType);
 
-            // verify TextWriter parameter
+            // verify TraceWriter parameter
             ParameterInfo parameter = parameters[1];
             Assert.Equal("_log", parameter.Name);
             Assert.Equal(typeof(TraceWriter), parameter.ParameterType);
@@ -205,8 +206,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("_context", parameter.Name);
             Assert.Equal(typeof(ExecutionContext), parameter.ParameterType);
 
-            // verify ExecutionContext parameter
+            // verify ClaimsIdentity parameter
             parameter = parameters[4];
+            Assert.Equal("_identity", parameter.Name);
+            Assert.Equal(typeof(ClaimsIdentity), parameter.ParameterType);
+
+            // verify ILogger parameter
+            parameter = parameters[5];
             Assert.Equal("_logger", parameter.Name);
             Assert.Equal(typeof(ILogger), parameter.ParameterType);
         }

--- a/test/WebJobs.Script.Tests/Description/PowerShell/PowerShellFunctionGenerationTests.cs
+++ b/test/WebJobs.Script.Tests/Description/PowerShell/PowerShellFunctionGenerationTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -103,10 +104,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             Assert.Equal(FunctionName, method.Name);
             ParameterInfo[] parameters = method.GetParameters();
-            Assert.Equal(5, parameters.Length);
+            Assert.Equal(6, parameters.Length);
             Assert.Equal(typeof(Task), method.ReturnType);
 
-            // verify TextWriter parameter
+            // verify TraceWriter parameter
             ParameterInfo parameter = parameters[1];
             Assert.Equal("_log", parameter.Name);
             Assert.Equal(typeof(TraceWriter), parameter.ParameterType);
@@ -121,8 +122,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("_context", parameter.Name);
             Assert.Equal(typeof(ExecutionContext), parameter.ParameterType);
 
-            // verify ILogger parameter
+            // verify ClaimsIdentity parameter
             parameter = parameters[4];
+            Assert.Equal("_identity", parameter.Name);
+            Assert.Equal(typeof(ClaimsIdentity), parameter.ParameterType);
+
+            // verify ILogger parameter
+            parameter = parameters[5];
             Assert.Equal("_logger", parameter.Name);
             Assert.Equal(typeof(ILogger), parameter.ParameterType);
         }

--- a/test/WebJobs.Script.Tests/Filters/AuthorizationLevelAttributeTests.cs
+++ b/test/WebJobs.Script.Tests/Filters/AuthorizationLevelAttributeTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task GetAuthorizationLevel_ValidKeyHeader_MasterKey_ReturnsAdmin()
+        public async Task GetAuthorizationResult_ValidKeyHeader_MasterKey_ReturnsAdmin()
         {
             HttpRequestMessage request = new HttpRequestMessage();
             request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, TestMasterKeyValue);
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData(TestHostFunctionKeyValue1, TestFunctionKeyValue1)]
         [InlineData(TestHostFunctionKeyValue2, TestFunctionKeyValue2)]
-        public async Task GetAuthorizationLevel_ValidKeyHeader_FunctionKey_ReturnsFunction(string hostFunctionKeyValue, string functionKeyValue)
+        public async Task GetAuthorizationResult_ValidKeyHeader_FunctionKey_ReturnsFunction(string hostFunctionKeyValue, string functionKeyValue)
         {
             // first verify the host level function key works
             HttpRequestMessage request = new HttpRequestMessage();
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task GetAuthorizationLevel_InvalidKeyHeader_ReturnsAnonymous()
+        public async Task GetAuthorizationResult_InvalidKeyHeader_ReturnsAnonymous()
         {
             HttpRequestMessage request = new HttpRequestMessage();
             request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, "invalid");
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task GetAuthorizationLevel_ValidCodeQueryParam_MasterKey_ReturnsAdmin()
+        public async Task GetAuthorizationResult_ValidCodeQueryParam_MasterKey_ReturnsAdmin()
         {
             Uri uri = new Uri(string.Format("http://functions/api/foo?code={0}", TestMasterKeyValue));
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task GetAuthorizationLevel_ValidCodeQueryParam_SystemKey_ReturnsSystem()
+        public async Task GetAuthorizationResult_ValidCodeQueryParam_SystemKey_ReturnsSystem()
         {
             Uri uri = new Uri(string.Format("http://functions/api/foo?code={0}", TestSystemKeyValue1));
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData(TestHostFunctionKeyValue1, TestFunctionKeyValue1)]
         [InlineData(TestHostFunctionKeyValue2, TestFunctionKeyValue2)]
-        public async Task GetAuthorizationLevel_ValidCodeQueryParam_FunctionKey_ReturnsFunction(string hostFunctionKeyValue, string functionKeyValue)
+        public async Task GetAuthorizationResult_ValidCodeQueryParam_FunctionKey_ReturnsFunction(string hostFunctionKeyValue, string functionKeyValue)
         {
             // first try host level function key
             Uri uri = new Uri(string.Format("http://functions/api/foo?code={0}", hostFunctionKeyValue));
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task GetAuthorizationLevel_InvalidCodeQueryParam_ReturnsAnonymous()
+        public async Task GetAuthorizationResult_InvalidCodeQueryParam_ReturnsAnonymous()
         {
             Uri uri = new Uri(string.Format("http://functions/api/foo?code={0}", "invalid"));
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
             var functionErrors = new Dictionary<string, Collection<string>>();
             var metadata = ScriptHost.ReadFunctionMetadata(config, traceWriter, null, functionErrors);
-            Assert.Equal(51, metadata.Count);
+            Assert.Equal(53, metadata.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk-script/issues/33 and https://github.com/Azure/azure-webjobs-sdk-script/issues/926. PR for the supporting binding changes can be found here: https://github.com/Azure/azure-webjobs-sdk-extensions/pull/262.

With these changes, we allow users to specify a new "user" auth level value to indicate that a function requires an EasyAuth validated identity.

We also now expose KeyId information to user code via the same mechanism.

I'm still in the process of adding some more tests.