### PR TITLE
Disabling ASP.NET version header

### DIFF
--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -35,7 +35,7 @@
           <clear />
         </namespaces>
       </pages>
-      <httpRuntime targetFramework="4.5" maxRequestLength="102400" maxUrlLength="8192" maxQueryStringLength="4096" requestPathInvalidCharacters="" />
+      <httpRuntime targetFramework="4.5" maxRequestLength="102400" maxUrlLength="8192" maxQueryStringLength="4096" requestPathInvalidCharacters="" enableVersionHeader="false"/>
     </system.web>
   </location>
   <system.webServer>


### PR DESCRIPTION
Removes the x-aspnet-version header. Related to https://github.com/Azure/azure-webjobs-sdk-script/issues/1237