### PR TITLE
Apply default source only when not specified

### DIFF
--- a/src/WebJobs.Script/Extensions/TraceWriterExtensions.cs
+++ b/src/WebJobs.Script/Extensions/TraceWriterExtensions.cs
@@ -36,7 +36,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return new InterceptingTraceWriter(traceWriter, interceptor);
         }
 
-        public static TraceWriter WithSource(this TraceWriter traceWriter, string source) => new InterceptingTraceWriter(traceWriter, t => t.Source = source);
+        /// <summary>
+        /// Apply the specified default source value to all trace events
+        /// when the source is not specified.
+        /// </summary>
+        public static TraceWriter WithSource(this TraceWriter traceWriter, string source) => new InterceptingTraceWriter(traceWriter, t => t.Source = string.IsNullOrEmpty(t.Source) ? source : t.Source);
 
         public static void Verbose(this TraceWriter traceWriter, string message, IDictionary<string, object> properties)
         {

--- a/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/SamplesEndToEndTests.cs
@@ -1015,6 +1015,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task HostLog_AdminLevel_Succeeds()
         {
+            TestHelpers.ClearHostLogs();
+
             var request = new HttpRequestMessage(HttpMethod.Post, "admin/host/log");
             request.Headers.Add(AuthorizationLevelAttribute.FunctionsKeyHeaderName, MasterKey);
             var logs = new HostLogEntry[]

--- a/test/WebJobs.Script.Tests/Diagnostics/TraceWriterExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/TraceWriterExtensionsTests.cs
@@ -13,6 +13,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class TraceWriterExtensionsTests
     {
         [Fact]
+        public void WithSource_AppliesDefaultSource()
+        {
+            TestTraceWriter testTraceWriter = new TestTraceWriter(TraceLevel.Verbose);
+            var wrappedTraceWriter = testTraceWriter.WithSource("TestDefault");
+
+            wrappedTraceWriter.Info("Test1");
+            wrappedTraceWriter.Info("Test2", "CustomSource");
+            wrappedTraceWriter.Info("Test3", string.Empty);
+
+            Assert.Equal(3, testTraceWriter.Traces.Count);
+
+            Assert.Equal("Test1", testTraceWriter.Traces[0].Message);
+            Assert.Equal("TestDefault", testTraceWriter.Traces[0].Source);
+
+            Assert.Equal("Test2", testTraceWriter.Traces[1].Message);
+            Assert.Equal("CustomSource", testTraceWriter.Traces[1].Source);
+
+            Assert.Equal("Test3", testTraceWriter.Traces[2].Message);
+            Assert.Equal("TestDefault", testTraceWriter.Traces[2].Source);
+        }
+
+        [Fact]
         public void Apply_CreatesInterceptingTraceWriter()
         {
             TestTraceWriter traceWriter = new TestTraceWriter(TraceLevel.Verbose);


### PR DESCRIPTION
@tohling noticed that logs written to the /host/log endpoint weren't honoring the Source that was sent in the events. This is because the AdminController uses "WithSource" on its TraceWriter. "WithSource" should really only be defaulting the Source when not set already.