### PR TITLE
Do not send any content if root is pinged by scale controller

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 {
                     // if the request is to the root and we can't find any matching FunctionDescriptors which might have been setup by proxies
                     // then homepage logic will be applied.
-                    return IsHomepageDisabled
+                    return (IsHomepageDisabled || request.IsAntaresInternalRequest())
                         ? new HttpResponseMessage(HttpStatusCode.NoContent)
                         : new HttpResponseMessage(HttpStatusCode.OK)
                         {

--- a/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
@@ -211,6 +211,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task Home_Get_InAzureEnvironment_AsInternalRequest_ReturnsNoContent()
+        {
+            // Pings to the site root should not return the homepage content if they are internal requests.
+            // This test sets a website instance Id which means that we'll go down the IsAzureEnvironment = true codepath
+            // but the sent request does NOT include an X-ARR-LOG-ID header. This indicates the request was internal.
+
+            using (new TestScopedSettings(_settingsManager, EnvironmentSettingNames.AzureWebsiteInstanceId, "123"))
+            {
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty);
+
+                HttpResponseMessage response = await this._fixture.HttpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            }
+        }
+
+        [Fact]
         public async Task HttpTrigger_CSharp_Poco_Post_Succeeds()
         {
             string uri = "api/httptrigger-csharp-poco?code=zlnu496ve212kk1p84ncrtdvmtpembduqp25ajjc";


### PR DESCRIPTION
Verified manually using fiddler and a private site extension. Also verified by checking data usage after deploying private site extension. The clear drop in the graph is when I deployed the update:

![image](https://user-images.githubusercontent.com/10663/30890152-fa65104c-a2df-11e7-96fd-79a048cb2a7d.png)
