### PR TITLE
Changing configuration setup order so environment variables take precedence over app settings

### DIFF
--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -137,8 +137,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         private static IConfigurationRoot BuildConfiguration()
         {
             var configurationBuilder = new ConfigurationBuilder()
-                .AddEnvironmentVariables()
-                .AddJsonFile("appsettings.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables();
 
             return configurationBuilder.Build();
         }


### PR DESCRIPTION
This change is similar to https://github.com/Azure/azure-webjobs-sdk/pull/1426 and made here so the default behavior in script is consistent.