### PR TITLE
Allow launching the nodejs worker with inspector

### DIFF
--- a/src/WebJobs.Script/Dispatch/LanguageWorkerConfig.cs
+++ b/src/WebJobs.Script/Dispatch/LanguageWorkerConfig.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
     {
         public string ExecutablePath { get; set; }
 
+        public string Options { get; set; }
+
         public string WorkerPath { get; set; }
 
         public string Arguments { get; set; }
@@ -20,6 +22,6 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
 
         internal int Port { get; set; }
 
-        internal string ToArgumentString(string workerId, string requestId) => $"{WorkerPath} {Arguments} --host 127.0.0.1 --port {Port} --workerId {workerId} --requestId {requestId}";
+        internal string ToArgumentString(string workerId, string requestId) => $"{Options} {WorkerPath} {Arguments} --host 127.0.0.1 --port {Port} --workerId {workerId} --requestId {requestId}";
     }
 }

--- a/src/WebJobs.Script/Dispatch/NodeLanguageWorkerConfig.cs
+++ b/src/WebJobs.Script/Dispatch/NodeLanguageWorkerConfig.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script.Dispatch
@@ -11,6 +12,10 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
         public NodeLanguageWorkerConfig()
         {
             ExecutablePath = "node";
+            string value = ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebJobsEnvironment);
+            if (string.Compare("Development", value, StringComparison.OrdinalIgnoreCase) == 0) {
+                Options = "--inspect";
+            }
             WorkerPath = Environment.GetEnvironmentVariable("NodeJSWorkerPath");
             ScriptType = ScriptType.Javascript;
             Extension = ".js";

--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebsitePlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
         public const string AzureWebsiteHomePath = "HOME";
         public const string AzureWebJobsScriptRoot = "AzureWebJobsScriptRoot";
+        public const string AzureWebJobsEnvironment = "AzureWebJobsEnv";
         public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";
         public const string AzureWebJobsDisableHomepage = "AzureWebJobsDisableHomepage";
         public const string TypeScriptCompilerPath = "AzureWebJobs_TypeScriptPath";


### PR DESCRIPTION
To enable passing the `--inspector` flag to the nodejs worker, a support
was added to pass options to the worker executable.

After this commit, the nodejs inspector debugger is enabled when the
`AzureWebJobsEnv` is set to value `Development`.

This feature is useful when debugging the entire stack and allows stepping
through the code across programming language boundaries.