### PR TITLE
Added WEBSITE_HOSTNAME to enable local http handlers from extensions

### DIFF
--- a/docker/2.0.0/runtime/jessie/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/jessie/amd64/Dockerfile
@@ -19,4 +19,6 @@ COPY --from=installer-env ["/azure-functions-runtime", "/azure-functions-runtime
 
 ENV AzureWebJobsScriptRoot=/app
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -48,4 +48,6 @@ COPY --from=installer-env ["c:\\runtime", "C:\\runtime"]
 
 ENV AzureWebJobsScriptRoot=C:\approot
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "C:\\runtime\\Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/stretch/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/stretch/amd64/Dockerfile
@@ -19,4 +19,6 @@ COPY --from=installer-env ["/azure-functions-runtime", "/azure-functions-runtime
 
 ENV AzureWebJobsScriptRoot=/app
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/stretch/arm32v7/Dockerfile
+++ b/docker/2.0.0/runtime/stretch/arm32v7/Dockerfile
@@ -16,4 +16,6 @@ ENV AzureWebJobsScriptRoot=/app
 
 EXPOSE 80
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]


### PR DESCRIPTION
Hi,

The **WEBSITE_HOSTNAME** env variable is not set in dockerfile and therefore attempts to run durable functions (http handlers from extensions) on a container fail with: **FunctionInvocationException: Webhooks are not configured.**

#### Repro steps:
If you run my sample provided [here](https://github.com/cmendible/dotnetcore.samples/tree/master/azure.durable.function.docker) everything runs smooth:

1. dotnet build -o .\wwwroot\bin\
2. docker build --build-arg STORAGE_ACCOUNT='[Storage Account Connection String]' -t durable .
3. docker run -it -p 5000:80 durable
4. curl -X POST http://localhost:5000/api/orchestrators/orchestrator -i -H "Content-Length: 0"

Now if you remove the ENV WEBSITE_HOSTNAME=localhost:80 line from the dockerfile and follow the steps again, you'll notice the **FunctionInvocationException: Webhooks are not configured.** exception.

This issue is related to: [Azure/azure-webjobs-sdk-script#1658](https://github.com/Azure/azure-webjobs-sdk-script/issues/1658) which was mitigated in Azure Functions CLI setting the variable: [CLI enable local http handlers from extensions #197](https://github.com/Azure/azure-functions-cli/issues/197)
