### PR TITLE
Adds log warnrings for explicitly set host id in host.json

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -353,6 +353,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 _startupLogger.LogInformation(readingFileMessage);
                 _startupLogger.LogInformation(readFileMessage);
 
+                // If they set the host id in the JSON, emit a warning that this could cause issues and they shouldn't do it.
+                if (ScriptConfig.HostConfig?.HostConfigMetadata?["id"] != null)
+                {
+                    _startupLogger.LogWarning("Host id explicitly set in the host.json. It is recommended that you remove the \"id\" property in your host.json.");
+                }
+
                 if (string.IsNullOrEmpty(_hostConfig.HostId))
                 {
                     _hostConfig.HostId = Utility.GetDefaultHostId(_settingsManager, ScriptConfig);


### PR DESCRIPTION
Adds warning message when host id is set in host.json

fixes https://github.com/Azure/azure-webjobs-sdk-extensions/issues/264