### PR TITLE
adding `cosmosDBTrigger` to the list of builtin providers

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             { "twilioSms", "Microsoft.Azure.WebJobs.Script.Binding.TwilioScriptBindingProvider" },
             { "notificationHub", "Microsoft.Azure.WebJobs.Script.Binding.NotificationHubScriptBindingProvider" },
+            { "cosmosDBTrigger", "Microsoft.Azure.WebJobs.Script.Binding.DocumentDBScriptBindingProvider" },
             { "documentDB", "Microsoft.Azure.WebJobs.Script.Binding.DocumentDBScriptBindingProvider" },
             { "mobileTable", "Microsoft.Azure.WebJobs.Script.Binding.MobileAppsScriptBindingProvider" },
             { "apiHubFileTrigger", "Microsoft.Azure.WebJobs.Script.Binding.ApiHubScriptBindingProvider" },

--- a/test/WebJobs.Script.Tests.Integration/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CSharpEndToEndTests.cs
@@ -45,12 +45,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task CosmosDBTriggerToBlobTest()
-        {
-            await CosmosDBTriggerToBlobTestImpl();
-        }
-
-        [Fact]
         public async Task TwilioReferenceInvokeSucceeds()
         {
             await TwilioReferenceInvokeSucceedsImpl(isDotNet: true);

--- a/test/WebJobs.Script.Tests.Integration/CosmosDBTrigger/CosmosDBTriggerCSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDBTrigger/CosmosDBTriggerCSharpEndToEndTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
+{
+    public class CosmosDBTriggerCSharpEndToEndTests :
+        CosmosDBTriggerEndToEndTestsBase<CosmosDBTriggerCSharpEndToEndTests.TestFixture>
+    {
+        public CosmosDBTriggerCSharpEndToEndTests(TestFixture fixture) : base(fixture)
+        {
+        }
+
+        public class TestFixture : CosmosDBTriggerTestFixture
+        {
+            private const string ScriptRoot = @"TestScripts\CSharp";
+
+            public TestFixture() : base(ScriptRoot, "csharp")
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/CosmosDBTrigger/CosmosDBTriggerEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDBTrigger/CosmosDBTriggerEndToEndTestsBase.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.WebJobs.Host;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
+{
+    public abstract class CosmosDBTriggerEndToEndTestsBase<TTestFixture> :
+        EndToEndTestsBase<TTestFixture> where TTestFixture : CosmosDBTriggerTestFixture, new()
+    {
+        public CosmosDBTriggerEndToEndTestsBase(TTestFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact]
+        public async Task CosmosDBTriggerToBlobTest()
+        {
+            // DocumentDB tests need the following environment vars:
+            // "AzureWebJobsDocumentDBConnectionString" -- the connection string to the account
+
+            // Waiting for the Processor to acquire leases
+            await Task.Delay(10000);
+
+            await Fixture.InitializeDocumentClient();
+            bool collectionsCreated = await Fixture.CreateDocumentCollections();
+            var resultBlob = Fixture.TestOutputContainer.GetBlockBlobReference("cosmosdbtriggere2e-completed");
+            await resultBlob.DeleteIfExistsAsync();
+
+            string id = Guid.NewGuid().ToString();
+
+            Document documentToTest = new Document()
+            {
+                Id = id
+            };
+
+            await Fixture.DocumentClient.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri("ItemDb", "ItemCollection"), documentToTest);
+
+            // wait for logs to flush
+            await Task.Delay(FileTraceWriter.LogFlushIntervalMs);
+
+            // now wait for function to be invoked
+            string result = await TestHelpers.WaitForBlobAndGetStringAsync(resultBlob);
+
+            if (collectionsCreated)
+            {
+                // cleanup collections
+                await Fixture.DeleteDocumentCollections();
+            }
+
+            Assert.Equal(TestHelpers.RemoveByteOrderMarkAndWhitespace(id), TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
+        }
+    }
+
+    public abstract class CosmosDBTriggerTestFixture : EndToEndTestFixture
+    {
+        protected CosmosDBTriggerTestFixture(string rootPath, string testId) : base(rootPath, testId)
+        {
+        }
+
+        public DocumentClient DocumentClient { get; private set; }
+
+        protected override void InitializeConfig(ScriptHostConfiguration config)
+        {
+            base.InitializeConfig(config);
+
+            config.OnConfigurationApplied = c =>
+                {
+                    // restrict these tests to only use this function
+                    c.Functions = new[] { "CosmosDBTrigger" };
+                };
+        }
+
+        public async Task InitializeDocumentClient()
+        {
+            if (DocumentClient == null)
+            {
+                var builder = new System.Data.Common.DbConnectionStringBuilder();
+                builder.ConnectionString = AmbientConnectionStringProvider.Instance.GetConnectionString("AzureWebJobsDocumentDBConnectionString");
+                var serviceUri = new Uri(builder["AccountEndpoint"].ToString());
+
+                DocumentClient = new DocumentClient(serviceUri, builder["AccountKey"].ToString());
+                await DocumentClient.OpenAsync();
+            }
+        }
+
+        public async Task<bool> CreateDocumentCollections()
+        {
+            bool willCreateCollection = false;
+            Database db = new Database() { Id = "ItemDb" };
+            await DocumentClient.CreateDatabaseIfNotExistsAsync(db);
+            Uri dbUri = UriFactory.CreateDatabaseUri(db.Id);
+
+            DocumentCollection collection = new DocumentCollection() { Id = "ItemCollection" };
+            willCreateCollection = !DocumentClient.CreateDocumentCollectionQuery(dbUri).Where(x => x.Id == collection.Id).ToList().Any();
+            await DocumentClient.CreateDocumentCollectionIfNotExistsAsync(dbUri, collection,
+                new RequestOptions()
+                {
+                    OfferThroughput = 400
+                });
+
+            Documents.DocumentCollection leasesCollection = new Documents.DocumentCollection() { Id = "leases" };
+            await DocumentClient.CreateDocumentCollectionIfNotExistsAsync(dbUri, leasesCollection,
+                new RequestOptions()
+                {
+                    OfferThroughput = 400
+                });
+
+            return willCreateCollection;
+        }
+
+        public async Task DeleteDocumentCollections()
+        {
+            Uri collectionsUri = UriFactory.CreateDocumentCollectionUri("ItemDb", "ItemCollection");
+            Uri leasesCollectionsUri = UriFactory.CreateDocumentCollectionUri("ItemDb", "leases");
+            await DocumentClient.DeleteDocumentCollectionAsync(collectionsUri);
+            await DocumentClient.DeleteDocumentCollectionAsync(leasesCollectionsUri);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            DocumentClient?.Dispose();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/CosmosDBTrigger/CosmosDBTriggerNodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDBTrigger/CosmosDBTriggerNodeEndToEndTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
+{
+    public class CosmosDBTriggerNodeEndToEndTests :
+        CosmosDBTriggerEndToEndTestsBase<CosmosDBTriggerNodeEndToEndTests.TestFixture>
+    {
+        public CosmosDBTriggerNodeEndToEndTests(TestFixture fixture) : base(fixture)
+        {
+        }
+
+        public class TestFixture : CosmosDBTriggerTestFixture
+        {
+            private const string ScriptRoot = @"TestScripts\Node";
+
+            public TestFixture() : base(ScriptRoot, "node")
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/EndToEndTestFixture.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Web.Http;
-using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -21,7 +19,6 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
-using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -88,8 +85,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public Microsoft.ServiceBus.Messaging.QueueClient ServiceBusQueueClient { get; private set; }
 
         public NamespaceManager NamespaceManager { get; private set; }
-
-        public DocumentClient DocumentClient { get; private set; }
 
         public CloudQueue TestQueue { get; private set; }
 
@@ -173,53 +168,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Host.Stop();
             Host.Dispose();
             ServiceBusQueueClient.Close();
-            DocumentClient?.Dispose();
-        }
-
-        public async Task InitializeDocumentClient()
-        {
-            if (DocumentClient == null)
-            {
-                var builder = new System.Data.Common.DbConnectionStringBuilder();
-                builder.ConnectionString = AmbientConnectionStringProvider.Instance.GetConnectionString("AzureWebJobsDocumentDBConnectionString");
-                var serviceUri = new Uri(builder["AccountEndpoint"].ToString());
-
-                DocumentClient = new DocumentClient(serviceUri, builder["AccountKey"].ToString());
-                await DocumentClient.OpenAsync();
-            }
-        }
-
-        public async Task<bool> CreateDocumentCollections()
-        {
-            bool willCreateCollection = false;
-            Documents.Database db = new Documents.Database() { Id = "ItemDb" };
-            await DocumentClient.CreateDatabaseIfNotExistsAsync(db);
-            Uri dbUri = UriFactory.CreateDatabaseUri(db.Id);
-
-            Documents.DocumentCollection collection = new Documents.DocumentCollection() { Id = "ItemCollection" };
-            willCreateCollection = !DocumentClient.CreateDocumentCollectionQuery(dbUri).Where(x => x.Id == collection.Id).ToList().Any();
-            await DocumentClient.CreateDocumentCollectionIfNotExistsAsync(dbUri, collection,
-                new RequestOptions()
-                {
-                    OfferThroughput = 400
-                });
-
-            Documents.DocumentCollection leasesCollection = new Documents.DocumentCollection() { Id = "leases" };
-            await DocumentClient.CreateDocumentCollectionIfNotExistsAsync(dbUri, leasesCollection,
-                new RequestOptions()
-                {
-                    OfferThroughput = 400
-                });
-
-            return willCreateCollection;
-        }
-
-        public async Task DeleteDocumentCollections()
-        {
-            Uri collectionsUri = UriFactory.CreateDocumentCollectionUri("ItemDb", "ItemCollection");
-            Uri leasesCollectionsUri = UriFactory.CreateDocumentCollectionUri("ItemDb", "leases");
-            await DocumentClient.DeleteDocumentCollectionAsync(collectionsUri);
-            await DocumentClient.DeleteDocumentCollectionAsync(leasesCollectionsUri);
         }
 
         public void DeleteEntities(CloudTable table, string partition = null)

--- a/test/WebJobs.Script.Tests.Integration/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EndToEndTestsBase.cs
@@ -289,43 +289,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(TestHelpers.RemoveByteOrderMarkAndWhitespace(id), TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
         }
 
-        protected async Task CosmosDBTriggerToBlobTestImpl()
-        {
-            // DocumentDB tests need the following environment vars:
-            // "AzureWebJobsDocumentDBConnectionString" -- the connection string to the account
-
-            // Waiting for the Processor to adquire leases
-            await Task.Delay(10000);
-
-            await Fixture.InitializeDocumentClient();
-            bool collectionsCreated = await Fixture.CreateDocumentCollections();
-            var resultBlob = Fixture.TestOutputContainer.GetBlockBlobReference("cosmosdbtriggere2e-completed");
-            await resultBlob.DeleteIfExistsAsync();
-
-            string id = Guid.NewGuid().ToString();
-
-            Document documentToTest = new Document()
-            {
-                Id = id
-            };
-
-            await Fixture.DocumentClient.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri("ItemDb", "ItemCollection"), documentToTest);
-
-            // wait for logs to flush
-            await Task.Delay(FileTraceWriter.LogFlushIntervalMs);
-
-            // now wait for function to be invoked
-            string result = await TestHelpers.WaitForBlobAndGetStringAsync(resultBlob);
-
-            if (collectionsCreated)
-            {
-                // cleanup collections
-                await Fixture.DeleteDocumentCollections();
-            }
-
-            Assert.Equal(TestHelpers.RemoveByteOrderMarkAndWhitespace(id), TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
-        }
-
         protected async Task NotificationHubTest(string functionName)
         {
             // NotificationHub tests need the following environment vars:

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -35,12 +35,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task CosmosDBTriggerToBlobTest()
-        {
-            await CosmosDBTriggerToBlobTestImpl();
-        }
-
-        [Fact]
         public async Task BlobTriggerToBlobTest()
         {
             TestHelpers.ClearFunctionLogs("BlobTriggerToBlob");

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -394,6 +394,9 @@
     <Compile Include="ApplicationInsights\ApplicationInsightsEndToEndTestsBase.cs" />
     <Compile Include="ApplicationInsights\ApplicationInsightsTestFixture.cs" />
     <Compile Include="ApplicationInsights\TelemetryPayload.cs" />
+    <Compile Include="CosmosDBTrigger\CosmosDBTriggerEndToEndTestsBase.cs" />
+    <Compile Include="CosmosDBTrigger\CosmosDBTriggerNodeEndToEndTests.cs" />
+    <Compile Include="CosmosDBTrigger\CosmosDBTriggerCSharpEndToEndTests.cs" />
     <Compile Include="DirectLoadEndToEndTests.cs" />
     <Compile Include="Controllers\ControllerDisabledAuthScenarioTestsFixture.cs" />
     <Compile Include="Controllers\Keys\DeleteFunctionKeysScenario.cs" />


### PR DESCRIPTION
Fixes #1776.

The first commit is before the fix -- to make sure the E2E tests fail as expected.
The second commit is the actual fix.