### PR TITLE
Update maxUrlLength and allow url double escaping for Functions

### DIFF
--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -35,7 +35,7 @@
           <clear />
         </namespaces>
       </pages>
-      <httpRuntime targetFramework="4.5" maxRequestLength="102400" />
+      <httpRuntime targetFramework="4.5" maxRequestLength="102400" maxUrlLength="4096" requestPathInvalidCharacters="" />
     </system.web>
   </location>
   <system.webServer>
@@ -47,7 +47,7 @@
     </handlers>
     <validation validateIntegratedModeConfiguration="false" />
     <security>
-      <requestFiltering>
+      <requestFiltering allowDoubleEscaping="true">
         <requestLimits maxAllowedContentLength="104857600" />
       </requestFiltering>
     </security>


### PR DESCRIPTION
Update maxUrlLength and allow url double escaping for Functions and Proxies.

Per customers' asks