### PR TITLE
dispose ILoggerFactory in ScriptHost

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/CosmosDBTrigger/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/CosmosDBTrigger/function.json
@@ -5,7 +5,8 @@
         "name": "input",
         "direction": "in",
         "databaseName": "ItemDb",
-        "collectionName": "ItemCollection"
+        "collectionName": "ItemCollection",
+        "createLeaseCollectionIfNotExists": true
       },
       {
         "type": "blob",


### PR DESCRIPTION
The race fixed with #1876 means that we should be able to dispose of the ILoggerFactory again. This is useful because it disposes of everything being used by the TelemetryClient and also flushes any outstanding telemetry.

Taking a different approach this time -- since the ScriptHost is creating the LoggerFactory, it should be responsible for disposing it. Previously, I was disposing it in the JobHostContext in the SDK repo.

My testing (explained in #1690) leads me to believe that the race is fixed, but it's tough to prove 100%. I'll be monitoring the next rollout to make sure that I don't see any of these ObjectDisposedExceptions getting thrown.