### PR TITLE
Added "worker" to config resolution

### DIFF
--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             foreach (var provider in providers)
             {
                 var description = provider.GetDescription();
-                var languageSection = _config.GetSection(description.Language);
+                var languageSection = _config.GetSection($"workers:{description.Language}");
 
                 // get explicit worker path from config, or build relative path from default
                 var workerPath = languageSection.GetSection("path").Value;

--- a/test/WebJobs.Script.Tests.Shared/TestWorkerProvider.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestWorkerProvider.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class TestWorkerProvider : IWorkerProvider
+    {
+        public string Language { get; set; }
+
+        public string Extension { get; set; }
+
+        public string DefaultWorkerPath { get; set; }
+
+        public WorkerDescription GetDescription() => new WorkerDescription
+        {
+            Language = this.Language,
+            Extension = this.Extension,
+            DefaultWorkerPath = this.DefaultWorkerPath,
+        };
+
+        public bool TryConfigureArguments(ArgumentsDescription args, IConfiguration config, ILogger logger)
+        {
+            // make no modifications
+            return true;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -23,5 +23,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestSecretManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSecretManagerFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTraceWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestWorkerProvider.cs" />
   </ItemGroup>
 </Project>

--- a/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _proxyClient = GetMockProxyClient();
             _settingsManager = ScriptSettingsManager.Instance;
+            _settingsManager.Reset();
             _host = ScriptHost.Create(environment.Object, eventManager.Object, _config, _settingsManager, proxyClient: _proxyClient);
             _metadataCollection = _host.ReadProxyMetadata(_config, _settingsManager);
         }

--- a/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
+{
+    public class WorkerConfigFactoryTests
+    {
+        [Fact]
+        public void SetsDebugPort()
+        {
+            var lang = "test";
+            var extension = ".test";
+            var defaultWorkerPath = "./test";
+
+            var workerPath = "/path/to/custom/worker";
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new List<KeyValuePair<string, string>>()
+                {
+                    new KeyValuePair<string, string>($"workers:{lang}:debug", "1000"),
+                    new KeyValuePair<string, string>($"workers:{lang}:path", workerPath),
+                })
+                .Build();
+
+            var logger = new TestLogger("test");
+            var workerConfigFactory = new WorkerConfigFactory(config, logger);
+
+            var workerConfigs = workerConfigFactory.GetConfigs(new List<IWorkerProvider>()
+            {
+                new TestWorkerProvider()
+                {
+                    Language = lang,
+                    Extension = extension,
+                    DefaultWorkerPath = defaultWorkerPath
+                }
+            });
+
+            Assert.Equal(workerConfigs.Single().Arguments.WorkerPath, workerPath);
+        }
+    }
+}


### PR DESCRIPTION
We were missing "worker:" in the language config module.