### PR TITLE
Add supports to load java_opts while starting jvm and resolve path issue

### DIFF
--- a/src/WebJobs.Script.Grpc/Abstractions/JavaLanguageWorkerConfig.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/JavaLanguageWorkerConfig.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
         public JavaLanguageWorkerConfig()
         {
             var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME") ?? string.Empty;
-            var javaPath = Path.Combine(javaHome, @"bin\java");
+            var javaPath = Path.Combine(javaHome, @"bin", @"java");
             ExecutablePath = Path.GetFullPath(javaPath);
             var workerJar = Environment.GetEnvironmentVariable("AzureWebJobsJavaWorkerPath");
             if (string.IsNullOrEmpty(workerJar))
@@ -20,7 +20,9 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
                 workerJar = Path.Combine(Location, @"workers\java\azure-functions-java-worker.jar");
             }
 
-            WorkerPath = $"-jar {workerJar}";
+            // Load the JVM starting parameters to support attach to debugging.
+            var javaOpts = Environment.GetEnvironmentVariable("JAVA_OPTS") ?? string.Empty;
+            WorkerPath = $"-jar {javaOpts} {workerJar}";
             Extension = ".jar";
         }
     }

--- a/src/WebJobs.Script.WebHost/Properties/launchSettings.json
+++ b/src/WebJobs.Script.WebHost/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:44347/"
+      "applicationUrl": "http://localhost:44347/"
     }
   }
 }


### PR DESCRIPTION
This commit includes:
1. Supports to load JAVA_OPTS while starting JVM, this can make attach to debugging much simpler.
2. "\" is not supported as x-platform feature for Path.Combine.
3. Use "http" instead of "https" while using dotnet run to start Kestrel.