### PR TITLE
Updating to latest data protection helper package

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -234,8 +234,9 @@
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-11007\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.79-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebSites.DataProtection">
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -59,7 +59,7 @@
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta1-11007" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-11007" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-11007" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.79-alpha" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -157,8 +157,9 @@
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-11007\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.79-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebSites.DataProtection">
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -43,7 +43,7 @@
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta1-11007" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-11007" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-11007" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.79-alpha" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -162,8 +162,9 @@
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1-11007\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.79-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebSites.DataProtection">
+      <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -42,7 +42,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta1-10517" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta1-11007" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1-11007" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.79-alpha" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />


### PR DESCRIPTION
This brings the changes added by this PR: https://github.com/Azure/azure-websites-security/pull/6

This change unblocks warm standby scenarios where keys are injected during specialization.
