### PR TITLE
Loosen host running status check (#2114)

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/AdminController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/AdminController.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         }
 
         [HttpPost]
+        [RequiresRunningHost]
         [Route("admin/functions/{name}")]
         public HttpResponseMessage Invoke(string name, [FromBody] FunctionInvocation invocation)
         {
@@ -68,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         }
 
         [HttpGet]
+        [RequiresRunningHost]
         [Route("admin/functions/{name}/status")]
         public FunctionStatus GetFunctionStatus(string name)
         {
@@ -211,6 +213,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpGet]
         [HttpPost]
         [AllowAnonymous]
+        [RequiresRunningHost]
         public async Task<HttpResponseMessage> ExtensionWebHookHandler(string name, CancellationToken token)
         {
             var provider = _scriptHostManager.BindingWebHookProvider;

--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -2,21 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
-using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
-using System.Web.Http.Dependencies;
 using Microsoft.Azure.AppService.Proxy.Client;
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Host;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
-using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Azure.WebJobs.Script.WebHost.WebHooks;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
@@ -37,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         public override async Task<HttpResponseMessage> ExecuteAsync(HttpControllerContext controllerContext, CancellationToken cancellationToken)
         {
+            await _scriptHostManager.DelayUntilHostReady();
+
             var request = controllerContext.Request;
             var function = _scriptHostManager.GetHttpFunctionOrNull(request);
 

--- a/src/WebJobs.Script.WebHost/Filters/RequiresRunningHostAttribute.cs
+++ b/src/WebJobs.Script.WebHost/Filters/RequiresRunningHostAttribute.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Filters
+{
+    /// <summary>
+    /// Filter applied to actions that require the host instance to be in a state
+    /// where functions can be invoked.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public sealed class RequiresRunningHostAttribute : ActionFilterAttribute
+    {
+        public RequiresRunningHostAttribute(int timeoutSeconds = ScriptConstants.HostTimeoutSeconds, int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds)
+        {
+            TimeoutSeconds = timeoutSeconds;
+            PollingIntervalMilliseconds = pollingIntervalMilliseconds;
+        }
+
+        public int TimeoutSeconds { get; }
+
+        public int PollingIntervalMilliseconds { get; }
+
+        public override async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+        {
+            var resolver = actionContext.ControllerContext.Configuration.DependencyResolver;
+            var scriptHostManager = resolver.GetService<WebScriptHostManager>();
+
+            // If the host is not ready, we'll wait a bit for it to initialize.
+            // This might happen if http requests come in while the host is starting
+            // up for the first time, or if it is restarting.
+            await scriptHostManager.DelayUntilHostReady(TimeoutSeconds, PollingIntervalMilliseconds);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -437,6 +437,7 @@
     <Compile Include="App_Start\WebHostResolver.cs" />
     <Compile Include="App_Start\WebHostSettings.cs" />
     <Compile Include="Diagnostics\Sanitizer.cs" />
+    <Compile Include="Filters\RequiresRunningHostAttribute.cs" />
     <Compile Include="StandbyManager.cs" />
     <Compile Include="Controllers\AdminController.cs" />
     <Compile Include="Controllers\FunctionsController.cs" />

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -26,6 +26,7 @@ using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Scale;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Handlers;
 using Microsoft.Extensions.Logging;
 
@@ -59,8 +60,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             IScriptHostFactory scriptHostFactory = null,
             ISecretsRepositoryFactory secretsRepositoryFactory = null,
             HostPerformanceManager hostPerformanceManager = null,
-            int hostTimeoutSeconds = WebScriptHostHandler.HostTimeoutSeconds,
-            int hostPollingIntervalMilliseconds = WebScriptHostHandler.HostPollingIntervalMilliseconds)
+            int hostTimeoutSeconds = ScriptConstants.HostTimeoutSeconds,
+            int hostPollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds)
             : base(config, settingsManager, scriptHostFactory, eventManager, null, hostPerformanceManager)
         {
             _config = config;
@@ -158,8 +159,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public async Task<HttpResponseMessage> HandleRequestAsync(FunctionDescriptor function, HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            // ensure that the host is ready to process requests
-            await DelayUntilHostReady(_hostTimeoutSeconds, _hostRunningPollIntervalMilliseconds);
+            await DelayUntilHostReady();
 
             // All authentication is assumed to have been done on the request
             // BEFORE this method is called
@@ -429,7 +429,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             HostingEnvironment.InitiateShutdown();
         }
 
-        public async Task DelayUntilHostReady(int timeoutSeconds = WebScriptHostHandler.HostTimeoutSeconds, int pollingIntervalMilliseconds = WebScriptHostHandler.HostPollingIntervalMilliseconds, bool throwOnFailure = true)
+        public async Task DelayUntilHostReady()
+        {
+            // ensure that the host is ready to process requests
+            await DelayUntilHostReady(_hostTimeoutSeconds, _hostRunningPollIntervalMilliseconds);
+        }
+
+        public async Task DelayUntilHostReady(int timeoutSeconds = ScriptConstants.HostTimeoutSeconds, int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds, bool throwOnFailure = true)
         {
             TimeSpan timeout = TimeSpan.FromSeconds(timeoutSeconds);
             TimeSpan delay = TimeSpan.FromMilliseconds(pollingIntervalMilliseconds);

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -76,5 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const int MaximumHostIdLength = 32;
         public const int DynamicSkuConnectionLimit = 50;
+        public const int HostTimeoutSeconds = 30;
+        public const int HostPollingIntervalMilliseconds = 25;
     }
 }

--- a/test/WebJobs.Script.Tests/Handlers/WebScriptHostHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Handlers/WebScriptHostHandlerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _settingsManager = ScriptSettingsManager.Instance;
             var eventManager = new Mock<IScriptEventManager>();
             _managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new ScriptHostConfiguration(), new TestSecretManagerFactory(), eventManager.Object,
-                _settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path });
+                _settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path }, null, null, null, 1, 50);
 
             _managerMock.SetupGet(p => p.Initialized).Returns(true);
             Mock<IDependencyResolver> mockResolver = new Mock<IDependencyResolver>(MockBehavior.Strict);
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             HttpConfiguration config = new HttpConfiguration();
             config.DependencyResolver = mockResolver.Object;
-            WebScriptHostHandler handler = new WebScriptHostHandler(config, hostTimeoutSeconds: 1, hostPollingIntervalMilliseconds: 50)
+            WebScriptHostHandler handler = new WebScriptHostHandler(config)
             {
                 InnerHandler = new TestHandler()
             };


### PR DESCRIPTION
Fix for issue #2114. Previously we were requiring the host to be up and initialized to the point where it could run functions for all but one API (the admin/host/status endpoint). Nearly all of our management APIs can be accessed w/o the host running. Fixing this will greatly improve portal experience in cases where the host is in an error state.