### PR TITLE
Proxy names should follow the same naming restrictions as functions

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -922,7 +922,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         continue;
                     }
 
-                    ValidateFunctionName(functionName);
+                    ValidateName(functionName);
 
                     string json = File.ReadAllText(functionConfigPath);
                     JObject functionConfig = JObject.Parse(json);
@@ -999,27 +999,38 @@ namespace Microsoft.Azure.WebJobs.Script
 
             foreach (var route in routes.Routes)
             {
-                var proxyMetadata = new FunctionMetadata();
-
-                var json = new JObject
+                try
                 {
-                    { "authLevel", "anonymous" },
-                    { "name", "req" },
-                    { "type", "httptrigger" },
-                    { "direction", "in" },
-                    { "Route", route.UrlTemplate.TrimStart('/') },
-                    { "Methods",  new JArray(route.Methods.Select(m => m.Method.ToString()).ToArray()) }
-                };
+                    // Proxy names should follow the same naming restrictions as in function names.
+                    ValidateName(route.Name, true);
 
-                BindingMetadata bindingMetadata = BindingMetadata.Create(json);
+                    var proxyMetadata = new FunctionMetadata();
 
-                proxyMetadata.Bindings.Add(bindingMetadata);
+                    var json = new JObject
+                    {
+                        { "authLevel", "anonymous" },
+                        { "name", "req" },
+                        { "type", "httptrigger" },
+                        { "direction", "in" },
+                        { "Route", route.UrlTemplate.TrimStart('/') },
+                        { "Methods",  new JArray(route.Methods.Select(m => m.Method.ToString()).ToArray()) }
+                    };
 
-                proxyMetadata.Name = route.Name;
-                proxyMetadata.ScriptType = ScriptType.Unknown;
-                proxyMetadata.IsProxy = true;
+                    BindingMetadata bindingMetadata = BindingMetadata.Create(json);
 
-                proxies.Add(proxyMetadata);
+                    proxyMetadata.Bindings.Add(bindingMetadata);
+
+                    proxyMetadata.Name = route.Name;
+                    proxyMetadata.ScriptType = ScriptType.Unknown;
+                    proxyMetadata.IsProxy = true;
+
+                    proxies.Add(proxyMetadata);
+                }
+                catch (Exception ex)
+                {
+                    // log any unhandled exceptions and continue
+                    AddFunctionError(FunctionErrors, route.Name, Utility.FlattenException(ex, includeSource: false), isFunctionShortName: true);
+                }
             }
 
             return proxies;
@@ -1087,11 +1098,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return httpTrigger.Methods.Intersect(otherHttpTrigger.Methods).Any();
         }
 
-        internal static void ValidateFunctionName(string functionName)
+        internal static void ValidateName(string name, bool isProxy = false)
         {
-            if (!FunctionNameValidationRegex.IsMatch(functionName))
+            if (!FunctionNameValidationRegex.IsMatch(name))
             {
-                throw new InvalidOperationException(string.Format("'{0}' is not a valid function name.", functionName));
+                throw new InvalidOperationException(string.Format("'{0}' is not a valid {1} name.", name, isProxy ? "proxy" : "function"));
             }
         }
 
@@ -1275,6 +1286,11 @@ namespace Microsoft.Azure.WebJobs.Script
                             throw new InvalidOperationException($"The route specified conflicts with the route defined by function '{pair.Key}'.");
                         }
                     }
+                }
+
+                if (httpFunctions.ContainsKey(function.Name))
+                {
+                    throw new InvalidOperationException($"The function or proxy name '{function.Name}' must be unique within the function app.");
                 }
 
                 httpFunctions.Add(function.Name, httpTrigger);

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1271,10 +1271,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                ScriptHost.ValidateFunctionName(functionName);
+                ScriptHost.ValidateName(functionName);
             });
 
             Assert.Equal(string.Format("'{0}' is not a valid function name.", functionName), ex.Message);
+        }
+
+        [Theory]
+        [InlineData("bing.com")]
+        [InlineData("http://bing.com")]
+        public void ValidateProxyName_ThrowsOnInvalidName(string proxyName)
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                ScriptHost.ValidateName(proxyName, true);
+            });
+
+            Assert.Equal(string.Format("'{0}' is not a valid proxy name.", proxyName), ex.Message);
         }
 
         [Theory]
@@ -1287,7 +1300,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             try
             {
-                ScriptHost.ValidateFunctionName(functionName);
+                ScriptHost.ValidateName(functionName);
             }
             catch (InvalidOperationException)
             {
@@ -1431,6 +1444,40 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(4, httpFunctions.Count);
             Assert.True(httpFunctions.ContainsKey("test6"));
             Assert.Equal("test6", attribute.Route);
+        }
+
+        [Fact]
+        public void ValidateFunction_ThrowsOnDuplicateName()
+        {
+            var httpFunctions = new Dictionary<string, HttpTriggerAttribute>();
+            var name = "test";
+
+            // first add an http function
+            var metadata = new FunctionMetadata();
+            var function = new Mock<FunctionDescriptor>(MockBehavior.Strict, name, null, metadata, null, null, null, null);
+            var attribute = new HttpTriggerAttribute(AuthorizationLevel.Function, "get");
+            function.Setup(p => p.GetTriggerAttributeOrNull<HttpTriggerAttribute>()).Returns(() => attribute);
+
+            ScriptHost.ValidateFunction(function.Object, httpFunctions);
+
+            // add a proxy with same name
+            metadata = new FunctionMetadata()
+            {
+                IsProxy = true
+            };
+            function = new Mock<FunctionDescriptor>(MockBehavior.Strict, name, null, metadata, null, null, null, null);
+            attribute = new HttpTriggerAttribute(AuthorizationLevel.Function, "get")
+            {
+                Route = "proxyRoute"
+            };
+            function.Setup(p => p.GetTriggerAttributeOrNull<HttpTriggerAttribute>()).Returns(() => attribute);
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                ScriptHost.ValidateFunction(function.Object, httpFunctions);
+            });
+
+            Assert.Equal(string.Format($"The function or proxy name '{name}' must be unique within the function app.", name), ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Proxy names should follow the same naming restrictions as function names.

https://github.com/Azure/azure-webjobs-sdk-script/issues/2010
https://github.com/Azure/azure-webjobs-sdk/issues/1368