### PR TITLE
Fixing duplicate compilation logs (#1866)

### DIFF
--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -138,9 +138,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
         }
 
-        protected void TraceOnPrimaryHost(string message, TraceLevel level, string source = null,  Exception exception = null)
+        protected internal void TraceOnPrimaryHost(string message, TraceLevel level, string source = null,  Exception exception = null)
         {
-            TraceWriter.Trace(message, level, PrimaryHostTraceProperties);
             var traceEvent = new TraceEvent(level, message, source, exception);
             foreach (var item in PrimaryHostTraceProperties)
             {

--- a/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
@@ -50,6 +50,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void TraceOnPrimaryHost_WritesExpectedLogs()
+        {
+            _traceWriter.Traces.Clear();
+
+            _invoker.TraceOnPrimaryHost("Test message", TraceLevel.Info, "TestSource");
+
+            Assert.Equal(1, _traceWriter.Traces.Count);
+            var trace = _traceWriter.Traces[0];
+            Assert.Equal("Test message", trace.Message);
+            Assert.Equal(TraceLevel.Info, trace.Level);
+            Assert.Equal("TestSource", trace.Source);
+        }
+
+        [Fact]
         public void LogInvocationMetrics_EmitsExpectedEvents()
         {
             var metrics = new TestMetricsLogger();


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/1866. This duplicate was added by commit https://github.com/Azure/azure-webjobs-sdk-script/commit/173f0af1fde02e6817e9f7d035d3338a57a313e0#diff-5068ee687748ecb1d19219ddd4287b90. Not sure why that additional log was added.