### PR TITLE
expose ILoggerFactoryBuilder to WebHostSettings; adding app insights http tests

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -108,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     _activeScriptHostConfig = CreateScriptHostConfiguration(settings);
 
-                    _activeHostManager = new WebScriptHostManager(_activeScriptHostConfig, _secretManagerFactory, _eventManager,  _settingsManager, settings);
+                    _activeHostManager = new WebScriptHostManager(_activeScriptHostConfig, _secretManagerFactory, _eventManager, _settingsManager, settings);
                     _activeReceiverManager = new WebHookReceiverManager(_activeHostManager.SecretManager);
 
                     _standbyHostManager?.Dispose();
@@ -142,7 +140,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 RootLogPath = settings.LogPath,
                 FileLoggingMode = FileLoggingMode.DebugOnly,
                 TraceWriter = settings.TraceWriter,
-                IsSelfHost = settings.IsSelfHost
+                IsSelfHost = settings.IsSelfHost,
+                LoggerFactoryBuilder = settings.LoggerFactoryBuilder
             };
 
             scriptHostConfig.HostConfig.HostId = Utility.GetDefaultHostId(_settingsManager, scriptHostConfig);

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostSettings.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public TraceWriter TraceWriter { get; set; }
 
+        public ILoggerFactoryBuilder LoggerFactoryBuilder { get; set; } = new DefaultLoggerFactoryBuilder();
+
         internal static WebHostSettings CreateDefault(ScriptSettingsManager settingsManager)
         {
             WebHostSettings settings = new WebHostSettings

--- a/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
+++ b/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script
             RootLogPath = Path.Combine(Path.GetTempPath(), "Functions");
             LogFilter = new LogCategoryFilter();
             RootExtensionsPath = ConfigurationManager.AppSettings[EnvironmentSettingNames.AzureWebJobsExtensionsPath];
+            LoggerFactoryBuilder = new DefaultLoggerFactoryBuilder();
         }
 
         /// <summary>
@@ -116,6 +117,12 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Insights client-side sampling. If null, client-side sampling is disabled.
         /// </summary>
         public SamplingPercentageEstimatorSettings ApplicationInsightsSamplingSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ILoggerFactoryBuilder"/> used to register <see cref="ILoggerProvider"/>s with
+        /// the host's <see cref="ILoggerFactory"/>.
+        /// </summary>
+        public ILoggerFactoryBuilder LoggerFactoryBuilder { get; set; }
 
         /// <summary>
         /// Gets or sets a test hook for modifying the configuration after host.json has been processed.

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -791,10 +791,7 @@ namespace Microsoft.Azure.WebJobs.Script
             scriptConfig.HostConfig.LoggerFactory.AddProvider(new FileLoggerProvider(traceWriteFactory,
                 (category, level) => (category == LogCategories.Function) && isFileLoggingEnabled()));
 
-            // Allow a way to plug in custom LoggerProviders.
-            ILoggerFactoryBuilder builder = scriptConfig.HostConfig.GetService<ILoggerFactoryBuilder>() ??
-                new DefaultLoggerFactoryBuilder();
-            builder.AddLoggerProviders(scriptConfig.HostConfig.LoggerFactory, scriptConfig, settingsManager);
+            scriptConfig.LoggerFactoryBuilder.AddLoggerProviders(scriptConfig.HostConfig.LoggerFactory, scriptConfig, settingsManager);
         }
 
         private void TraceFileChangeRestart(string changeType, string path, bool isShutdown)

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsCSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsCSharpEndToEndTests.cs
@@ -12,12 +12,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
         {
         }
 
-        [Fact]
-        public async Task ApplicationInsights_Succeeds()
-        {
-            await ApplicationInsights_SucceedsTest();
-        }
-
         public class TestFixture : ApplicationInsightsTestFixture
         {
             private const string ScriptRoot = @"TestScripts\CSharp";

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsNodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsNodeEndToEndTests.cs
@@ -1,21 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
-using Xunit;
-
 namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 {
     public class ApplicationInsightsNodeEndToEndTests : ApplicationInsightsEndToEndTestsBase<ApplicationInsightsNodeEndToEndTests.TestFixture>
     {
         public ApplicationInsightsNodeEndToEndTests(TestFixture fixture) : base(fixture)
         {
-        }
-
-        [Fact]
-        public async Task ApplicationInsights_Succeeds()
-        {
-            await ApplicationInsights_SucceedsTest();
         }
 
         public class TestFixture : ApplicationInsightsTestFixture

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -1,40 +1,130 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Web.Http;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 {
-    public abstract class ApplicationInsightsTestFixture : EndToEndTestFixture
+    public abstract class ApplicationInsightsTestFixture
     {
-        static ApplicationInsightsTestFixture()
-        {
-            // We need to set this to something in order to trigger App Insights integration. But since
-            // we're hitting a local HttpListener, it can be anything.
-            ScriptSettingsManager.Instance.ApplicationInsightsInstrumentationKey = TestChannelLoggerFactoryBuilder.ApplicationInsightsKey;
-        }
+        private readonly ScriptSettingsManager _settingsManager;
+        private readonly HttpConfiguration _config = new HttpConfiguration();
 
         public ApplicationInsightsTestFixture(string scriptRoot, string testId)
-            : base(scriptRoot, testId)
         {
+            _settingsManager = ScriptSettingsManager.Instance;
+
+            HostSettings = new WebHostSettings
+            {
+                IsSelfHost = true,
+                ScriptPath = Path.Combine(Environment.CurrentDirectory, scriptRoot),
+                LogPath = Path.Combine(Path.GetTempPath(), @"Functions"),
+                SecretsPath = Environment.CurrentDirectory, // not used
+                LoggerFactoryBuilder = new TestLoggerFactoryBuilder(Channel),
+                IsAuthDisabled = true
+            };
+            WebApiConfig.Register(_config, _settingsManager, HostSettings);
+
+            var resolver = _config.DependencyResolver;
+            var hostConfig = resolver.GetService<WebHostResolver>().GetScriptHostConfiguration(HostSettings);
+
+            _settingsManager.ApplicationInsightsInstrumentationKey = TestChannelLoggerFactoryBuilder.ApplicationInsightsKey;
+
+            InitializeConfig(hostConfig);
+
+            var httpServer = new HttpServer(_config);
+            HttpClient = new HttpClient(httpServer)
+            {
+                BaseAddress = new Uri("https://localhost/")
+            };
+
+            TestHelpers.WaitForWebHost(HttpClient);
         }
 
         public TestTelemetryChannel Channel { get; private set; } = new TestTelemetryChannel();
 
-        protected override void InitializeConfig(ScriptHostConfiguration config)
+        public WebHostSettings HostSettings { get; private set; }
+
+        public HttpClient HttpClient { get; private set; }
+
+        protected void InitializeConfig(ScriptHostConfiguration config)
         {
-            var builder = new TestChannelLoggerFactoryBuilder(Channel);
-            config.HostConfig.AddService<ILoggerFactoryBuilder>(builder);
-
-            // turn this off as it makes validation tough
-            config.HostConfig.Aggregator.IsEnabled = false;
-
             config.OnConfigurationApplied = c =>
             {
-                // Overwrite the generated function whitelist to only include one function.
-                c.Functions = new[] { "Scenarios" };
+                // turn this off as it makes validation tough
+                config.HostConfig.Aggregator.IsEnabled = false;
+
+                // Overwrite the generated function whitelist to only include two functions.
+                c.Functions = new[] { "Scenarios", "HttpTrigger-Scenarios" };
             };
+        }
+
+        private class TestLoggerFactoryBuilder : DefaultLoggerFactoryBuilder
+        {
+            private readonly TestTelemetryChannel _channel;
+
+            public TestLoggerFactoryBuilder(TestTelemetryChannel channel)
+            {
+                _channel = channel;
+            }
+
+            public override void AddLoggerProviders(ILoggerFactory factory, ScriptHostConfiguration scriptConfig, ScriptSettingsManager settingsManager)
+            {
+                // Replace TelemetryClient
+                var clientFactory = new TestTelemetryClientFactory(scriptConfig.LogFilter.Filter, _channel);
+                scriptConfig.HostConfig.AddService<ITelemetryClientFactory>(clientFactory);
+
+                base.AddLoggerProviders(factory, scriptConfig, settingsManager);
+            }
+        }
+
+        public class TestTelemetryChannel : ITelemetryChannel
+        {
+            public IList<ITelemetry> Telemetries { get; private set; } = new List<ITelemetry>();
+
+            public bool? DeveloperMode { get; set; }
+
+            public string EndpointAddress { get; set; }
+
+            public void Dispose()
+            {
+            }
+
+            public void Flush()
+            {
+            }
+
+            public void Send(ITelemetry item)
+            {
+                Telemetries.Add(item);
+            }
+        }
+
+        private class TestTelemetryClientFactory : ScriptTelemetryClientFactory
+        {
+            private TestTelemetryChannel _channel;
+
+            public TestTelemetryClientFactory(Func<string, LogLevel, bool> filter, TestTelemetryChannel channel)
+                : base(TestChannelLoggerFactoryBuilder.ApplicationInsightsKey, new SamplingPercentageEstimatorSettings(), filter)
+            {
+                _channel = channel;
+            }
+
+            protected override ITelemetryChannel CreateTelemetryChannel()
+            {
+                return _channel;
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using Autofac;
@@ -39,10 +38,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
             WebApiConfig.Register(_config, _settingsManager, HostSettings, RegisterDependencies);
 
             HttpServer = new HttpServer(_config);
-            this.HttpClient = new HttpClient(HttpServer);
-            this.HttpClient.BaseAddress = new Uri("https://localhost/");
+            HttpClient = new HttpClient(HttpServer);
+            HttpClient.BaseAddress = new Uri("https://localhost/");
 
-            WaitForHost();
+            TestHelpers.WaitForWebHost(HttpClient);
         }
 
         public WebHostSettings HostSettings { get; private set; }
@@ -50,25 +49,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
         public HttpClient HttpClient { get; set; }
 
         public HttpServer HttpServer { get; set; }
-
-        private void WaitForHost()
-        {
-            TestHelpers.Await(() =>
-            {
-                return IsHostRunning();
-            }).Wait();
-        }
-
-        private bool IsHostRunning()
-        {
-            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty))
-            {
-                using (HttpResponseMessage response = this.HttpClient.SendAsync(request).Result)
-                {
-                    return response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.OK;
-                }
-            }
-        }
 
         protected virtual void RegisterDependencies(ContainerBuilder builder, WebHostSettings settings)
         {

--- a/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
@@ -1186,8 +1186,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 WebApiConfig.Register(_config, _settingsManager, HostSettings);
 
                 HttpServer = new HttpServer(_config);
-                this.HttpClient = new HttpClient(HttpServer);
-                this.HttpClient.BaseAddress = new Uri("https://localhost/");
+                HttpClient = new HttpClient(HttpServer);
+                HttpClient.BaseAddress = new Uri("https://localhost/");
 
                 string connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString("Storage");
                 CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
@@ -1211,7 +1211,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.ServiceBus);
                 NamespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
 
-                WaitForHost();
+                TestHelpers.WaitForWebHost(HttpClient);
             }
 
             public WebHostSettings HostSettings { get; private set; }
@@ -1227,25 +1227,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             public HttpClient HttpClient { get; set; }
 
             public HttpServer HttpServer { get; set; }
-
-            private void WaitForHost()
-            {
-                TestHelpers.Await(() =>
-                {
-                    return IsHostRunning();
-                }).Wait();
-            }
-
-            private bool IsHostRunning()
-            {
-                using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty))
-                {
-                    using (HttpResponseMessage response = this.HttpClient.SendAsync(request).Result)
-                    {
-                        return response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.OK;
-                    }
-                }
-            }
 
             public void Dispose()
             {

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTrigger-Scenarios/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTrigger-Scenarios/function.json
@@ -1,0 +1,16 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "post" ],
+            "authLevel": "anonymous"
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTrigger-Scenarios/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTrigger-Scenarios/run.csx
@@ -1,0 +1,32 @@
+﻿#r "Newtonsoft.Json"
+
+using System;
+using System.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, ExecutionContext context, ILogger logger)
+{
+    string bodyJson = await req.Content.ReadAsStringAsync();
+    JObject body = JObject.Parse(bodyJson);
+    string scenario = body["scenario"].ToString();
+    string value = body["value"].ToString();
+
+    string logPayload = JObject.FromObject(new { invocationId = context.InvocationId, trace = value }).ToString(Formatting.None);
+
+    switch (scenario)
+    {
+        case "appInsights-Success":
+            logger.LogInformation(logPayload);
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(context.InvocationId.ToString()) };
+        case "appInsights-Failure":
+            logger.LogInformation(logPayload);
+            return new HttpResponseMessage(HttpStatusCode.Conflict) { Content = new StringContent(context.InvocationId.ToString()) };
+        case "appInsights-Throw":
+            logger.LogInformation(logPayload);
+            throw new InvalidOperationException(context.InvocationId.ToString());
+        default:
+            throw new InvalidOperationException();
+            break;
+    }    
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/Scenarios/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/Scenarios/run.csx
@@ -23,8 +23,8 @@ public static void Run(ScenarioInput input, out string blob, TraceWriter trace, 
     {
         var logPayload = new
         {
-            InvocationId = context.InvocationId,
-            Trace = input.Value
+            invocationId = context.InvocationId,
+            trace = input.Value
         };
 
         logger.LogInformation(JObject.FromObject(logPayload).ToString(Formatting.None));

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
@@ -2,7 +2,7 @@
 
 module.exports = function (context, req) {
     var scenario = (req.headers && req.headers.scenario) || req.body.scenario;
-    
+
     switch (scenario) {
         case "echo":
             context.res = req.body.value;
@@ -20,7 +20,7 @@ module.exports = function (context, req) {
                     'Content-Type': req.body.contenttype
                 },
                 isRaw: true
-            }
+            };
             break;
 
         case "rawresponsenocontenttype":
@@ -28,7 +28,7 @@ module.exports = function (context, req) {
                 status: 200,
                 body: req.body.value,
                 isRaw: true
-            }
+            };
             break;
 
         case "content":
@@ -49,6 +49,28 @@ module.exports = function (context, req) {
             context.res = { status: 204, body: null, headers: { 'content-type': 'application/json' } };
             break;
 
+        case "appInsights-Success":
+            logAppInsightsPayload(context, req.body.value);
+            context.res = {
+                status: 200,
+                body: context.invocationId,
+                isRaw: true
+            };
+            break;
+
+        case "appInsights-Failure":
+            logAppInsightsPayload(context, req.body.value);
+            context.res = {
+                status: 409,
+                body: context.invocationId,
+                isRaw: true
+            };
+            break;
+
+        case "appInsights-Throw":
+            logAppInsightsPayload(context, req.body.value);
+            throw new Error(context.invocationId);
+
         default:
             context.res = {
                 status: 400
@@ -57,4 +79,13 @@ module.exports = function (context, req) {
     }
 
     context.done();
+};
+
+function logAppInsightsPayload(context, functionTrace) {
+    var logPayload = {
+        invocationId: context.invocationId,
+        trace: functionTrace
+    };
+
+    context.log(logPayload);
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
@@ -55,8 +55,7 @@ var assert = require('assert');
         }
 
         // verify all binding data properties are camel cased
-        for (var key in context.bindingData)
-        {
+        for (var key in context.bindingData) {
             assert(isLowerCase(key[0]), "Expected lower case: " + key);
         }
 
@@ -88,11 +87,11 @@ var assert = require('assert');
     else if (scenario === 'appInsights') {
 
         var logPayload = {
-            InvocationId: context.executionContext.invocationId,
-            Trace: input.value
+            invocationId: context.executionContext.invocationId,
+            trace: input.value
         };
 
-        context.log(JSON.stringify(logPayload));
+        context.log(logPayload);
         context.log.metric("TestMetric", 1234, {
             count: 50,
             min: 10.4,
@@ -105,7 +104,7 @@ var assert = require('assert');
         // throw if the scenario didn't match
         throw new Error(util.format("The scenario '%s' did not match any known scenario.", scenario));
     }
-}
+};
 
 function isLowerCase(c) {
     return c.toLowerCase() === c;

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -603,6 +603,12 @@
     <None Include="TestScripts\CSharp\FunctionExecutionContext\function.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestScripts\CSharp\HttpTrigger-Scenarios\function.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestScripts\CSharp\HttpTrigger-Scenarios\run.csx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestScripts\CSharp\FunctionExecutionContext\run.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
@@ -133,11 +133,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(2, completionEvents.Count);
             int invocation1Duration = (int.Parse(completionEvents[1].Groups["duration"].Value) / 100) * 100;
-            int invocation2Duration = (int.Parse(completionEvents[0].Groups["duration"].Value) / 100) * 100;
+
+            int invocation2RawDuration = int.Parse(completionEvents[0].Groups["duration"].Value); // save this for better output below.
+            int invocation2Duration = (invocation2RawDuration / 100) * 100;
 
             Assert.NotEqual(invocation1Duration, invocation2Duration);
             Assert.Equal(2000, invocation1Duration);
-            Assert.Equal(500, invocation2Duration);
+
+            Assert.True(invocation2Duration == 500, $"Expected 500. Actual: {invocation2Duration}. Raw value: {invocation2RawDuration}");
         }
 
         [Fact]
@@ -190,10 +193,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 FunctionInstanceLogEntry item = new FunctionInstanceLogEntry
                 {
-                     FunctionInstanceId = context.ExecutionContext.InvocationId,
-                     StartTime = DateTime.UtcNow,
-                     FunctionName = this.Metadata.Name,
-                     Properties = new Dictionary<string, object>()
+                    FunctionInstanceId = context.ExecutionContext.InvocationId,
+                    StartTime = DateTime.UtcNow,
+                    FunctionName = this.Metadata.Name,
+                    Properties = new Dictionary<string, object>()
                 };
                 await _fastLogger.AddAsync(item);
 

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
 
             TestLoggerProvider provider = new TestLoggerProvider();
-            scriptConfig.HostConfig.AddService<ILoggerFactoryBuilder>(new TestLoggerFactoryBuilder(provider));
+            scriptConfig.LoggerFactoryBuilder = new TestLoggerFactoryBuilder(provider);
 
             var environment = new Mock<IScriptHostEnvironment>();
             var eventManager = new Mock<IScriptEventManager>();
@@ -1019,7 +1019,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RootScriptPath = rootPath
             };
 
-            config.HostConfig.AddService<ILoggerFactoryBuilder>(loggerFactoryHookMock.Object);
+            config.LoggerFactoryBuilder = loggerFactoryHookMock.Object;
 
             config.HostConfig.HostId = ID;
             var environment = new Mock<IScriptHostEnvironment>();
@@ -1060,7 +1060,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RootScriptPath = rootPath
             };
 
-            config.HostConfig.AddService<ILoggerFactoryBuilder>(loggerFactoryHookMock.Object);
+            config.LoggerFactoryBuilder = loggerFactoryHookMock.Object;
 
             config.HostConfig.HostId = ID;
             var environment = new Mock<IScriptHostEnvironment>();
@@ -1141,8 +1141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var channel = new TestTelemetryChannel();
             var builder = new TestChannelLoggerFactoryBuilder(channel);
 
-            config.HostConfig.AddService<ILoggerFactoryBuilder>(builder);
-
+            config.LoggerFactoryBuilder = builder;
             config.HostConfig.LoggerFactory = new LoggerFactory();
 
             var settingsManager = ScriptSettingsManager.Instance;


### PR DESCRIPTION
This changes how we get the `ILoggerFactoryBuilder`. It now allows you to pass one into the `WebHostSettings`, which should allow the CLI to properly write ILogger logs to the console. That work is tracked with https://github.com/Azure/azure-functions-cli/issues/130. This doesn't fix it, but opens things up for a fix.

It also allows for full HTTP tests that log directly to a mock App Insights channel for easy validation. I've added some comprehensive tests for a few core scenarios to make sure they continue working as we approach GA.