### PR TITLE
Port timeout fix 

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -38,12 +38,12 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10577" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10577">
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10578" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10578">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11117" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11117" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11124" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11124" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.88-alpha" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client.Contract" Version="0.3.1.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11117" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10577" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10577">
       <NoWarn>NU1701</NoWarn>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10026">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11117" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10577" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10577">
       <NoWarn>NU1701</NoWarn>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -26,12 +26,12 @@
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10577" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10577">
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10578" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10578">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11117" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11117" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11124" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11124" />
     <PackageReference Include="Microsoft.Build" Version="15.3.409" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />

--- a/test/WebJobs.Script.Tests.Integration/FunctionGeneratorEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/FunctionGeneratorEndToEndTests.cs
@@ -44,17 +44,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // Get the Type Attributes (in this case, a TimeoutAttribute)
             ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
             scriptConfig.FunctionTimeout = TimeSpan.FromMinutes(5);
-            Collection<CustomAttributeBuilder> typeAttributes = ScriptHost.CreateTypeAttributes(scriptConfig);
+            Collection<CustomAttributeBuilder> typeAttributes = new Collection<CustomAttributeBuilder>();
 
             // generate the Type
             Type functionType = FunctionGenerator.Generate("TestScriptHost", "TestFunctions", typeAttributes, functions);
 
             // verify the generated function
             MethodInfo method = functionType.GetMethod("TimerFunction");
-            TimeoutAttribute timeoutAttribute = (TimeoutAttribute)functionType.GetCustomAttributes().Single();
-            Assert.Equal(TimeSpan.FromMinutes(5), timeoutAttribute.Timeout);
-            Assert.True(timeoutAttribute.ThrowOnTimeout);
-            Assert.True(timeoutAttribute.TimeoutWhileDebugging);
             ParameterInfo triggerParameter = method.GetParameters()[0];
             TimerTriggerAttribute triggerAttribute = triggerParameter.GetCustomAttribute<TimerTriggerAttribute>();
             Assert.NotNull(triggerAttribute);

--- a/test/WebJobs.Script.Tests/Description/FunctionGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionGeneratorTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // Make sure we don't generate a TimeoutAttribute if FunctionTimeout is null.
             ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
             scriptConfig.FunctionTimeout = null;
-            Collection<CustomAttributeBuilder> typeAttributes = ScriptHost.CreateTypeAttributes(scriptConfig);
+            Collection<CustomAttributeBuilder> typeAttributes = new Collection<CustomAttributeBuilder>();
 
             // generate the Type
             Type functionType = FunctionGenerator.Generate("TestScriptHost", "TestFunctions", typeAttributes, functions);


### PR DESCRIPTION
https://github.com/Azure/azure-webjobs-sdk-script/pull/2221

Since Timeout is now on the JobHost, function generator doesn't need to set individual TimeoutAttributes set anymore.

Update SDK nuget to 3.0.0-beta4-11124 to pick up SDK support for timeouts.