### PR TITLE
Private ref warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Publish
 *.Cache
 msbuild.log
 package-lock.json
+.DS_Store
 
 /packages
 /TestResults

--- a/src/WebJobs.Script/Description/DotNet/Compilation/CSharp/Analyzers/InvalidPrivateMetadataReferenceAnalyzer.cs
+++ b/src/WebJobs.Script/Description/DotNet/Compilation/CSharp/Analyzers/InvalidPrivateMetadataReferenceAnalyzer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Description.DotNet.CSharp.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class InvalidPrivateMetadataReferenceAnalyzer : DiagnosticAnalyzer
+    {
+        private const string Title = "Invalid private metadata reference";
+        private const string MessageFormat = "The reference '{0}' is invalid. Private assembly references must include the file extension. Try using '{1}'.";
+        private readonly DiagnosticDescriptor _supportedDiagnostic;
+        private static readonly ImmutableArray<string> _validMetadataExtensions = ImmutableArray.Create(".dll", ".exe");
+
+        public InvalidPrivateMetadataReferenceAnalyzer()
+        {
+            _supportedDiagnostic = new DiagnosticDescriptor(DotNetConstants.InvalidPrivateMetadataReferenceCode,
+                Title, MessageFormat, "Function", DiagnosticSeverity.Warning, true);
+        }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(_supportedDiagnostic);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCompilationAction(AnalyzeCompilation);
+        }
+
+        private void AnalyzeCompilation(CompilationAnalysisContext context)
+        {
+            // Find CS0006: Metadata file '{0}' could not be found
+            Diagnostic invalidMetadataDiagnostic = context.Compilation
+                .GetDiagnostics().FirstOrDefault(d => string.Compare(d.Id, "CS0006") == 0);
+
+            if (invalidMetadataDiagnostic != null)
+            {
+                var argument = invalidMetadataDiagnostic.GetDiagnosticMessageArguments().First().ToString();
+                var resolver = context.Compilation.Options.MetadataReferenceResolver as IFunctionMetadataResolver;
+                if (argument != null && !_validMetadataExtensions.Contains(Path.GetExtension(argument)) &&
+                    resolver != null && resolver.TryResolvePrivateAssembly(argument, out string path))
+                {
+                    var diagnostic = Diagnostic.Create(_supportedDiagnostic,
+                        invalidMetadataDiagnostic.Location,
+                        argument,
+                        Path.GetFileName(path));
+
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Description/DotNet/Compilation/CSharp/CSharpCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/Compilation/CSharp/CSharpCompilation.cs
@@ -26,7 +26,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         // Simply getting the built in analyzers for now.
         // This should eventually be enhanced to dynamically discover/load analyzers.
-        private static ImmutableArray<DiagnosticAnalyzer> _analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new InvalidFileMetadataReferenceAnalyzer(), new AsyncVoidAnalyzer());
+        private static ImmutableArray<DiagnosticAnalyzer> _analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+            new InvalidFileMetadataReferenceAnalyzer(),
+            new AsyncVoidAnalyzer(),
+            new InvalidPrivateMetadataReferenceAnalyzer());
 
         public CSharpCompilation(Compilation compilation)
         {

--- a/src/WebJobs.Script/Description/DotNet/DotNetConstants.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetConstants.cs
@@ -17,5 +17,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public const string InvalidFileMetadataReferenceCode = "AF006";
         public const string InvalidEntryPointNameCompilationCode = "AF007";
         public const string AsyncVoidCode = "AF008";
+        public const string InvalidPrivateMetadataReferenceCode = "AF009";
     }
 }

--- a/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionMetadataResolver.cs
@@ -245,17 +245,17 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return assembly;
         }
 
-        private bool HasValidAssemblyFileExtension(string reference)
-        {
-            return _assemblyExtensions.Contains(Path.GetExtension(reference));
-        }
-
-        private bool TryResolvePrivateAssembly(string name, out string assemblyPath)
+        public bool TryResolvePrivateAssembly(string name, out string assemblyPath)
         {
             var names = GetProbingFilePaths(name);
             assemblyPath = names.FirstOrDefault(n => File.Exists(n));
 
             return assemblyPath != null;
+        }
+
+        private bool HasValidAssemblyFileExtension(string reference)
+        {
+            return _assemblyExtensions.Contains(Path.GetExtension(reference));
         }
 
         private IEnumerable<string> GetProbingFilePaths(string name)

--- a/src/WebJobs.Script/Description/DotNet/IFunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/IFunctionMetadataResolver.cs
@@ -26,5 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         bool RequiresPackageRestore(FunctionMetadata metadata);
 
         bool TryGetPackageReference(string referenceName, out PackageReference package);
+
+        bool TryResolvePrivateAssembly(string name, out string assemblyPath);
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -434,6 +434,7 @@
     <Compile Include="Description\Compilation\ICompilation.cs" />
     <Compile Include="Description\DiagnosticSeverityExtensions.cs" />
     <Compile Include="Description\DotNet\Compilation\CSharp\Analyzers\AsyncVoidAnalyzer.cs" />
+    <Compile Include="Description\DotNet\Compilation\CSharp\Analyzers\InvalidPrivateMetadataReferenceAnalyzer.cs" />
     <Compile Include="Description\DotNet\Compilation\IDotNetCompilation.cs" />
     <Compile Include="Description\DotNet\Compilation\CSharp\Analyzers\InvalidFileMetadataReferenceAnalyzer.cs" />
     <Compile Include="Description\DotNet\Compilation\CSharp\CSharpCompilation.cs" />

--- a/test/WebJobs.Script.Tests/Description/DotNet/CSharp/CSharpCompilationTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/CSharp/CSharpCompilationTests.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
@@ -40,6 +44,7 @@ public void Run(){
   invalid.SomeMethod();
 }";
             Script<object> script = CSharpScript.Create(code);
+
             var compilation = new CSharpCompilation(script.GetCompilation());
 
             ImmutableArray<Diagnostic> diagnostics = compilation.GetDiagnostics();
@@ -62,6 +67,91 @@ await System.Threading.Tasks.Task.Run(() => {});
             Assert.Equal("This method has the async keyword but it returns void",
                 diagnostic.GetMessage());
             Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        }
+
+        [Fact]
+        public void InvalidPrivateReference_ReturnsExpectedDiagnostics()
+        {
+            string code = @"
+#r ""PrivateReference""
+public async void Run(){
+await System.Threading.Tasks.Task.Run(() => {});
+}";
+            var file = Path.GetTempFileName();
+            file = Path.ChangeExtension(file, "dll");
+
+            Script<object> script = CSharpScript.Create(code)
+                .WithOptions(ScriptOptions.Default.WithMetadataResolver(new TestFunctionMetadataResolver(file)));
+
+            var compilation = new CSharpCompilation(script.GetCompilation());
+
+            var diagnostic = compilation
+                .GetDiagnostics()
+                .First(d => string.Equals(d.Id, DotNetConstants.InvalidPrivateMetadataReferenceCode, System.StringComparison.Ordinal));
+
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Contains(Path.GetFileName(file), diagnostic.GetMessage());
+        }
+
+        private class TestFunctionMetadataResolver : MetadataReferenceResolver, IFunctionMetadataResolver
+        {
+            private readonly string _privateAssemblyFilePath;
+
+            public TestFunctionMetadataResolver(string privateAssemblyFilePath)
+            {
+                _privateAssemblyFilePath = privateAssemblyFilePath;
+            }
+
+            public ScriptOptions CreateScriptOptions()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override bool Equals(object other)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public IReadOnlyCollection<string> GetCompilationReferences()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override int GetHashCode()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool RequiresPackageRestore(FunctionMetadata metadata)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Assembly ResolveAssembly(string assemblyName)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+            {
+                return ImmutableArray<PortableExecutableReference>.Empty;
+            }
+
+            public Task<PackageRestoreResult> RestorePackagesAsync()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetPackageReference(string referenceName, out PackageReference package)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryResolvePrivateAssembly(string name, out string assemblyPath)
+            {
+                assemblyPath = _privateAssemblyFilePath;
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #2191 

This improves the compilation message to show the following:

```
warning AF009: The reference 'PrivateDependency' is invalid. Private assembly references must include the file extension. Consider using 'PrivateDependency.dll'.
```