### PR TITLE
Create a new host for the standalone runtime which has no dependency on Azure Storage

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}"
 EndProject
@@ -376,6 +376,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Script.Tests.Integr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Script.Grpc", "src\WebJobs.Script.Grpc\WebJobs.Script.Grpc.csproj", "{38920568-003E-448F-963B-41B739D1E01C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Script.Host.Standalone", "src\WebJobs.Script.Host.Standalone\WebJobs.Script.Host.Standalone.csproj", "{9741FFA8-252C-4FB9-8EE6-DAEEB3DBDA84}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
@@ -417,6 +419,10 @@ Global
 		{38920568-003E-448F-963B-41B739D1E01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{38920568-003E-448F-963B-41B739D1E01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{38920568-003E-448F-963B-41B739D1E01C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9741FFA8-252C-4FB9-8EE6-DAEEB3DBDA84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9741FFA8-252C-4FB9-8EE6-DAEEB3DBDA84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9741FFA8-252C-4FB9-8EE6-DAEEB3DBDA84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9741FFA8-252C-4FB9-8EE6-DAEEB3DBDA84}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -488,6 +494,7 @@ Global
 		{137FB7AA-B192-4766-B86A-C813D94B1995} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
 		{EDDDAED1-0E37-4ED7-A595-63F686DEE90A} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
 		{38920568-003E-448F-963B-41B739D1E01C} = {16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}
+		{9741FFA8-252C-4FB9-8EE6-DAEEB3DBDA84} = {16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/src/WebJobs.Script.Host.Standalone/App.config
+++ b/src/WebJobs.Script.Host.Standalone/App.config
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20511.1437" newVersion="4.0.20511.1437" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Mobile" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.FileVersionInfo" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup>
+<appSettings>
+<!-- NotificationHubs specific app setings for messaging connections -->
+<add key="Microsoft.Azure.NotificationHubs.ConnectionString" value="Endpoint=sb://[your namespace].notificationhubs.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]" />
+</appSettings>
+<system.serviceModel>
+<extensions>
+<!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
+<behaviorExtensions>
+<add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+</behaviorExtensions>
+<bindingElementExtensions>
+<add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+</bindingElementExtensions>
+<bindingExtensions>
+<add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+</bindingExtensions>
+</extensions>
+</system.serviceModel>
+</configuration>

--- a/src/WebJobs.Script.Host.Standalone/GlobalSuppressions.cs
+++ b/src/WebJobs.Script.Host.Standalone/GlobalSuppressions.cs
@@ -1,0 +1,14 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+//
+// To add a suppression to this file, right-click the message in the
+// Code Analysis results, point to "Suppress Message", and click
+// "In Suppression File".
+// You do not need to add suppressions to this file manually.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "WebJobs.Script.Host.Program.#Main(System.String[])")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "Microsoft.Azure.WebJobs.Script.Host.Program.#Main(System.String[])")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1636:File header copyright text must match", Justification = "<Pending>")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1014:MarkAssembliesWithClsCompliant")]

--- a/src/WebJobs.Script.Host.Standalone/Program.cs
+++ b/src/WebJobs.Script.Host.Standalone/Program.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Logging;
+
+namespace WebJobs.Script.Host.Standalone
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            if (args == null)
+            {
+                throw new ArgumentNullException("args");
+            }
+
+            string rootPath = Environment.CurrentDirectory;
+            if (args.Length > 0)
+            {
+                rootPath = args[0];
+            }
+
+            string rootLogPath = Path.Combine(Path.GetTempPath(), "Functions");
+            if (args.Length > 1)
+            {
+                rootLogPath = args[1];
+            }
+
+            var config = new ScriptHostConfiguration()
+            {
+                RootScriptPath = rootPath,
+                RootLogPath = rootLogPath,
+                IsSelfHost = true
+            };
+
+            // Add the services for standalone workloads.
+            config.HostConfig = config.HostConfig ?? new JobHostConfiguration();
+            config.HostConfig.TimerMode = TimerMode.File;
+            config.HostConfig.AddService<IDistributedLockManager>(new SqlLeaseDistributedLockManager());
+            config.HostConfig.AddService<ILoggerFactory>(new LoggerFactory());
+            config.HostConfig.LoggerFactory.AddProvider(new SqlLoggerProvider());
+
+            var scriptHostManager = new ScriptHostManager(config);
+            scriptHostManager.RunAndBlock();
+        }
+    }
+}

--- a/src/WebJobs.Script.Host.Standalone/Program.cs
+++ b/src/WebJobs.Script.Host.Standalone/Program.cs
@@ -33,6 +33,7 @@ namespace WebJobs.Script.Host.Standalone
 
             var config = new ScriptHostConfiguration()
             {
+                FileLoggingMode = FileLoggingMode.Always,
                 RootScriptPath = rootPath,
                 RootLogPath = rootLogPath,
                 IsSelfHost = true

--- a/src/WebJobs.Script.Host.Standalone/Properties/launchSettings.json
+++ b/src/WebJobs.Script.Host.Standalone/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "WebJobs.Script.Host": {
+      "commandName": "Project",
+      "commandLineArgs": "D:\\Home",
+      "environmentVariables": {
+        "WEBSITE_SITE_NAME": "FuntionApp1",
+        "AzureWebJobsSqlTracer": "Server=<Server>;Database=<Database>;User=<User>;Password=<Password>;",
+        "AzureWebJobsLease": "Server=<Server>;Database=<Database>;User=<User>;Password=<Password>;"
+      }
+    }
+  }
+}

--- a/src/WebJobs.Script.Host.Standalone/Properties/launchSettings.json
+++ b/src/WebJobs.Script.Host.Standalone/Properties/launchSettings.json
@@ -2,9 +2,10 @@
   "profiles": {
     "WebJobs.Script.Host": {
       "commandName": "Project",
-      "commandLineArgs": "D:\\Home",
+      "commandLineArgs": "D:\\home\\site\\wwwroot D:\\home\\LogFiles",
       "environmentVariables": {
         "WEBSITE_SITE_NAME": "FuntionApp1",
+        "WEBSITE_INSTANCE_ID": "3723F6CF-5844-4448-B37B-785919330908",
         "AzureWebJobsSqlTracer": "Server=<Server>;Database=<Database>;User=<User>;Password=<Password>;",
         "AzureWebJobsLease": "Server=<Server>;Database=<Database>;User=<User>;Password=<Password>;"
       }

--- a/src/WebJobs.Script.Host.Standalone/SqlLeaseDistributedLockManager.cs
+++ b/src/WebJobs.Script.Host.Standalone/SqlLeaseDistributedLockManager.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Newtonsoft.Json;
+
+namespace WebJobs.Script.Host.Standalone
+{
+    /*
+    -- Stored procedure needs to be modified as shown below:
+    
+    ALTER PROCEDURE [function].[leases_tryAcquireOrRenew]
+    @LeaseName NVARCHAR (127), @RequestorName NVARCHAR (127), @LeaseExpirationTimeSpan INT, @Metadata NVARCHAR(MAX) = NULL, @HasLease BIT OUTPUT
+    AS
+    BEGIN
+        SET NOCOUNT ON;
+
+        BEGIN TRANSACTION
+
+        UPDATE  [function].[Leases] SET [LastRenewal] = CURRENT_TIMESTAMP, [LeaseExpirationTimeSpan] = @LeaseExpirationTimeSpan WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+        IF @@ROWCOUNT = 0
+            INSERT INTO [function].[Leases] ([LeaseName], [RequestorName], [LeaseExpirationTimeSpan], [LastRenewal], [Metadata], [HasLease])
+            VALUES (@LeaseName, @RequestorName, @LeaseExpirationTimeSpan, CURRENT_TIMESTAMP, @Metadata, 0)
+
+        COMMIT TRANSACTION
+    
+        UPDATE [function].[Leases]
+        SET [HasLease] = 0
+        WHERE [LeaseName] = @LeaseName AND [HasLease] = 1 AND [RequestorName] <> @RequestorName AND DATEDIFF(SECOND, [LastRenewal], CURRENT_TIMESTAMP) > @LeaseExpirationTimeSpan
+
+        BEGIN TRANSACTION
+    
+        IF NOT EXISTS (SELECT * FROM [function].[Leases] WHERE [LeaseName] = @LeaseName AND [HasLease] = 1)
+            UPDATE [function].[Leases]
+            SET [HasLease] = 1
+            WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+
+        COMMIT TRANSACTION
+
+        SELECT @HasLease = [HasLease] FROM [function].[Leases] WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+    END
+    GO
+    */
+
+    internal class SqlLeaseDistributedLockManager : IDistributedLockManager
+    {
+        private const string OwnerKey = "_owner";
+
+        private static readonly string InstanceId = Guid.NewGuid().ToString();
+
+        public const string ConnectionStringName = "AzureWebJobsLease";
+
+        public SqlLeaseDistributedLockManager()
+        {
+        }
+
+        public async Task<IDistributedLock> TryLockAsync(string account, string lockId, string lockOwnerId,
+            string proposedLeaseId, TimeSpan lockPeriod,
+            CancellationToken cancellationToken)
+        {
+            var result = await TryAcquireOrRenewLeaseAsync(account, lockId, lockOwnerId, lockPeriod, cancellationToken);
+
+            if (result)
+            {
+                return new SqlLockHandle(account, lockId, lockPeriod);
+            }
+
+            return null;
+        }
+
+        public async Task<bool> RenewAsync(IDistributedLock lockHandle, CancellationToken cancellationToken)
+        {
+            SqlLockHandle sqlLockHandle = (SqlLockHandle)lockHandle;
+            return await TryAcquireOrRenewLeaseAsync(sqlLockHandle.Account, sqlLockHandle.LockId, null, sqlLockHandle.LockPeriod, cancellationToken);
+        }
+
+        public async Task<string> GetLockOwnerAsync(string account, string lockId, CancellationToken cancellationToken)
+        {
+            var metadata = await ReadMetadataAsync(account, lockId, cancellationToken);
+            return metadata[OwnerKey];
+        }
+
+        public async Task ReleaseLockAsync(IDistributedLock lockHandle, CancellationToken cancellationToken)
+        {
+            SqlLockHandle sqlLockHandle = (SqlLockHandle)lockHandle;
+
+            var connectionString = GetConnectionString(sqlLockHandle.Account);
+
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+
+                using (SqlCommand cmd = connection.CreateCommand())
+                {
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.CommandText = "[function].[leases_release]";
+                    cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = sqlLockHandle.LockId;
+                    cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+
+                    await cmd.ExecuteNonQueryAsync(cancellationToken);
+                }
+            }
+        }
+
+        private static async Task<bool> TryAcquireOrRenewLeaseAsync(string account, string lockId, string owner, TimeSpan lockPeriod,
+            CancellationToken cancellationToken)
+        {
+            var connectionString = GetConnectionString(account);
+
+            var metadata = new Dictionary<string, string>();
+            if (!string.IsNullOrEmpty(owner))
+            {
+                metadata.Add(OwnerKey, owner);
+            }
+
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+                using (SqlCommand cmd = connection.CreateCommand())
+                {
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.CommandText = "[function].[leases_tryAcquireOrRenew]";
+                    cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = lockId;
+                    cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+                    cmd.Parameters.Add("@LeaseExpirationTimeSpan", SqlDbType.Int).Value = (int)lockPeriod.TotalSeconds;
+                    cmd.Parameters.Add("@Metadata", SqlDbType.NVarChar).Value = JsonConvert.SerializeObject(metadata);
+                    cmd.Parameters.Add("@HasLease", SqlDbType.Bit).Direction = ParameterDirection.Output;
+
+                    await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+                    return (bool)cmd.Parameters["@HasLease"].Value;
+                }
+            }
+        }
+
+        private async Task<Dictionary<string, string>> ReadMetadataAsync(string account, string lockId, CancellationToken cancellationToken)
+        {
+            var connectionString = GetConnectionString(account);
+
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+
+                using (SqlCommand cmd = connection.CreateCommand())
+                {
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.CommandText = "[function].leases_getMetadata";
+                    cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = lockId;
+                    cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+                    cmd.Parameters.Add("@Metadata", SqlDbType.NVarChar, -1).Direction = ParameterDirection.Output;
+                    cmd.Parameters.Add("@HasLease", SqlDbType.Bit).Direction = ParameterDirection.Output;
+                    await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+                    var hasLease = (bool)cmd.Parameters["@HasLease"].Value;
+
+                    var serializedMetadata = (string)cmd.Parameters["@Metadata"].Value;
+
+                    Dictionary<string, string> metadataDict;
+
+                    if (string.IsNullOrEmpty(serializedMetadata))
+                    {
+                        metadataDict = new Dictionary<string, string>();
+                    }
+                    else
+                    {
+                        metadataDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(serializedMetadata);
+                    }
+
+                    // We don't want to fail even if the lease is not active
+                    return metadataDict;
+                }
+            }
+        }
+
+        private static string GetConnectionString(string accountName)
+        {
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                accountName = ConnectionStringName;
+            }
+
+            return AmbientConnectionStringProvider.Instance.GetConnectionString(accountName);
+        }
+    }
+
+    internal class SqlLockHandle : IDistributedLock
+    {
+        public SqlLockHandle(string account, string lockId, TimeSpan lockPeriod)
+        {
+            Account = account;
+            LockId = lockId;
+            LockPeriod = lockPeriod;
+        }
+
+        public string Account { get; private set; }
+
+        public string LockId { get; private set; }
+
+        public TimeSpan LockPeriod { get; private set; }
+    }
+}

--- a/src/WebJobs.Script.Host.Standalone/SqlLoggerProvider.cs
+++ b/src/WebJobs.Script.Host.Standalone/SqlLoggerProvider.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace WebJobs.Script.Host.Standalone
+{
+    // This needs to move out of this project. Should be plugged into the logging pipeline. But for now, anything that works is fine.
+    public class SqlLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new SqlLogger(categoryName);
+        }
+
+        public void Dispose()
+        {
+            // DO NOTHING (Needed because ILoggerProvider : IDisposable)
+        }
+    }
+
+    /**
+     * Sql based implementation of ILogger.
+     *
+     * Expected table definition:
+     *
+     * CREATE TABLE [function].[logs]
+     * (
+     * [Id] [int] IDENTITY(1,1) PRIMARY KEY,
+     * [Timestamp] [datetime2](7) NOT NULL,
+     * [AppName] [nvarchar](max) NOT NULL,
+     * [FunctionName] [nvarchar](max), -- NULL is OK
+     * [Message] [nvarchar](max) NOT NULL
+     * )
+     *
+     */
+    public class SqlLogger : BufferedLogger
+    {
+        public const string ConnectionStringName = "AzureWebJobsSqlTracer";
+        private const string InsertStatement = "INSERT INTO [function].[Logs] ([Timestamp], [ServerName], [AppName], [FunctionName], [TraceLevel], [Message]) values(@Timestamp, @ServerName, @AppName, @FunctionName, @TraceLevel, @Message)";
+        private string _functionApp;
+
+        public SqlLogger(string category)
+            : base(category)
+        {
+            _functionApp = ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteName);
+        }
+
+        protected async override Task FlushAsync(IEnumerable<TraceMessage> traceMessages)
+        {
+            string conenctionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringName);
+            string functionName = GetFunctionName();
+
+            using (SqlConnection connection = new SqlConnection(conenctionString))
+            {
+                await connection.OpenAsync();
+
+                using (SqlCommand command = new SqlCommand(InsertStatement, connection))
+                {
+                    command.Parameters.Add("@Timestamp", SqlDbType.DateTime2);
+                    command.Parameters.Add("@ServerName", SqlDbType.NVarChar).Value = Environment.MachineName;
+                    command.Parameters.Add("@TraceLevel", SqlDbType.Int).Value = 100;
+                    command.Parameters.Add("@AppName", SqlDbType.NVarChar).Value = _functionApp ?? (object)DBNull.Value;
+                    command.Parameters.Add("@FunctionName", SqlDbType.NVarChar).Value = functionName ?? (object)DBNull.Value;
+                    command.Parameters.Add("@Message", SqlDbType.NVarChar);
+
+                    foreach (var traceMessage in traceMessages)
+                    {
+                        command.Parameters["@Timestamp"].Value = traceMessage.Time;
+                        command.Parameters["@Message"].Value = traceMessage.Message;
+
+                        await command.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.Host.Standalone/WebJobs.Script.Host.Standalone.csproj
+++ b/src/WebJobs.Script.Host.Standalone/WebJobs.Script.Host.Standalone.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <Version>2.0.0-standalone-preview2</Version>
+    <Product>Azure WebJobs SDK Script Standalone Runtime</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebJobs.Script\WebJobs.Script.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/src/WebJobs.Script.Host/Properties/launchSettings.json
+++ b/src/WebJobs.Script.Host/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "WebJobs.Script.Host": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
+++ b/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.WebJobs.Script
     {
         public ScriptHostConfiguration()
         {
-            HostConfig = new JobHostConfiguration();
             FileWatchingEnabled = true;
             FileLoggingMode = FileLoggingMode.Never;
             RootScriptPath = Environment.CurrentDirectory;

--- a/src/WebJobs.Script/Diagnostics/BufferedLogger.cs
+++ b/src/WebJobs.Script/Diagnostics/BufferedLogger.cs
@@ -1,0 +1,190 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Timers;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    // Abstract class that buffers the traces and flushes them periodically
+    // Methods of this class are thread safe.
+    // Subclass this class to provide custom buffered tracing implementation. Example: Trace to sql, trace to file, etc
+    public abstract class BufferedLogger : ILogger, IDisposable
+    {
+        private const int LogFlushIntervalMs = 1000;
+        private readonly object _syncLock = new object();
+        private readonly Timer _flushTimer;
+
+        private string _category;
+        private ConcurrentQueue<TraceMessage> _logBuffer = new ConcurrentQueue<TraceMessage>();
+
+        protected BufferedLogger(string categoryName)
+        {
+            try
+            {
+                _category = categoryName;
+
+                _flushTimer = new Timer(LogFlushIntervalMs);
+
+                // start a timer to flush accumulated logs in batches
+                _flushTimer.AutoReset = true;
+                _flushTimer.Elapsed += OnFlushLogs;
+                _flushTimer.Start();
+            }
+            catch
+            {
+                // Clean up, if the constructor throws
+                if (_flushTimer != null)
+                {
+                    _flushTimer.Dispose();
+                }
+
+                throw;
+            }
+        }
+
+        ~BufferedLogger()
+        {
+            Dispose(false);
+        }
+
+        public string Category
+        {
+            get
+            {
+                return _category;
+            }
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            IEnumerable<KeyValuePair<string, object>> properties = state as IEnumerable<KeyValuePair<string, object>>;
+            string formattedMessage = formatter?.Invoke(state, exception);
+
+            AppendLine(formattedMessage);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            return DictionaryLoggerScope.Push(state);
+        }
+
+        public void Flush()
+        {
+            if (_logBuffer.Count == 0)
+            {
+                return;
+            }
+
+            ConcurrentQueue<TraceMessage> currentBuffer;
+            lock (_syncLock)
+            {
+                // Snapshot the current set of buffered logs
+                // and set a new queue. This ensures that any new
+                // logs are written to the new buffer.
+                // We do this snapshot in a lock since Flush might be
+                // called by multiple threads concurrently, and we need
+                // to ensure we only log each log once.
+                currentBuffer = _logBuffer;
+                _logBuffer = new ConcurrentQueue<TraceMessage>();
+            }
+
+            if (currentBuffer.Count == 0)
+            {
+                return;
+            }
+
+            // Flush the trace messages
+            lock (_syncLock)
+            {
+                this.FlushAsync(currentBuffer).Wait();
+            }
+        }
+
+        // Flush the traces
+        protected abstract Task FlushAsync(IEnumerable<TraceMessage> traceMessages);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _flushTimer.Dispose();
+
+                // ensure any remaining logs are flushed
+                Flush();
+            }
+        }
+
+        protected virtual void AppendLine(string line)
+        {
+            if (line == null)
+            {
+                return;
+            }
+
+            // add the line to the current buffer batch, which is flushed on a timer
+            _logBuffer.Enqueue(new TraceMessage
+            {
+                Time = DateTime.UtcNow,
+                Message = line.Trim()
+            });
+        }
+
+        protected string GetFunctionName()
+        {
+            IDictionary<string, object> scopeProperties = DictionaryLoggerScope.GetMergedStateDictionary();
+
+            if (!scopeProperties.TryGetValue(ScriptConstants.LoggerFunctionNameKey, out string functionName))
+            {
+                return null;
+            }
+
+            // this function name starts with "Functions.", but file paths do not include this
+            string functionsPrefix = "Functions.";
+            if (functionName.StartsWith(functionsPrefix))
+            {
+                functionName = functionName.Substring(functionsPrefix.Length);
+            }
+
+            return functionName;
+        }
+
+        private void OnFlushLogs(object sender, ElapsedEventArgs e)
+        {
+            Flush();
+        }
+    }
+
+    public class TraceMessage
+    {
+        public DateTime Time { get; set; }
+
+        public string MachineName { get; set; }
+
+        public string AppName { get; set; }
+
+        public string FunctionName { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -137,10 +137,14 @@ namespace Microsoft.Azure.WebJobs.Script
                     }
 
                     // Create a new host config, but keep the host id from existing one
-                    _config.HostConfig = new JobHostConfiguration(_settingsManager.Configuration)
+                    if (_config.HostConfig == null)
                     {
-                        HostId = _config.HostConfig.HostId
-                    };
+                        _config.HostConfig = new JobHostConfiguration(_settingsManager.Configuration)
+                        {
+                            HostId = _config.HostConfig.HostId
+                        };
+                    }
+
                     OnInitializeConfig(_config);
                     newInstance = _scriptHostFactory.Create(_environment, EventManager, _settingsManager, _config, _loggerFactoryBuilder);
                     _traceWriter = newInstance.TraceWriter;


### PR DESCRIPTION
It relies on SQL Server for distributed locks, uses file based scheduling for timers and generates logs into file and into SQL Server.

NOTE: This is part of a bigger change that needs changes on this repo and in azure-webjobs-sdk and azure-webjobs-sdk-extensions to create a custom host for standalone workloads.
IMPORTANT: This changes has dependencies on the following pull requests:
https://github.com/Azure/azure-webjobs-sdk/pull/1384
https://github.com/Azure/azure-webjobs-sdk-extensions/pull/313