### PR TITLE
Added process registry based on platform

### DIFF
--- a/src/WebJobs.Script/Dispatch/EmptyProcessRegistry.cs
+++ b/src/WebJobs.Script/Dispatch/EmptyProcessRegistry.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Dispatch
+{
+    internal class EmptyProcessRegistry : IProcessRegistry
+    {
+        public bool Register(Process process) => true;
+    }
+}

--- a/src/WebJobs.Script/Dispatch/IProcessRegistry.cs
+++ b/src/WebJobs.Script/Dispatch/IProcessRegistry.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Dispatch
+{
+    internal interface IProcessRegistry
+    {
+        bool Register(Process process);
+    }
+}

--- a/src/WebJobs.Script/Dispatch/JobObjectRegistry.cs
+++ b/src/WebJobs.Script/Dispatch/JobObjectRegistry.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Azure.WebJobs.Script.Dispatch
+{
+    public class JobObjectRegistry : IDisposable, IProcessRegistry
+    {
+        private IntPtr _handle;
+        private bool _disposed = false;
+
+        public JobObjectRegistry()
+        {
+            _handle = CreateJobObject(IntPtr.Zero, null);
+
+            var info = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+            {
+                LimitFlags = 0x2000
+            };
+
+            var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = info
+            };
+
+            int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            IntPtr extendedInfoPtr = Marshal.AllocHGlobal(length);
+            Marshal.StructureToPtr(extendedInfo, extendedInfoPtr, false);
+
+            if (!SetInformationJobObject(_handle, JobObjectInfoType.ExtendedLimitInformation, extendedInfoPtr, (uint)length))
+                throw new Exception(string.Format("Unable to set information.  Error: {0}", Marshal.GetLastWin32Error()));
+        }
+
+        public bool Register(Process proc)
+        {
+            return AssignProcessToJobObject(_handle, proc.Handle);
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        static extern IntPtr CreateJobObject(object a, string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool CloseHandle(IntPtr job);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing) { }
+
+            Close();
+            _disposed = true;
+        }
+
+        public void Close()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                CloseHandle(_handle);
+            }
+            _handle = IntPtr.Zero;
+        }
+    }
+
+    #region Helper classes
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct IO_COUNTERS
+    {
+        public UInt64 ReadOperationCount;
+        public UInt64 WriteOperationCount;
+        public UInt64 OtherOperationCount;
+        public UInt64 ReadTransferCount;
+        public UInt64 WriteTransferCount;
+        public UInt64 OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public Int64 PerProcessUserTimeLimit;
+        public Int64 PerJobUserTimeLimit;
+        public UInt32 LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public UInt32 ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public UInt32 PriorityClass;
+        public UInt32 SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SECURITY_ATTRIBUTES
+    {
+        public UInt32 nLength;
+        public IntPtr lpSecurityDescriptor;
+        public Int32 bInheritHandle;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    public enum JobObjectInfoType
+    {
+        AssociateCompletionPortInformation = 7,
+        BasicLimitInformation = 2,
+        BasicUIRestrictions = 4,
+        EndOfJobTimeInformation = 6,
+        ExtendedLimitInformation = 9,
+        SecurityLimitInformation = 5,
+        GroupInformation = 11
+    }
+
+    #endregion
+}

--- a/src/WebJobs.Script/Dispatch/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Dispatch/LanguageWorkerChannel.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
         private readonly ScriptHostConfiguration _scriptConfig;
         private readonly IScriptEventManager _eventManager;
         private readonly IWorkerProcessFactory _processFactory;
+        private readonly IProcessRegistry _processRegistry;
         private readonly IObservable<FunctionRegistrationContext> _functionRegistrations;
         private readonly WorkerConfig _workerConfig;
         private readonly Uri _serverUri;
@@ -54,6 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
             ScriptHostConfiguration scriptConfig,
             IScriptEventManager eventManager,
             IWorkerProcessFactory processFactory,
+            IProcessRegistry processRegistry,
             IObservable<FunctionRegistrationContext> functionRegistrations,
             WorkerConfig workerConfig,
             Uri serverUri,
@@ -64,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
             _scriptConfig = scriptConfig;
             _eventManager = eventManager;
             _processFactory = processFactory;
+            _processRegistry = processRegistry;
             _functionRegistrations = functionRegistrations;
             _workerConfig = workerConfig;
             _serverUri = serverUri;
@@ -239,6 +242,8 @@ namespace Microsoft.Azure.WebJobs.Script.Dispatch
 
         internal void WorkerReady(RpcEvent initEvent)
         {
+            _processRegistry?.Register(_process);
+
             var initMessage = initEvent.Message.WorkerInitResponse;
             if (initMessage.Result.IsFailure(out Exception exc))
             {

--- a/src/WebJobs.Script/Dispatch/ProcessRegistryFactory.cs
+++ b/src/WebJobs.Script/Dispatch/ProcessRegistryFactory.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Azure.WebJobs.Script.Config;
+
+namespace Microsoft.Azure.WebJobs.Script.Dispatch
+{
+    internal class ProcessRegistryFactory
+    {
+        static internal IProcessRegistry Create()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                && !ScriptSettingsManager.Instance.IsAzureEnvironment)
+            {
+                return new JobObjectRegistry();
+            }
+            else
+            {
+                return new EmptyProcessRegistry();
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Configuration;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
@@ -17,12 +15,14 @@ using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.AppService.Proxy.Client.Contract;
 using Microsoft.Azure.WebJobs.Extensions;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Abstractions.Rpc;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -31,14 +31,12 @@ using Microsoft.Azure.WebJobs.Script.Dispatch;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Eventing.File;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.IO;
+using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Microsoft.Azure.AppService.Proxy.Client.Contract;
-using Microsoft.Azure.WebJobs.Script.Abstractions.Rpc;
-using Microsoft.Azure.WebJobs.Script.Grpc;
-using Microsoft.Azure.WebJobs.Script.Models;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -69,6 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private ProxyClientExecutor _proxyClient;
         private IFunctionDispatcher _functionDispatcher;
         private ILoggerFactory _loggerFactory;
+        private IProcessRegistry _processRegistry = new EmptyProcessRegistry();
 
         // Specify the "builtin binding types". These are types that are directly accesible without needing an explicit load gesture.
         // This is the set of bindings we shipped prior to binding extensibility.
@@ -471,9 +470,26 @@ namespace Microsoft.Azure.WebJobs.Script
                 server.Start();
                 var processFactory = new DefaultWorkerProcessFactory();
 
+                try
+                {
+                    _processRegistry = ProcessRegistryFactory.Create();
+                }
+                catch (Exception e)
+                {
+                    _startupLogger.LogWarning(e, "Unable to create process registry");
+                }
+
                 CreateChannel channelFactory = (config, registrations) =>
                 {
-                    return new LanguageWorkerChannel(ScriptConfig, EventManager, processFactory, registrations, config, server.Uri, hostConfig.LoggerFactory);
+                    return new LanguageWorkerChannel(
+                        ScriptConfig,
+                        EventManager,
+                        processFactory,
+                        _processRegistry,
+                        registrations,
+                        config,
+                        server.Uri,
+                        hostConfig.LoggerFactory);
                 };
 
                 _functionDispatcher = new FunctionDispatcher(EventManager, server, channelFactory, TraceWriter, new List<WorkerConfig>()
@@ -1981,6 +1997,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 _debugModeFileWatcher?.Dispose();
                 _blobLeaseManager?.Dispose();
                 _functionDispatcher?.Dispose();
+                (_processRegistry as IDisposable)?.Dispose();
 
                 foreach (var function in Functions)
                 {


### PR DESCRIPTION
Currently uses JobObjects on Windows in order to kill child process trees.

OSX and Linux appear to be better at cleaning up child processes, but this interface should allow child process management implementations for those languages.