### PR TITLE
Fix/content type raw response

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/NodeContentTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeContentTests.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Web.Http.Results;
 using Moq;
 using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -56,6 +57,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var str = "asdf";
             var content = await Raw(str, "text/plain; charset=utf-8");
             Assert.Equal(str, content);
+        }
+
+        [Fact]
+        public async Task BadContentType_ThrowsExpectedException()
+        {
+            await Assert.ThrowsAsync<FunctionInvocationException>(async () =>
+            {
+                var content = await Response("asdf", null);
+            });
         }
 
         [Fact]


### PR DESCRIPTION
Description:
 - fixes https://github.com/Azure/azure-webjobs-sdk-script/issues/2053
 - fixes a bug where non 200 status codes would fail for `isRaw = true` (discovered while fixing above)

Todo:

- [x] rebase onto dev
