### PR TITLE
Ensure host started up on specialization timer

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebApiConfig.cs
@@ -20,10 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             Register(config, settingsManager, settings, dependencyCallback);
 
             var scriptHostManager = config.DependencyResolver.GetService<WebScriptHostManager>();
-            if (scriptHostManager != null && !scriptHostManager.Initialized)
-            {
-                scriptHostManager.Initialize();
-            }
+            scriptHostManager?.EnsureInitialized();
         }
 
         public static void Register(HttpConfiguration config, ScriptSettingsManager settingsManager = null,

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -268,6 +268,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private void OnSpecializationTimerTick(object state)
         {
             EnsureInitialized((WebHostSettings)state);
+
+            // We know we've just specialized, since this timer only runs
+            // when in standby mode. We want to initialize the host manager
+            // immediately. Note that the host might also be initialized
+            // concurrently  by incoming http requests, but the initialization
+            // here ensures that it takes place in the absence of any http
+            // traffic.
+            _activeHostManager?.EnsureInitialized();
         }
 
         private static void InitializeFileSystem()

--- a/src/WebJobs.Script.WebHost/Global.asax.cs
+++ b/src/WebJobs.Script.WebHost/Global.asax.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             using (var metricsLogger = new WebHostMetricsLogger())
             using (metricsLogger.LatencyEvent(MetricEventNames.ApplicationStartLatency))
             {
+                // this startup call ensures that the host is started when the WebApp starts
                 GlobalConfiguration.Configure(c => WebApiConfig.Initialize(c, settingsManager, webHostSettings));
             }
         }

--- a/src/WebJobs.Script.WebHost/Handlers/WebScriptHostHandler.cs
+++ b/src/WebJobs.Script.WebHost/Handlers/WebScriptHostHandler.cs
@@ -28,13 +28,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Handlers
             SetRequestId(request);
 
             var resolver = _config.DependencyResolver;
+
+            // Need to ensure the host manager is initialized early in the pipeline
+            // before any other request code runs.
             var scriptHostManager = resolver.GetService<WebScriptHostManager>();
-            if (!scriptHostManager.Initialized)
-            {
-                // need to ensure the host manager is initialized early in the pipeline
-                // before any other request code runs
-                scriptHostManager.Initialize();
-            }
+            scriptHostManager.EnsureInitialized();
 
             var webHostSettings = resolver.GetService<WebHostSettings>();
             if (webHostSettings.IsAuthDisabled)

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -118,14 +118,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public HttpRequestManager HttpRequestManager => _httpRequestManager;
 
-        public virtual bool Initialized
-        {
-            get
-            {
-                return _hostStarted;
-            }
-        }
-
         public static bool InStandbyMode
         {
             get
@@ -192,7 +184,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return response;
         }
 
-        public void Initialize()
+        /// <summary>
+        /// Ensures that the host has been fully initialized and startup
+        /// has been initiated. This method is idempotent.
+        /// </summary>
+        public virtual void EnsureInitialized()
         {
             lock (_syncLock)
             {

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets the collection of all valid Functions. For functions that are in error
         /// and were unable to load successfully, consult the <see cref="FunctionErrors"/> collection.
         /// </summary>
-        public virtual Collection<FunctionDescriptor> Functions { get; private set; }
+        public virtual Collection<FunctionDescriptor> Functions { get; private set; } = new Collection<FunctionDescriptor>();
 
         // Maps from FunctionName to a set of errors for that function.
         public virtual Dictionary<string, Collection<string>> FunctionErrors { get; private set; }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
@@ -112,21 +112,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 // Now specialize the host
                 ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
-                request = new HttpRequestMessage(HttpMethod.Get, "api/dne");
-                response = await httpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+                // give time for the specialization to happen
+                await Task.Delay(2000);
 
                 httpServer.Dispose();
                 httpClient.Dispose();
 
                 await Task.Delay(2000);
 
+                var hostConfig = WebHostResolver.CreateScriptHostConfiguration(webHostSettings, true);
+                var expectedHostId = hostConfig.HostConfig.HostId;
+
                 string[] logLines = traceWriter.Traces.Select(p => p.Message).ToArray();
-                int stopCount = logLines.Count(p => p.Contains("Stopping Host"));
-                Assert.True(stopCount >= 1);
+                string text = string.Join(Environment.NewLine, logLines);
+                Assert.True(logLines.Count(p => p.Contains("Stopping Host")) > 1);
+                Assert.Equal(1, logLines.Count(p => p.Contains("Creating StandbyMode placeholder function directory")));
+                Assert.Equal(1, logLines.Count(p => p.Contains("StandbyMode placeholder function directory created")));
+                Assert.Equal(2, logLines.Count(p => p.Contains("Starting Host (HostId=placeholder-host")));
                 Assert.Equal(2, logLines.Count(p => p.Contains("Host is in standby mode")));
                 Assert.Equal(2, logLines.Count(p => p.Contains("Executed 'Functions.WarmUp' (Succeeded")));
                 Assert.Equal(1, logLines.Count(p => p.Contains("Starting host specialization")));
+                Assert.Equal(1, logLines.Count(p => p.Contains($"Starting Host (HostId={expectedHostId}")));
+                Assert.Contains("Generating 0 job function(s)", logLines);
 
                 WebScriptHostManager.ResetStandbyMode();
             }

--- a/test/WebJobs.Script.Tests/Handlers/WebScriptHostHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Handlers/WebScriptHostHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new ScriptHostConfiguration(), new TestSecretManagerFactory(), eventManager.Object,
                 _settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path }, null, null, null, 1, 50);
 
-            _managerMock.SetupGet(p => p.Initialized).Returns(true);
+            _managerMock.Setup(p => p.EnsureInitialized());
             Mock<IDependencyResolver> mockResolver = new Mock<IDependencyResolver>(MockBehavior.Strict);
             mockResolver.Setup(p => p.GetService(typeof(WebScriptHostManager))).Returns(_managerMock.Object);
 


### PR DESCRIPTION
The previous fix for https://github.com/Azure/azure-webjobs-sdk-script/issues/2201 wasn't complete. While we were doing specialization correctly, we weren't ensuring host startup happened. We were still relying on http traffic to initiate that.