### PR TITLE
EventHubScriptBindingProvider should set the connection on the attribute

### DIFF
--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -109,7 +109,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -139,13 +139,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -17,8 +17,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta6-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -28,8 +28,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -17,7 +17,7 @@
       <dependency id="Edge.js" version="6.11.3" />
       <dependency id="FSharp.Compiler.Service" version="9.0.1" />
       <dependency id="FSharp.Core" version="4.0.0.1" />
-      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11064" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11069" />
       <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" />
       <dependency id="Microsoft.Azure.AppService.Proxy" version="0.3.2.14" />
       <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -199,7 +199,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -232,16 +232,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -45,8 +45,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta6-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -58,8 +58,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/src/WebJobs.Script/Binding/ServiceBusScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/ServiceBusScriptBindingProvider.cs
@@ -148,14 +148,11 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                 }
 
                 string connectionString = Context.GetMetadataValue<string>("connection");
-                if (!string.IsNullOrEmpty(connectionString))
-                {
-                    connectionString = _nameResolver.Resolve(connectionString);
-                }
 
                 if (Context.IsTrigger)
                 {
                     var attribute = new EventHubTriggerAttribute(eventHubName);
+                    attribute.Connection = connectionString;
                     string consumerGroup = Context.GetMetadataValue<string>("consumerGroup");
                     if (consumerGroup != null)
                     {
@@ -163,13 +160,12 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                         attribute.ConsumerGroup = consumerGroup;
                     }
                     attributes.Add(attribute);
-                    _eventHubConfiguration.AddReceiver(eventHubName, connectionString);
                 }
                 else
                 {
-                    attributes.Add(new EventHubAttribute(eventHubName));
-
-                    _eventHubConfiguration.AddSender(eventHubName, connectionString);
+                    var attribute = new EventHubAttribute(eventHubName);
+                    attribute.Connection = connectionString;
+                    attributes.Add(attribute);
                 }
 
                 return attributes;

--- a/src/WebJobs.Script/Binding/ServiceBusScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/ServiceBusScriptBindingProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             if (string.Compare(context.Type, "eventHubTrigger", StringComparison.OrdinalIgnoreCase) == 0 ||
                 string.Compare(context.Type, "eventHub", StringComparison.OrdinalIgnoreCase) == 0)
             {
-                binding = new EventHubScriptBinding(Config, _eventHubConfiguration, context);
+                binding = new EventHubScriptBinding(Config, context);
             }
 
             return binding != null;
@@ -103,12 +103,10 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
         private class EventHubScriptBinding : ScriptBinding
         {
-            private readonly EventHubConfiguration _eventHubConfiguration;
             private readonly INameResolver _nameResolver;
 
-            public EventHubScriptBinding(JobHostConfiguration hostConfig, EventHubConfiguration eventHubConfig, ScriptBindingContext context) : base(context)
+            public EventHubScriptBinding(JobHostConfiguration hostConfig, ScriptBindingContext context) : base(context)
             {
-                _eventHubConfiguration = eventHubConfig;
                 _nameResolver = hostConfig.NameResolver;
             }
 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -110,7 +110,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -143,13 +143,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -21,8 +21,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta6-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -33,8 +33,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -126,7 +126,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -159,16 +159,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -29,8 +29,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta6-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -42,8 +42,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -137,7 +137,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -167,13 +167,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.1.0-beta4-10554\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11069\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -30,8 +30,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta6-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net46" />
@@ -41,8 +41,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta4-10554" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11069" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11069" targetFramework="net461" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />


### PR DESCRIPTION
This PR consumes latest webjobs bits which includes https://github.com/Azure/azure-webjobs-sdk/pull/1417

Tested that the whole e2e of duplicate event hub names works fine with a private site extension built from this PR.

