### PR TITLE
test improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
 
     Install-Product node 6.11.2 x86
 build_script:
-- cmd: msbuild "WebJobs.Script.proj" /target:EnableSkipStrongNames;PackageScriptHost;PackageWebHost;TestBuild /verbosity:normal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Buildnumber=%APPVEYOR_BUILD_NUMBER%;Configuration=Release
+- cmd: msbuild "WebJobs.Script.proj" /target:EnableSkipStrongNames;PackageScriptHost;PackageWebHost;TestBuild /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Buildnumber=%APPVEYOR_BUILD_NUMBER%;Configuration=Release
 test_script:
 - ps: .\runappveyortests.ps1
 artifacts:

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -98,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 
         public class TestTelemetryChannel : ITelemetryChannel
         {
-            public IList<ITelemetry> Telemetries { get; private set; } = new List<ITelemetry>();
+            public ConcurrentBag<ITelemetry> Telemetries { get; private set; } = new ConcurrentBag<ITelemetry>();
 
             public bool? DeveloperMode { get; set; }
 

--- a/test/WebJobs.Script.Tests.Integration/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EndToEndTestsBase.cs
@@ -485,7 +485,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             await TestHelpers.Await(() =>
             {
-                traceEvent = Fixture.TraceWriter.Traces.SingleOrDefault(filter);
+                traceEvent = Fixture.TraceWriter.GetTraces().SingleOrDefault(filter);
                 return traceEvent != null;
             });
 

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 TestHelpers.WaitForWebHost(httpClient);
 
-                var traces = traceWriter.Traces.ToArray();
+                var traces = traceWriter.GetTraces().ToArray();
                 Assert.Equal($"Creating StandbyMode placeholder function directory ({Path.GetTempPath()}Functions\\Standby\\WWWRoot)", traces[0].Message);
                 Assert.Equal("StandbyMode placeholder function directory created", traces[1].Message);
 
@@ -126,8 +126,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 await TestHelpers.Await(() =>
                 {
                     // wait for the trace indicating that the host has been specialized
-                    logLines = traceWriter.Traces.Select(p => p.Message).ToArray();
-                    return logLines.Count(p => p.Contains($"Starting Host (HostId={expectedHostId}")) == 1;
+                    logLines = traceWriter.GetTraces().Select(p => p.Message).ToArray();
+                    return logLines.Contains("Generating 0 job function(s)");
                 });
 
                 // verify the rest of the expected logs
@@ -140,7 +140,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(2, logLines.Count(p => p.Contains("Executed 'Functions.WarmUp' (Succeeded")));
                 Assert.Equal(1, logLines.Count(p => p.Contains("Starting host specialization")));
                 Assert.Equal(1, logLines.Count(p => p.Contains($"Starting Host (HostId={expectedHostId}")));
-                Assert.Contains("Generating 0 job function(s)", logLines);
 
                 WebScriptHostManager.ResetStandbyMode();
             }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             using (new TestEnvironment())
             {
-                _traceWriter.Traces.Clear();
+                _traceWriter.ClearTraces();
 
                 var settings = GetWebHostSettings();
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _webHostResolver.EnsureInitialized(settings);
 
                 // ensure specialization message is NOT written
-                var traces = _traceWriter.Traces.ToArray();
+                var traces = _traceWriter.GetTraces();
                 var traceEvent = traces.SingleOrDefault(p => p.Message.Contains(Resources.HostSpecializationTrace));
                 Assert.Null(traceEvent);
             }
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             using (new TestEnvironment())
             {
-                _traceWriter.Traces.Clear();
+                _traceWriter.ClearTraces();
 
                 var settings = GetWebHostSettings();
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.False(WebScriptHostManager.InStandbyMode);
                 _webHostResolver.EnsureInitialized(settings);
 
-                var traces = _traceWriter.Traces.ToArray();
+                var traces = _traceWriter.GetTraces();
                 var traceEvent = traces.Last();
                 Assert.Equal(Resources.HostSpecializationTrace, traceEvent.Message);
                 Assert.Equal(TraceLevel.Info, traceEvent.Level);

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
@@ -29,9 +29,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
             await RunTimeoutExceptionTest(trace, handleCancellation: false);
 
             await TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running), userMessage: "Expected host to not be running");
-            Assert.DoesNotContain(trace.Traces, t => t.Message.StartsWith("Done"));
-            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
-            Assert.Contains(trace.Traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
+
+            var traces = trace.GetTraces();
+            Assert.DoesNotContain(traces, t => t.Message.StartsWith("Done"));
+            Assert.Contains(traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
+            Assert.Contains(traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
         }
 
         [Fact]
@@ -44,9 +46,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
             // wait a few seconds to make sure the manager doesn't die
             await Assert.ThrowsAsync<ApplicationException>(() => TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running),
                 timeout: 3000, throwWhenDebugging: true, userMessage: "Expected host manager not to die"));
-            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Done"));
-            Assert.Contains(trace.Traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
-            Assert.DoesNotContain(trace.Traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
+
+            var traces = trace.GetTraces();
+            Assert.Contains(traces, t => t.Message.StartsWith("Done"));
+            Assert.Contains(traces, t => t.Message.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
+            Assert.DoesNotContain(traces, t => t.Message == "A function timeout has occurred. Host is shutting down.");
         }
 
         private async Task RunTimeoutExceptionTest(TraceWriter trace, bool handleCancellation)

--- a/test/WebJobs.Script.Tests.Integration/PrimaryHostCoordinatorTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/PrimaryHostCoordinatorTests.cs
@@ -178,10 +178,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 renewResetEvent.Wait(TimeSpan.FromSeconds(10));
 
                 // Make sure we have enough time to trace the renewal
-                await TestHelpers.Await(() => traceWriter.Traces.Count == 1, 5000, 500);
+                await TestHelpers.Await(() => traceWriter.GetTraces().Count == 1, 5000, 500);
             }
 
-            TraceEvent acquisitionEvent = traceWriter.Traces.First();
+            TraceEvent acquisitionEvent = traceWriter.GetTraces().First();
             Assert.Contains($"Host lock lease acquired by instance ID '{instanceId}'.", acquisitionEvent.Message);
             Assert.Equal(TraceLevel.Info, acquisitionEvent.Level);
         }
@@ -206,14 +206,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             using (var manager = new PrimaryHostCoordinator(blobMock.Object, TimeSpan.FromSeconds(5), hostId, instanceId, traceWriter, null))
             {
                 renewResetEvent.Wait(TimeSpan.FromSeconds(10));
-                await TestHelpers.Await(() => traceWriter.Traces.Count == 2, 5000, 500);
+                await TestHelpers.Await(() => traceWriter.GetTraces().Count == 2, 5000, 500);
             }
 
-            TraceEvent acquisitionEvent = traceWriter.Traces.First();
+            TraceEvent acquisitionEvent = traceWriter.GetTraces().First();
             Assert.Contains($"Host lock lease acquired by instance ID '{instanceId}'.", acquisitionEvent.Message);
             Assert.Equal(TraceLevel.Info, acquisitionEvent.Level);
 
-            TraceEvent renewalEvent = traceWriter.Traces.Skip(1).First();
+            TraceEvent renewalEvent = traceWriter.GetTraces().Skip(1).First();
             string pattern = @"Failed to renew host lock lease: Another host has acquired the lease. The last successful renewal completed at (.+) \([0-9]+ milliseconds ago\) with a duration of [0-9]+ milliseconds.";
             Assert.True(Regex.IsMatch(renewalEvent.Message, pattern), $"Expected trace event {pattern} not found.");
             Assert.Equal(TraceLevel.Info, renewalEvent.Level);

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -112,7 +112,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
 
             DirectoryInfo directory = GetFunctionLogFileDirectory(functionName);
-            FileInfo lastLogFile = directory.GetFiles("*.log").OrderByDescending(p => p.LastWriteTime).FirstOrDefault();
+            FileInfo lastLogFile = null;
+
+            if (directory.Exists)
+            {
+                 lastLogFile = directory.GetFiles("*.log").OrderByDescending(p => p.LastWriteTime).FirstOrDefault();
+            }
 
             if (lastLogFile != null)
             {

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
@@ -79,18 +79,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             await TestHelpers.Await(() =>
             {
-                return dependencies.TraceWriter.Traces.Any(t => t.Message.Contains("Compilation failed.")) &&
-                 dependencies.TraceWriter.Traces.Any(t => t.Message.Contains(DotNetConstants.MissingFunctionEntryPointCompilationCode));
+                var traces = dependencies.TraceWriter.GetTraces();
+                return traces.Any(t => t.Message.Contains("Compilation failed.")) &&
+                 traces.Any(t => t.Message.Contains(DotNetConstants.MissingFunctionEntryPointCompilationCode));
             });
 
-            dependencies.TraceWriter.Traces.Clear();
+            dependencies.TraceWriter.ClearTraces();
 
             CompilationErrorException resultException = await Assert.ThrowsAsync<CompilationErrorException>(() => invoker.GetFunctionTargetAsync());
 
             await TestHelpers.Await(() =>
             {
-                return dependencies.TraceWriter.Traces.Any(t => t.Message.Contains("Function compilation error")) &&
-                 dependencies.TraceWriter.Traces.Any(t => t.Message.Contains(DotNetConstants.MissingFunctionEntryPointCompilationCode));
+                var traces = dependencies.TraceWriter.GetTraces();
+                return traces.Any(t => t.Message.Contains("Function compilation error")) &&
+                 traces.Any(t => t.Message.Contains(DotNetConstants.MissingFunctionEntryPointCompilationCode));
             });
         }
 
@@ -145,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     throw new Exception(compilationDetails, exc);
                 }
 
-                Assert.Contains(dependencies.TraceWriter.Traces,
+                Assert.Contains(dependencies.TraceWriter.GetTraces(),
                     t => t.Message.Contains($"warning {DotNetConstants.MissingBindingArgumentCompilationCode}") && t.Message.Contains("'TestBinding'"));
             }
         }
@@ -204,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 }
 
                 // Verify that logs on the second instance were suppressed
-                int count = dependencies.TraceWriter.Traces.Count();
+                int count = dependencies.TraceWriter.GetTraces().Count();
                 Assert.Equal(0, count);
             }
         }
@@ -295,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(expectedAttempt.ToString(), exception.Message);
             }
 
-            var compilerErrorTraces = dependencies.TraceWriter.Traces
+            var compilerErrorTraces = dependencies.TraceWriter.GetTraces()
                 .Where(t => string.Equals(t.Message, "Function loader reset. Failed compilation result will not be cached."));
 
             // 3 attempts total, make sure we've logged the 2 retries.

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoaderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoaderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
@@ -57,9 +58,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assembly result = resolver.ResolveAssembly(AppDomain.CurrentDomain, new System.ResolveEventArgs("MyTestAssembly.dll",
                 new TestAssembly(new AssemblyName("MyDirectReference"), @"file:///c:/testroot/test2/bin/MyDirectReference.dll")));
 
+            var traces = traceWriter.GetTraces();
             Assert.Null(result);
-            Assert.Equal(1, traceWriter.Traces.Count);
-            Assert.Contains("MyTestAssembly.dll", traceWriter.Traces[0].Message);
+            Assert.Equal(1, traces.Count);
+            Assert.Contains("MyTestAssembly.dll", traces.First().Message);
         }
 
         private class TestAssembly : Assembly

--- a/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
@@ -52,12 +52,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void TraceOnPrimaryHost_WritesExpectedLogs()
         {
-            _traceWriter.Traces.Clear();
+            _traceWriter.ClearTraces();
 
             _invoker.TraceOnPrimaryHost("Test message", TraceLevel.Info, "TestSource");
 
-            Assert.Equal(1, _traceWriter.Traces.Count);
-            var trace = _traceWriter.Traces[0];
+            var traces = _traceWriter.GetTraces();
+            Assert.Equal(1, traces.Count);
+            var trace = traces.First();
             Assert.Equal("Test message", trace.Message);
             Assert.Equal(TraceLevel.Info, trace.Level);
             Assert.Equal("TestSource", trace.Source);
@@ -110,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var completedStartEvent = (FunctionStartedEvent)_metricsLogger.MetricEventsEnded[0];
             Assert.Same(startedEvent, completedStartEvent);
             Assert.True(completedStartEvent.Success);
-            var message = _traceWriter.Traces.Last().Message;
+            var message = _traceWriter.GetTraces().Last().Message;
             Assert.True(Regex.IsMatch(message, $"Function completed \\(Success, Id={executionContext.InvocationId}, Duration=[0-9]*ms\\)"));
 
             // verify latency event
@@ -140,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(2, _metricsLogger.MetricEventsEnded.Count);
             Assert.Equal(2, _metricsLogger.EventsEnded.Count);
 
-            var completionEvents = _traceWriter.Traces
+            var completionEvents = _traceWriter.GetTraces()
                 .Select(e => Regex.Match(e.Message, $"Function completed \\(Success, Id={executionContext.InvocationId}, Duration=(?'duration'[0-9]*)ms\\)"))
                 .Where(m => m.Success)
                 .ToList();
@@ -180,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var completedStartEvent = (FunctionStartedEvent)_metricsLogger.MetricEventsEnded[0];
             Assert.Same(startedEvent, completedStartEvent);
             Assert.False(completedStartEvent.Success);
-            var message = _traceWriter.Traces.Last().Message;
+            var message = _traceWriter.GetTraces().Last().Message;
             Assert.True(Regex.IsMatch(message, $"Function completed \\(Failure, Id={executionContext.InvocationId}, Duration=[0-9]*ms\\)"));
 
             // verify latency event

--- a/test/WebJobs.Script.Tests/Diagnostics/CompositeTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/CompositeTraceWriterTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string message = "Test trace";
             compositeWriter.Verbose(message);
 
-            TraceEvent trace = traceWriter.Traces.FirstOrDefault();
+            TraceEvent trace = traceWriter.GetTraces().FirstOrDefault();
 
             Assert.NotNull(trace);
             Assert.Equal(TraceLevel.Verbose, trace.Level);
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             compositeWriter.Verbose(message);
             compositeWriter.Error(message);
 
-            Assert.Equal(1, traceWriter.Traces.Count);
+            Assert.Equal(1, traceWriter.GetTraces().Count);
 
-            TraceEvent trace = traceWriter.Traces.First();
+            TraceEvent trace = traceWriter.GetTraces().First();
 
             Assert.Equal(TraceLevel.Error, trace.Level);
             Assert.Equal(message, trace.Message);

--- a/test/WebJobs.Script.Tests/Diagnostics/FastLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FastLoggerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var ex = new InvalidOperationException("Boom!");
             FunctionInstanceLogger.OnException(ex, trace);
 
-            TraceEvent traceEvent = trace.Traces.Single();
+            TraceEvent traceEvent = trace.GetTraces().Single();
             Assert.StartsWith("Error writing logs to table storage: System.InvalidOperationException: Boom!", traceEvent.Message);
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Same(ex, traceEvent.Exception);

--- a/test/WebJobs.Script.Tests/Diagnostics/FileLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileLoggerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             // FunctionName comes from scope -- call with no scope values
             logger.Log(LogLevel.Information, 0, new FormattedLogValues("Some Message"), null, (s, e) => s.ToString());
 
-            Assert.Empty(trace.Traces);
+            Assert.Empty(trace.GetTraces());
             factoryMock.Verify(f => f.Create(It.IsAny<string>(), null), Times.Never);
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 logger.Log(LogLevel.Information, 0, new FormattedLogValues("Some Message"), null, (s, e) => s.ToString());
             }
 
-            var traceEvent = trace.Traces.Single();
+            var traceEvent = trace.GetTraces().Single();
             Assert.Equal(TraceLevel.Info, traceEvent.Level);
             Assert.Equal("Some Message", traceEvent.Message);
             Assert.Equal("SomeCategory", traceEvent.Source);

--- a/test/WebJobs.Script.Tests/Diagnostics/HostPerformanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HostPerformanceManagerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             value = "this is not json";
             counters = performanceManager.GetPerformanceCounters(traceWriter);
             Assert.Null(counters);
-            var error = traceWriter.Traces.Last();
+            var error = traceWriter.GetTraces().Last();
             Assert.Equal("Failed to deserialize application performance counters. JSON Content: \"this is not json\"", error.Message);
         }
 

--- a/test/WebJobs.Script.Tests/Diagnostics/TraceWriterExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/TraceWriterExtensionsTests.cs
@@ -22,16 +22,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             wrappedTraceWriter.Info("Test2", "CustomSource");
             wrappedTraceWriter.Info("Test3", string.Empty);
 
-            Assert.Equal(3, testTraceWriter.Traces.Count);
+            var traces = testTraceWriter.GetTraces().ToArray();
+            Assert.Equal(3, traces.Length);
 
-            Assert.Equal("Test1", testTraceWriter.Traces[0].Message);
-            Assert.Equal("TestDefault", testTraceWriter.Traces[0].Source);
+            Assert.Equal("Test1", traces[0].Message);
+            Assert.Equal("TestDefault", traces[0].Source);
 
-            Assert.Equal("Test2", testTraceWriter.Traces[1].Message);
-            Assert.Equal("CustomSource", testTraceWriter.Traces[1].Source);
+            Assert.Equal("Test2", traces[1].Message);
+            Assert.Equal("CustomSource", traces[1].Source);
 
-            Assert.Equal("Test3", testTraceWriter.Traces[2].Message);
-            Assert.Equal("TestDefault", testTraceWriter.Traces[2].Source);
+            Assert.Equal("Test3", traces[2].Message);
+            Assert.Equal("TestDefault", traces[2].Source);
         }
 
         [Fact]
@@ -40,10 +41,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             TestTraceWriter traceWriter = new TestTraceWriter(TraceLevel.Verbose);
 
             traceWriter.Info("Test message");
-            var traceEvent = traceWriter.Traces.Single();
+            var traceEvent = traceWriter.GetTraces().Single();
             Assert.Equal(0, traceEvent.Properties.Count);
 
-            traceWriter.Traces.Clear();
+            traceWriter.ClearTraces();
             var properties = new Dictionary<string, object>
             {
                 { "Foo", 123 },
@@ -52,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var interceptingTraceWriter = traceWriter.Apply(properties);
 
             interceptingTraceWriter.Info("Test message");
-            traceEvent = traceWriter.Traces.Single();
+            traceEvent = traceWriter.GetTraces().Single();
             Assert.Equal(2, traceEvent.Properties.Count);
             Assert.Equal(123, traceEvent.Properties["Foo"]);
             Assert.Equal(456, traceEvent.Properties["Bar"]);
@@ -114,9 +115,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             traceWriter.Trace("test", TraceLevel.Verbose, properties);
 
-            Assert.Equal(1, traceWriter.Traces.Count);
+            Assert.Equal(1, traceWriter.GetTraces().Count);
 
-            var trace = traceWriter.Traces.First();
+            var trace = traceWriter.GetTraces().First();
             foreach (var property in properties)
             {
                 Assert.True(trace.Properties.ContainsKey(property.Key));
@@ -129,9 +130,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var traceWriter = new TestTraceWriter(level);
             traceHandler(traceWriter);
 
-            Assert.Equal(1, traceWriter.Traces.Count);
-            Assert.Equal(level, traceWriter.Traces.First().Level);
-            Assert.Equal(message, traceWriter.Traces.First().Message);
+            var traces = traceWriter.GetTraces();
+            Assert.Equal(1, traces.Count);
+            Assert.Equal(level, traces.First().Level);
+            Assert.Equal(message, traces.First().Message);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Handlers/SystemTraceHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Handlers/SystemTraceHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Handlers
 
             await _invoker.SendAsync(request, CancellationToken.None);
 
-            var traces = _traceWriter.Traces.ToArray();
+            var traces = _traceWriter.GetTraces().ToArray();
             Assert.Equal(3, traces.Length);
 
             // validate executing trace

--- a/test/WebJobs.Script.Tests/IO/AutoRecoveringFileSystemWatcherTests.cs
+++ b/test/WebJobs.Script.Tests/IO/AutoRecoveringFileSystemWatcherTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.IO
 
                 await TestHelpers.Await(() =>
                 {
-                    return traceWriter.Traces.Count == expectedTracesBeforeRecovery;
+                    return traceWriter.GetTraces().Count == expectedTracesBeforeRecovery;
                 }, pollingInterval: 500);
 
                 if (isFailureScenario)
@@ -102,14 +102,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.IO
 
                 await TestHelpers.Await(() =>
                 {
-                    return traceWriter.Traces.Count == expectedTracesAfterRecovery;
+                    return traceWriter.GetTraces().Count == expectedTracesAfterRecovery;
                 }, pollingInterval: 500);
 
-                TraceEvent failureEvent = traceWriter.Traces.First();
+                TraceEvent failureEvent = traceWriter.GetTraces().First();
                 Assert.Equal(TraceLevel.Warning, failureEvent.Level);
                 Assert.Contains("Failure detected", failureEvent.Message);
 
-                var retryEvents = traceWriter.Traces.Where(t => t.Level == TraceLevel.Warning).Skip(1).ToList();
+                var retryEvents = traceWriter.GetTraces().Where(t => t.Level == TraceLevel.Warning).Skip(1).ToList();
 
                 if (isFailureScenario)
                 {
@@ -134,18 +134,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.IO
                         $"Recovering interval did not meet the expected interval (expected '{expectedInterval}', actual '{intervalInSeconds}");
                 }
 
-                Assert.True(traceWriter.Traces.All(t => t.Message.EndsWith(fileWatcherLogSuffix)));
+                Assert.True(traceWriter.GetTraces().All(t => t.Message.EndsWith(fileWatcherLogSuffix)));
 
                 if (isFailureScenario)
                 {
-                    Assert.Contains("Recovery process aborted.", traceWriter.Traces.Last().Message);
+                    Assert.Contains("Recovery process aborted.", traceWriter.GetTraces().Last().Message);
                 }
                 else
                 {
-                    Assert.Contains("File watcher recovered.", traceWriter.Traces.Last().Message);
+                    Assert.Contains("File watcher recovered.", traceWriter.GetTraces().Last().Message);
                 }
 
-                Assert.Equal(ScriptConstants.TraceSourceFileWatcher, traceWriter.Traces.Last().Source);
+                Assert.Equal(ScriptConstants.TraceSourceFileWatcher, traceWriter.GetTraces().Last().Source);
             }
         }
 

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1122,7 +1122,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var logMessage = logger.LogMessages.Single(l => l.FormattedMessage.StartsWith("Host configuration ")).FormattedMessage;
             Assert.Equal(expectedMessgae, logMessage);
 
-            var traceMessage = traceWriter.Traces.Single(t => t.Message.StartsWith("Host configuration ")).Message;
+            var traceMessage = traceWriter.GetTraces().Single(t => t.Message.StartsWith("Host configuration ")).Message;
             Assert.Equal(expectedMessgae, traceMessage);
         }
 
@@ -1232,7 +1232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 }
             }
 
-            Assert.Equal(4, trace.Traces.Count);
+            Assert.Equal(4, trace.GetTraces().Count);
             Assert.Equal(4, channel.Telemetries.Count);
 
             var traces = channel.Telemetries.Cast<TraceTelemetry>().OrderBy(t => t.Message).ToArray();

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
                 Assert.Equal(2, result.Keys.Count);
                 Assert.True(functionSecretsConverted, "Function secrets were not persisted");
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
             }
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.Equal("!" + hostSecrets.MasterKey, result.MasterKey.Value);
                 Assert.True(functionSecretsConverted, "Function secrets were not persisted");
                 Assert.True(systemSecretsConverted, "System secrets were not persisted");
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
             }
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.Equal(0, hostSecrets.SystemKeys.Count);
                 Assert.Equal(persistedSecrets.MasterKey.Value, hostSecrets.MasterKey);
                 Assert.Equal(persistedSecrets.FunctionKeys.First().Value, hostSecrets.FunctionKeys.First().Value);
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
             }
         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.True(functionSecretsExists);
                 Assert.Equal(1, functionSecrets.Count);
                 Assert.Equal(ScriptConstants.DefaultFunctionKeyName, functionSecrets.Keys.First());
-                Assert.True(traceWriter.Traces.Any(
+                Assert.True(traceWriter.GetTraces().Any(
                     t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage, StringComparison.OrdinalIgnoreCase) > -1),
                     "Expected Trace message not found");
             }
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.NotNull(persistedSecrets);
                 Assert.Equal(result.Secret, persistedSecrets.Keys.First().Value);
                 Assert.Equal(secretName, persistedSecrets.Keys.First().Name, StringComparer.Ordinal);
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
                     "Expected Trace message not found");
             }
         }
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.NotNull(persistedSecrets);
                 Assert.Equal(result.Secret, persistedSecrets.Keys.First().Value);
                 Assert.Equal(secretName, persistedSecrets.Keys.First().Name, StringComparer.Ordinal);
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
                     "Expected Trace message not found");
             }
         }
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             Assert.Equal(result.Secret, newSecret.Value);
             Assert.Equal(secretName, newSecret.Name, StringComparer.Ordinal);
             Assert.NotNull(persistedSecrets.MasterKey);
-            Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
+            Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
                 "Expected Trace message not found");
         }
 
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.NotNull(persistedSecrets.MasterKey);
                 Assert.Equal(OperationResult.Updated, result.Result);
                 Assert.Equal(testSecret, result.Secret);
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1));
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1));
             }
         }
 
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.NotNull(persistedSecrets.MasterKey);
                 Assert.Equal(OperationResult.Created, result.Result);
                 Assert.Equal(result.Secret, persistedSecrets.MasterKey.Value);
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Info && t.Message.IndexOf(expectedTraceMessage) > -1),
                     "Expected Trace message not found");
             }
         }
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
                 Assert.False(preExistingFile);
                 Assert.True(fileCreated);
-                Assert.True(traceWriter.Traces.Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
+                Assert.True(traceWriter.GetTraces().Any(t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage) > -1));
             }
             finally
             {
@@ -532,7 +532,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.Equal(result.MasterKey.Value, "!cryptoError");
                 Assert.Equal(1, Directory.GetFiles(directory.Path, $"host.{ScriptConstants.Snapshot}*").Length);
 
-                Assert.True(traceWriter.Traces.Any(
+                Assert.True(traceWriter.GetTraces().Any(
                     t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage, StringComparison.OrdinalIgnoreCase) > -1),
                     "Expected Trace message not found");
             }
@@ -577,7 +577,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.Equal(result.GetFunctionKey("Key1", functionName).Value, "!cryptoError");
                 Assert.Equal(1, Directory.GetFiles(directory.Path, $"{functionName}.{ScriptConstants.Snapshot}*").Length);
 
-                Assert.True(traceWriter.Traces.Any(
+                Assert.True(traceWriter.GetTraces().Any(
                     t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage, StringComparison.OrdinalIgnoreCase) > -1),
                     "Expected Trace message not found");
             }
@@ -627,7 +627,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 }
 
                 Assert.True(Directory.GetFiles(directory.Path, $"{functionName}.{ScriptConstants.Snapshot}*").Length >= ScriptConstants.MaximumSecretBackupCount);
-                Assert.True(traceWriter.Traces.Any(
+                Assert.True(traceWriter.GetTraces().Any(
                     t => t.Level == TraceLevel.Verbose && t.Message.IndexOf(expectedTraceMessage, StringComparison.OrdinalIgnoreCase) > -1),
                     "Expected Trace message not found");
             }

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -86,7 +86,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             sw.Start();
             await Utility.DelayWithBackoffAsync(2, CancellationToken.None);
             sw.Stop();
-            Assert.True(sw.ElapsedMilliseconds >= 2000, $"Expected sw.ElapsedMilliseconds >= 2000; Actual: {sw.ElapsedMilliseconds}");
+
+            // We expect 2 seconds, but the timer could be slighlty off.
+            Assert.True(sw.ElapsedMilliseconds >= 1950, $"Expected sw.ElapsedMilliseconds >= 1950; Actual: {sw.ElapsedMilliseconds}");
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/WebScriptHostRequestManagerTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostRequestManagerTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
             Assert.Equal(2, highLoadQueryCount);
             Assert.Equal(3, throttleMetricCount);
-            var trace = _traceWriter.Traces.Last();
+            var trace = _traceWriter.GetTraces().Last();
             Assert.Equal("Thresholds for the following counters have been exceeded: [Threads, Processes]", trace.Message);
 
             await Task.Delay(1000);


### PR DESCRIPTION
This cleans up a handful of test issues that I've found:
- Improved `TimerTrigger` test so that the Fixture waits until the host is ready before running any tests. There was a timing issue where it'd fire late previously. I don't think this is fully fixed; I've added additional logging to help understand the issue.
- Hardened the `TestTraceWriter`. There were scenarios where a test would be enumerating the list of `Traces` while more traces were being written. Doing so throws an exception, so I began locking around the internal collection of traces and not allowing direct access. I would have just swapped to using a `ConcurrentBag` but there's not a guaranteed way to clear a `ConcurrentBag` without locking anyway.
- Improved the AppInsights `TestTelemetryChannel` as well. It had a similar issue to the TestTraceWriter that caused occassional failures. Swapped this to a `ConcurrentBag` since we don't rely on order and don't need to clear it.
- Slightly expanded range of one numerical comparison. We expected 2000 milliseconds but would sometimes get 1999.
- Set the MSBuild output to 'minimal' and reduced some Console output from the Host where it was easy. This reduced our AppVeyor console logs (which were very hard to read through) from 12k lines down to 6k.