### PR TITLE
Fixing race condition in host restart

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private static void AddMessageHandlers(HttpConfiguration config)
         {
-            config.MessageHandlers.Add(new WebScriptHostHandler(config));
             config.MessageHandlers.Add(new SystemTraceHandler(config));
+            config.MessageHandlers.Add(new WebScriptHostHandler(config));
         }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -399,12 +399,15 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public virtual void RestartHost()
         {
-            _restartHostEvent.Set();
-
-            // we reset the state immediately here to ensure that
+            // We reset the state immediately here to ensure that
             // any external calls to CanInvoke will return false
-            // immediately after the restart has been initiated
+            // immediately after the restart has been initiated.
+            // Note: this state change must be done BEFORE we set
+            // the event below to avoid a race condition with the
+            // main host lifetime loop.
             State = ScriptHostState.Default;
+
+            _restartHostEvent.Set();
         }
 
         public virtual void Shutdown()

--- a/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
@@ -287,10 +287,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var eventManagerMock = new Mock<IScriptEventManager>();
             ScriptHostManager hostManager = new ScriptHostManager(config, eventManagerMock.Object);
 
+            // start the host and wait for it to be running
             Task runTask = Task.Run(() => hostManager.RunAndBlock());
-
             await TestHelpers.Await(() => hostManager.State == ScriptHostState.Running, timeout: 10000);
 
+            // exercise restart
+            hostManager.RestartHost();
+            Assert.Equal(ScriptHostState.Default, hostManager.State);
+            await TestHelpers.Await(() => hostManager.State == ScriptHostState.Running, timeout: 10000);
+
+            // stop the host fully
             hostManager.Stop();
             Assert.Equal(ScriptHostState.Default, hostManager.State);
 


### PR DESCRIPTION
Fixing a race condition identified by Kranthi.  This was introduced a while back in my commit https://github.com/Azure/azure-webjobs-sdk-script/commit/642d3b186d0a017783c133240323f8703483e79e#diff-62f03af2f495fb19b4e6de748d6f21f8R406. The fact that I was setting the state AFTER setting the event opened the door to race conditions with the main host even loop in ScriptHostManager. E.g.:

- host manager RunAndBlock is waiting on WaitHandle.WaitAny
- RestartHost is called (e.g. a file has changed)
- Restart sets the event releasing the host loop. Assume at this point there is a context switch and we start creating a new host and the state changes to Running
- Another context switch happens back to RestartHost, and it overwrites the state back to Default
- at that point we have a host with the wrong state, preventing invocations
