### PR TITLE
Port of hotfix from master.

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -471,6 +471,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 var functionMetadata = ReadFunctionMetadata(ScriptConfig, TraceWriter, _startupLogger, FunctionErrors, _settingsManager);
                 var usedBindingTypes = DiscoverBindingTypes(functionMetadata);
 
+                bool useLazyLoad = false; // todo - https://github.com/Azure/azure-webjobs-sdk-script/issues/1637
+                if (!useLazyLoad)
+                {
+                    usedBindingTypes = _builtinBindingTypes.Keys.Concat(_builtinScriptBindingTypes.Keys).ToArray();
+                }
+
                 var bindingProviders = LoadBindingProviders(ScriptConfig, hostConfigObject, TraceWriter, _startupLogger, usedBindingTypes);
                 ScriptConfig.BindingProviders = bindingProviders;
 


### PR DESCRIPTION
Need to disable lazy loading by default since it regresses the IBinder imperative binding scenario.

Reactivate https://github.com/Azure/azure-webjobs-sdk-script/issues/1637
Fix for: https://github.com/Azure/azure-webjobs-sdk/issues/1295