### PR TITLE
Allow script to run off a SAS container 

### DIFF
--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebsiteHomePath = "HOME";
         public const string AzureWebJobsScriptRoot = "AzureWebJobsScriptRoot";
         public const string AzureWebJobsEnvironment = "AzureWebJobsEnv";
+        public const string AzureWebJobsStorageBlobContainer = "AzureWebJobsStorageBlobContainer";
         public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";
         public const string AzureWebJobsDisableHomepage = "AzureWebJobsDisableHomepage";
         public const string TypeScriptCompilerPath = "AzureWebJobs_TypeScriptPath";

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -444,6 +444,10 @@ namespace Microsoft.Azure.WebJobs.Script
                 // to prevent host startup failure
                 config.HostConfig.DashboardConnectionString = null;
             }
+
+            // If set, will run the SDK in a Blob Container specified by a SAS connection. 
+            config.SaSContainerConnectionString = 
+                _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebJobsStorageBlobContainer);
         }
 
         protected virtual void OnHostInitialized()


### PR DESCRIPTION
and not require full connection string.

Fix Azure/azure-webjobs-sdk-script#2209
Relies on SDK changes from: Azure/azure-webjobs-sdk#1425

This needs to pull the SAS connection from config and pass to the SDK.
Adds a new config knob.