### PR TITLE
Change calls to Assembly.GetName() to use AssemblyNameCache

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DirectSharedAssemblyProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/DirectSharedAssemblyProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
@@ -17,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public bool TryResolveAssembly(string assemblyName, out Assembly assembly)
         {
-            if (string.Compare(_assembly.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Compare(AssemblyNameCache.GetName(_assembly).Name, assemblyName, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 assembly = _assembly;
                 return true;

--- a/src/WebJobs.Script/Description/DotNet/ExtensionSharedAssemblyProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/ExtensionSharedAssemblyProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
@@ -45,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             assembly = null;
             Assembly providerAssembly = bindingProvider.GetType().Assembly;
 
-            if (string.Compare(assemblyName, providerAssembly.GetName().Name) == 0)
+            if (string.Compare(assemblyName, AssemblyNameCache.GetName(providerAssembly).Name) == 0)
             {
                 assembly = providerAssembly;
             }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.WebJobs.Script
             matchedAssembly = null;
 
             var candidateAssembly = type.Assembly;
-            if (string.Compare(assemblyName, candidateAssembly.GetName().Name, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Compare(assemblyName, AssemblyNameCache.GetName(candidateAssembly).Name, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 matchedAssembly = candidateAssembly;
                 return true;


### PR DESCRIPTION
Resolves #1745 