### PR TITLE
Suppress host restart for hostingstart.html

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1619,6 +1619,16 @@ namespace Microsoft.Azure.WebJobs.Script
                  string.Compare(fileName, ScriptConstants.ProxyMetadataFileName, StringComparison.OrdinalIgnoreCase) == 0) ||
                 !_directorySnapshot.SequenceEqual(Directory.EnumerateDirectories(ScriptConfig.RootScriptPath)))
             {
+                // CRI ICM: 46695121
+                // Do not allow the host to restart if this notification is for the hostingstart.html file in the root
+                if (string.Compare(directory, "hostingstart.html", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    string hostingWarning = string.Format(CultureInfo.InvariantCulture, "Unexpected file change event detected for '{0}' which evaluated to a host restart. Suppressing restart.", e.FullPath);
+                    TraceWriter.Warning(hostingWarning);
+                    Logger?.LogWarning(hostingWarning);
+                    return;
+                }
+
                 bool shutdown = false;
                 string fileExtension = Path.GetExtension(fileName);
                 if (!string.IsNullOrEmpty(fileExtension) && ScriptConstants.AssemblyFileTypes.Contains(fileExtension, StringComparer.OrdinalIgnoreCase))


### PR DESCRIPTION
This should mitigate an obscure issue that is impacting a small number of apps where the host gets stuck in a restart loop that somehow relates to file change events happening for hostingstart.html