### PR TITLE
Increase querystring and url limits take 2

### DIFF
--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -46,7 +46,7 @@
     <validation validateIntegratedModeConfiguration="false" />
     <security>
       <requestFiltering allowDoubleEscaping="true">
-        <requestLimits maxAllowedContentLength="104857600" />
+        <requestLimits maxAllowedContentLength="104857600" maxUrl="8192" maxQueryString="4096"/>
       </requestFiltering>
     </security>
   <handlers>


### PR DESCRIPTION
Looks like in addition to asp.net limits, iis limits needed to be increased as well. our tests were passing but apparently that was not enough. looks like appveyor host settings are different from app service applicationhost.config.

https://github.com/Azure/azure-webjobs-sdk-script/issues/2331