### PR TITLE
Update Microsoft.Azure.Functions.JavaWorker to 1.1.0-beta2-10009

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client.Contract" Version="0.3.1.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta1-20170921">
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10009">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10022">

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client.Contract" Version="0.3.1.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta1-20170921" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10009" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10022" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="Moq" Version="4.7.99" />


### PR DESCRIPTION
Updates Java Worker to beta2 - https://github.com/Azure/azure-functions-java-worker/releases/tag/v1.0.0-beta-2 