### PR TITLE
[WIP] Adds config driven language worker support

### DIFF
--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                  string instanceId = GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId)
                      ?? Environment.MachineName.GetHashCode().ToString("X").PadLeft(32, '0');
 
-                 return instanceId.Substring(0, 32);
+                 return instanceId.Substring(0, Math.Min(instanceId.Length, 32));
              }
          }
 

--- a/src/WebJobs.Script/Diagnostics/DefaultLoggerProviderFactory.cs
+++ b/src/WebJobs.Script/Diagnostics/DefaultLoggerProviderFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -39,6 +40,11 @@ namespace Microsoft.Azure.WebJobs.Script
 
             providers.Add(new FunctionFileLoggerProvider(scriptConfig.RootLogPath, isFileLoggingEnabled, isPrimary));
             providers.Add(new HostFileLoggerProvider(scriptConfig.RootLogPath, isFileLoggingEnabled));
+
+            if (settingsManager.Configuration.GetSection("host:logger:consoleLoggingMode").Value == "always")
+            {
+                providers.Add(new ConsoleLoggerProvider(scriptConfig.LogFilter.Filter, includeScopes: true));
+            }
 
             return providers;
         }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -408,13 +408,16 @@ namespace Microsoft.Azure.WebJobs.Script
                         server.Uri,
                         _hostConfig.LoggerFactory);
                 };
-
-                var configFactory = new WorkerConfigFactory(ScriptSettingsManager.Instance.Configuration, _startupLogger);
-                var workerConfigs = configFactory.GetConfigs(new List<IWorkerProvider>()
+                var providers = new List<IWorkerProvider>()
                 {
                     new NodeWorkerProvider(),
                     new JavaWorkerProvider()
-                });
+                };
+
+                providers.AddRange(GenericWorkerProvider.ReadWorkerProviderFromConfig(ScriptConfig, _startupLogger));
+
+                var configFactory = new WorkerConfigFactory(ScriptSettingsManager.Instance.Configuration, _startupLogger);
+                var workerConfigs = configFactory.GetConfigs(providers);
 
                 _functionDispatcher = new FunctionRegistry(EventManager, server, channelFactory, workerConfigs);
 

--- a/src/WebJobs.Script/Rpc/Configuration/GenericWorkerProvider.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/GenericWorkerProvider.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal class GenericWorkerProvider : IWorkerProvider
+    {
+        private WorkerDescription workerDescription;
+        private List<string> arguments;
+
+        public GenericWorkerProvider(WorkerDescription workerDescription, List<string> arguments)
+        {
+            this.workerDescription = workerDescription;
+            this.arguments = arguments;
+        }
+
+        public WorkerDescription GetDescription()
+        {
+            return this.workerDescription;
+        }
+
+        public bool TryConfigureArguments(ArgumentsDescription args, IConfiguration config, ILogger logger)
+        {
+            // TODO: probably shouldn't be like this?
+            if (arguments?.Count > 0)
+            {
+                args.ExecutableArguments.AddRange(arguments);
+            }
+            return true;
+        }
+
+        public static List<IWorkerProvider> ReadWorkerProviderFromConfig(ScriptHostConfiguration config, ILogger logger, ScriptSettingsManager settingsManager = null)
+        {
+            var providers = new List<IWorkerProvider>();
+            settingsManager = settingsManager ?? ScriptSettingsManager.Instance;
+            var assemblyDir = Path.GetDirectoryName(new Uri(typeof(WorkerConfigFactory).Assembly.CodeBase).LocalPath);
+
+            var workerDirPath = settingsManager.Configuration.GetSection("workers:config:path").Value ?? Path.Combine(assemblyDir, "workers");
+
+            foreach (var workerDir in Directory.EnumerateDirectories(workerDirPath))
+            {
+                try
+                {
+                    // check if worker config exists
+                    string workerConfigPath = Path.Combine(workerDir, "worker.config.json"); // TODO: Move to constant
+                    if (!File.Exists(workerConfigPath))
+                    {
+                        // not a worker directory
+                        continue;
+                    }
+
+                    string json = File.ReadAllText(workerConfigPath);
+                    JObject workerConfig = JObject.Parse(json);
+
+                    WorkerDescription description = workerConfig.Property("Description").Value.ToObject<WorkerDescription>();
+                    var workerSettings = settingsManager.Configuration.GetSection($"workers:{description.Language}");
+
+                    var arguments = new List<string>();
+                    arguments.AddRange(workerConfig.Property("Arguments").Value.ToObject<string[]>());
+
+                    var provider = new GenericWorkerProvider(description, arguments);
+
+                    providers.Add(provider);
+                }
+                catch (Exception e)
+                {
+                    logger.LogCritical(e, $"Failed to initialize worker provider for: {workerDir}");
+                }
+            }
+
+            return providers;
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/Configuration/GenericWorkerProvider.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/GenericWorkerProvider.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Azure.WebJobs.Script.Abstractions;
@@ -16,8 +18,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public GenericWorkerProvider(WorkerDescription workerDescription, List<string> arguments)
         {
-            this.workerDescription = workerDescription;
-            this.arguments = arguments;
+            this.workerDescription = workerDescription ?? throw new ArgumentNullException(nameof(workerDescription));
+            this.arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
         }
 
         public WorkerDescription GetDescription()
@@ -27,11 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public bool TryConfigureArguments(ArgumentsDescription args, IConfiguration config, ILogger logger)
         {
-            // TODO: probably shouldn't be like this?
-            if (arguments?.Count > 0)
-            {
-                args.ExecutableArguments.AddRange(arguments);
-            }
+            args.ExecutableArguments.AddRange(arguments);
             return true;
         }
 
@@ -48,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 try
                 {
                     // check if worker config exists
-                    string workerConfigPath = Path.Combine(workerDir, "worker.config.json"); // TODO: Move to constant
+                    string workerConfigPath = Path.Combine(workerDir, ScriptConstants.WorkerConfigFileName); // TODO: Move to constant
                     if (!File.Exists(workerConfigPath))
                     {
                         // not a worker directory
@@ -59,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     JObject workerConfig = JObject.Parse(json);
 
                     WorkerDescription description = workerConfig.Property("Description").Value.ToObject<WorkerDescription>();
-                    var workerSettings = settingsManager.Configuration.GetSection($"workers:{description.Language}");
+                    // var workerSettings = settingsManager.Configuration.GetSection($"workers:{description.Language}");
 
                     var arguments = new List<string>();
                     arguments.AddRange(workerConfig.Property("Arguments").Value.ToObject<string[]>());

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -35,7 +35,15 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 var workerPath = languageSection.GetSection("path").Value;
                 if (string.IsNullOrEmpty(workerPath) && !string.IsNullOrEmpty(description.DefaultWorkerPath))
                 {
-                    workerPath = Path.Combine(_assemblyDir, "workers", description.Language.ToLower(), description.DefaultWorkerPath);
+                    // TODO: This is ugly
+                    if (_config.GetSection("workers:config:path") != null && description.Language != "Node" && description.Language != "Java")
+                    {
+                        workerPath = Path.Combine(_config.GetSection("workers:config:path").Value, description.Language.ToLower(), description.DefaultWorkerPath);
+                    }
+                    else
+                    {
+                        workerPath = Path.Combine(_assemblyDir, "workers", description.Language.ToLower(), description.DefaultWorkerPath);
+                    }
                 }
 
                 var arguments = new ArgumentsDescription()

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -93,9 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     .Subscribe(msg =>
                     {
                         var jsonMsg = JsonConvert.SerializeObject(msg, _verboseSerializerSettings);
-
-                        // TODO: change to trace when ILogger & TraceWriter merge (issues with file trace writer)
-                        _logger.LogInformation(jsonMsg);
+                        _logger.LogTrace(jsonMsg);
                     }));
             }
 

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LogCategoryAdminController = "Host.Controllers.Admin";
         public const string LogCategoryKeysController = "Host.Controllers.Keys";
         public const string LogCategoryHostGeneral = "Host.General";
+        public const string LogCategoryHost = "Host";
+        public const string LogCategoryFunction = "Function";
+        public const string LogCategoryWorker = "Worker";
 
         // Define all system parameters we inject with a prefix to avoid collisions
         // with user parameters
@@ -52,6 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionMetadataFileName = "function.json";
         public const string ProxyMetadataFileName = "proxies.json";
         public const string ExtensionsMetadataFileName = "extensions.json";
+        public const string WorkerConfigFileName = "worker.config.json";
         public const string DefaultMasterKeyName = "master";
         public const string DefaultFunctionKeyName = "default";
 

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -396,9 +396,10 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static LoggerFilterOptions CreateLoggerFilterOptions()
         {
+            // TODO: Whitelist should be configurable
             // Whitelist our log categories to remove large amounts of ASP.NET logs.
             var filterOptions = new LoggerFilterOptions();
-            filterOptions.AddFilter((category, level) => category.StartsWith("Host.") || category.StartsWith("Function."));
+            filterOptions.AddFilter((category, level) => category.StartsWith($"{ScriptConstants.LogCategoryHost}.") || category.StartsWith($"{ScriptConstants.LogCategoryFunction}.") || category.StartsWith($"{ScriptConstants.LogCategoryWorker}."));
 
             return filterOptions;
         }

--- a/test/WebJobs.Script.Tests.Integration/Properties/launchSettings.json
+++ b/test/WebJobs.Script.Tests.Integration/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "WebJobs.Script.Tests.Integration": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests.Integration/appsettings.json
+++ b/test/WebJobs.Script.Tests.Integration/appsettings.json
@@ -1,0 +1,4 @@
+﻿{
+  "AzureWebJobsDashboard": "DefaultEndpointsProtocol=https;AccountName=functiondevchra88b7;AccountKey=RFLh9SgK4lMcyocfKVx9ijTnhR5YW8p9XLjB2HLbbEV3vm6fFuKCTARf5MaD0f1wwFmGe6d3pJDuQq1awT9CnA==",
+  "AzureWebJobsStorage": "DefaultEndpointsProtocol=https;AccountName=functiondevchra88b7;AccountKey=RFLh9SgK4lMcyocfKVx9ijTnhR5YW8p9XLjB2HLbbEV3vm6fFuKCTARf5MaD0f1wwFmGe6d3pJDuQq1awT9CnA=="
+}

--- a/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             WebHostSettings settings = new WebHostSettings();
             settings.SecretsPath = _secretsDirectory.Path;
             _secretsManagerMock = new Mock<ISecretManager>(MockBehavior.Strict);
-            _managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new object[] { config, new TestSecretManagerFactory(_secretsManagerMock.Object), eventManager.Object, _settingsManager, settings, mockRouter.Object, NullLoggerFactory.Instance});
+
+            _managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new object[] { config, new TestSecretManagerFactory(_secretsManagerMock.Object), eventManager.Object, _settingsManager, settings, mockRouter.Object, NullLoggerFactory.Instance });
+
             _managerMock.SetupGet(p => p.Instance).Returns(_hostMock.Object);
 
             _testController = new KeysController(_managerMock.Object, _secretsManagerMock.Object, new LoggerFactory());

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
+{
+    public class GenericWorkerProviderTests
+    {
+        [Fact]
+        public void Constructor_ThrowsNullArgument()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(null, new List<string>()));
+            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(new WorkerDescription(), null));
+        }
+
+        [Fact]
+        public void GetDescription_ReturnsDescription()
+        {
+            var workerDescription = new WorkerDescription();
+            var arguments = new List<string>();
+            var provider = new GenericWorkerProvider(workerDescription, arguments);
+
+            Assert.Equal(workerDescription, provider.GetDescription());
+        }
+
+        [Fact]
+        public void TryConfigureArguments_ReturnsTrue()
+        {
+            var provider = new GenericWorkerProvider(new WorkerDescription(), new List<string>());
+            var args = new ArgumentsDescription();
+
+            Assert.True(provider.TryConfigureArguments(args, null, null));
+        }
+
+        [Fact]
+        public void ReadWorkerProviderFromConfig_ReturnsProviderWithArguments()
+        {
+            string language = "test";
+            var description = new WorkerDescription()
+            {
+                DefaultExecutablePath = "foopath",
+                DefaultWorkerPath = "./src/index.test",
+                Language = "test",
+                Extension = ".test"
+            };
+
+            var arguments = new string[] { "-v", "verbose" };
+
+            JObject config = new JObject();
+            config["Description"] = JObject.FromObject(description);
+            config["Arguments"] = JArray.FromObject(arguments);
+
+            string json = config.ToString();
+
+            var mockLogger = new Mock<ILogger<object>>(MockBehavior.Loose);
+            mockLogger.Setup(x => x.Log<object>(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<object>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()));
+
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            var providers = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
+
+            mockLogger.Verify(x => x.Log<object>(
+               It.IsAny<LogLevel>(),
+               It.IsAny<EventId>(),
+               It.IsAny<object>(),
+               It.IsAny<Exception>(),
+               It.IsAny<Func<object, Exception, string>>()), Times.Never());
+
+            Assert.Single(providers);
+        }
+
+        [Fact]
+        public void ReadWorkerProviderFromConfig_ReturnsProviderNoArguments()
+        {
+            string language = "test";
+            var description = new WorkerDescription()
+            {
+                DefaultExecutablePath = "foopath",
+                DefaultWorkerPath = "./src/index.test",
+                Language = "test",
+                Extension = ".test"
+            };
+
+            var arguments = new string[] { };
+
+            JObject config = new JObject();
+            config["Description"] = JObject.FromObject(description);
+            config["Arguments"] = JArray.FromObject(arguments);
+
+            string json = config.ToString();
+
+            var mockLogger = new Mock<ILogger<object>>(MockBehavior.Loose);
+            mockLogger.Setup(x => x.Log<object>(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<object>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()));
+
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            var providers = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
+
+            mockLogger.Verify(x => x.Log<object>(
+               It.IsAny<LogLevel>(),
+               It.IsAny<EventId>(),
+               It.IsAny<object>(),
+               It.IsAny<Exception>(),
+               It.IsAny<Func<object, Exception, string>>()), Times.Never());
+
+            Assert.Single(providers);
+        }
+
+        [Fact]
+        public void ReadWorkerProviderFromConfig_BadConfigFile()
+        {
+            string language = "test";
+            var description = new WorkerDescription()
+            {
+                DefaultExecutablePath = "foopath",
+                DefaultWorkerPath = "./src/index.test",
+                Language = "test",
+                Extension = ".test"
+            };
+
+            var arguments = new string[] { };
+
+            string json = "garbage";
+
+            var mockLogger = new Mock<ILogger<object>>(MockBehavior.Loose);
+            mockLogger.Setup(x => x.Log<object>(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<object>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()));
+
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            var providers = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
+
+            mockLogger.Verify(x => x.Log<object>(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<object>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Once());
+
+            Assert.Empty(providers);
+        }
+
+        private IEnumerable<IWorkerProvider> TestReadWorkerProviderFromConfig(string language, string json, string[] arguments, Mock<ILogger<object>> mockLogger)
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string workerPath = Path.Combine(rootPath, language);
+            try
+            {
+                Directory.CreateDirectory(workerPath);
+
+                File.WriteAllText(Path.Combine(workerPath, ScriptConstants.WorkerConfigFileName), json);
+
+                var scriptHostConfig = new ScriptHostConfiguration();
+                var scriptSettingsManager = new ScriptSettingsManager();
+                var settings = new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("workers:config:path", rootPath)
+                };
+                scriptSettingsManager.SetConfigurationFactory(() => new ConfigurationBuilder()
+                    .AddInMemoryCollection(settings).Build());
+                return GenericWorkerProvider.ReadWorkerProviderFromConfig(scriptHostConfig, mockLogger.Object, scriptSettingsManager);
+            }
+            finally
+            {
+                if (Directory.Exists(rootPath))
+                {
+                    Directory.Delete(rootPath, true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-webjobs-sdk-script/issues/2319

Notes:
 - Allows you to create a "workers" directory and specify it with `workers:config:path`
 - "workers" directory contains directories for each language worker
 - directory name needs to match `Language` in the config (and be lower case)
 - each directory contains config file named "worker.config.json" with content like:
```json
{
    "Description":{
        "Language":"python",
        "Extension":".py",
        "DefaultExecutablePath":"python",
        "DefaultWorkerPath":"worker.py"
        
    },
    "Arguments":[]
}
```
 - `DefaultWorkerPath` is a relative path, so `./src/worker.py` is valid