### PR TITLE
Enabling TransferRequestHandler for all request 

### DIFF
--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -43,7 +43,7 @@
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
       <remove name="OPTIONSVerbHandler" />
       <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*" verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
     <validation validateIntegratedModeConfiguration="false" />
     <security>


### PR DESCRIPTION
(This will include static content - The reason we do this is to enable us to have routes with period in them. i.e. with extensions)

Look at the issue #969

Essentially, Functions currently does not allow paths to have a period in them. for instance /index.html, etc etc. Proxies does allow users to have such paths. With Proxies merging with function this creates a problem. To enable such paths, we need to ensure that the manage module are executed for such path. There are a couple of way of enabling this as mentioned in the issue.

The change made here is a way of ensuring that TransferRequestHandler is invoked for all requests