### PR TITLE
Fixing bug in method discovery

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/Compilation/Raw/RawAssemblyCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/Compilation/Raw/RawAssemblyCompilation.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 throw new InvalidOperationException($"The function type name '{typeName}' is invalid.");
             }
 
-            MethodInfo method = functionType.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
+            MethodInfo method = functionType.GetMethod(methodName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
             if (method == null)
             {
                 throw new InvalidOperationException($"The method '{methodName}' cannot be found.");


### PR DESCRIPTION
Function methods can be instance methods, but our existing code only supports static methods. I discovered this in some end to end tooling prototyping I was doing using the VS Functions tools. Instance methods are not currently discovered.