### PR TITLE
Setting ScriptHostManager state before ScriptHost disposal

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -174,6 +174,9 @@ namespace Microsoft.Azure.WebJobs.Script
                         _stopEvent
                     });
 
+                    // Immediately set the state to Default, which causes CanInvoke() to return false.
+                    State = ScriptHostState.Default;
+
                     // Orphan the current host instance. We're stopping it, so it won't listen for any new functions
                     // it will finish any currently executing functions and then clean itself up.
                     // Spin around and create a new host instance.


### PR DESCRIPTION
Fixes #1690.

See my [comment here](https://github.com/Azure/azure-webjobs-sdk-script/issues/1690#issuecomment-327630737) for how I've been testing this. I added back in the LoggerFactory disposal, and before the fix, that test had hundreds of errors when run for 10k requests. Now, I see zero.