### PR TITLE
Fixing the host check timeout and middleware registration order

### DIFF
--- a/src/WebJobs.Script.WebHost/Middleware/ScriptHostCheckMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/ScriptHostCheckMiddleware.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
             if (!bypassHostCheck)
             {
-                bool hostReady = await manager.DelayUntilHostReady(timeoutSeconds: 5);
+                bool hostReady = await manager.DelayUntilHostReady();
 
                 if (!hostReady)
                 {

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -19,11 +19,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public static IApplicationBuilder UseWebJobsScriptHost(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
         {
             builder.UseMiddleware<FunctionInvocationMiddleware>();
-            builder.UseHttpBindingRouting(applicationLifetime, routes);
             builder.UseWhen(context => !context.Request.Path.StartsWithSegments("/admin/host/status"), config =>
             {
                 config.UseMiddleware<ScriptHostCheckMiddleware>();
             });
+
+            // Ensure the HTTP binding routing is registered after all middleware
+            builder.UseHttpBindingRouting(applicationLifetime, routes);
 
             builder.UseMvc(r =>
             {


### PR DESCRIPTION
This changes resolve 503 and 404 issues when the function host is initializing (impacts first/initial requests) #1944 

**NOTE:** There are tests validating this behavior that need to be migrated and are currently tracked by #1700 and #2022. The migration work is not being done as part of this PR since that would significantly increase the scope and block this fix until that work is assigned.